### PR TITLE
feat(shimmer-button): remove highlight shadows and add hover speed-up

### DIFF
--- a/apps/docs/next-env.d.ts
+++ b/apps/docs/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/components/src/shimmer-button.tsx
+++ b/packages/components/src/shimmer-button.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { CSSProperties } from "react";
 import * as React from "react";
 
@@ -82,11 +84,14 @@ const ShimmerButton = React.forwardRef<HTMLButtonElement, ShimmerButtonProps>(
       background,
       children,
       type = "button",
+      onMouseEnter,
+      onMouseLeave,
       ...props
     },
     ref,
   ) => {
     const defaults = variantDefaults[variant];
+    const sparkRef = React.useRef<HTMLDivElement>(null);
 
     const style = {
       "--spread": defaults.shimmerSpread,
@@ -97,6 +102,20 @@ const ShimmerButton = React.forwardRef<HTMLButtonElement, ShimmerButtonProps>(
       "--bg": background ?? defaults.background,
     } as CSSProperties;
 
+    const handleMouseEnter = (e: React.MouseEvent<HTMLButtonElement>) => {
+      sparkRef.current?.getAnimations({ subtree: true }).forEach((a) => {
+        a.playbackRate = 3;
+      });
+      onMouseEnter?.(e);
+    };
+
+    const handleMouseLeave = (e: React.MouseEvent<HTMLButtonElement>) => {
+      sparkRef.current?.getAnimations({ subtree: true }).forEach((a) => {
+        a.playbackRate = 1;
+      });
+      onMouseLeave?.(e);
+    };
+
     return (
       <button
         ref={ref}
@@ -106,9 +125,12 @@ const ShimmerButton = React.forwardRef<HTMLButtonElement, ShimmerButtonProps>(
         data-shimmer={shimmer ? "true" : undefined}
         style={style}
         className={`group shimmer-button relative z-0 flex cursor-pointer items-center justify-center overflow-hidden [border-radius:var(--radius)] border whitespace-nowrap [background:var(--bg)] transform-gpu transition-transform duration-300 ease-in-out active:translate-y-px focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ${defaults.textClass} ${defaults.borderClass} ${sizeClasses[size]} ${className ?? ""}`}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
         {...props}
       >
         <div
+          ref={sparkRef}
           className="shimmer-button-spark absolute inset-0 -z-30 overflow-visible blur-[2px] [container-type:size]"
           aria-hidden="true"
         >

--- a/packages/components/styles.css
+++ b/packages/components/styles.css
@@ -287,6 +287,7 @@
     transition: box-shadow 300ms ease-in-out;
   }
 
+
   .shimmer-button:not([data-shimmer="true"]) .shimmer-button-spark,
   .shimmer-button:not([data-shimmer="true"]) .shimmer-button-highlight,
   .shimmer-button:not([data-shimmer="true"]) .shimmer-button-backdrop,
@@ -300,34 +301,13 @@
     filter: blur(1px);
   }
 
-  .shimmer-button[data-variant="primary"] .shimmer-button-highlight {
-    box-shadow: inset 0 1px 0
-      color-mix(in srgb, var(--primary-foreground) 28%, transparent);
-  }
-
-  .shimmer-button[data-variant="primary"]:hover .shimmer-button-highlight {
-    box-shadow: inset 0 1px 0
-      color-mix(in srgb, var(--primary-foreground) 38%, transparent);
-  }
-
-  .shimmer-button[data-variant="secondary"] .shimmer-button-highlight {
-    box-shadow: inset 0 1px 0
-      color-mix(in srgb, var(--secondary-foreground) 18%, transparent);
-  }
-
-  .shimmer-button[data-variant="secondary"]:hover .shimmer-button-highlight {
-    box-shadow: inset 0 1px 0
-      color-mix(in srgb, var(--secondary-foreground) 28%, transparent);
-  }
-
-  .shimmer-button[data-variant="outline"] .shimmer-button-highlight {
-    box-shadow: inset 0 -6px 10px
-      color-mix(in srgb, var(--foreground) 6%, transparent);
-  }
-
+  .shimmer-button[data-variant="primary"] .shimmer-button-highlight,
+  .shimmer-button[data-variant="primary"]:hover .shimmer-button-highlight,
+  .shimmer-button[data-variant="secondary"] .shimmer-button-highlight,
+  .shimmer-button[data-variant="secondary"]:hover .shimmer-button-highlight,
+  .shimmer-button[data-variant="outline"] .shimmer-button-highlight,
   .shimmer-button[data-variant="outline"]:hover .shimmer-button-highlight {
-    box-shadow: inset 0 -6px 10px
-      color-mix(in srgb, var(--foreground) 10%, transparent);
+    box-shadow: none;
   }
 
   .variable-text {

--- a/packages/components/theme/dark.css
+++ b/packages/components/theme/dark.css
@@ -1,93 +1,93 @@
 @media (prefers-color-scheme: dark) {
   :root:not(.light) {
     /* Base — deep celestial midnight */
-    --background: oklch(0.155 0.028 264);
-    --foreground: oklch(0.96 0.008 264);
+    --background: oklch(0.16 0.026 266);
+    --foreground: oklch(0.96 0.008 266);
 
     /* Surfaces */
-    --card: oklch(0.2 0.03 264);
-    --card-foreground: oklch(0.96 0.008 264);
+    --card: oklch(0.205 0.027 266);
+    --card-foreground: oklch(0.96 0.008 266);
 
-    --popover: oklch(0.2 0.03 264);
-    --popover-foreground: oklch(0.96 0.008 264);
+    --popover: oklch(0.235 0.028 266);
+    --popover-foreground: oklch(0.96 0.008 266);
 
     /* Brand — luminous Celestial Sapphire */
-    --primary: oklch(0.72 0.155 264);
-    --primary-foreground: oklch(0.17 0.04 264);
+    --primary: oklch(0.72 0.15 266);
+    --primary-foreground: oklch(0.18 0.04 266);
 
     /* Heavenly Gold on dusk violet */
-    --secondary: oklch(0.27 0.035 290);
-    --secondary-foreground: oklch(0.9 0.06 88);
+    --secondary: oklch(0.275 0.038 290);
+    --secondary-foreground: oklch(0.9 0.07 90);
 
     /* Celestial Accent */
-    --accent: oklch(0.3 0.05 264);
-    --accent-foreground: oklch(0.86 0.06 264);
+    --accent: oklch(0.3 0.045 266);
+    --accent-foreground: oklch(0.85 0.055 266);
 
     /* Neutral */
-    --muted: oklch(0.225 0.02 264);
-    --muted-foreground: oklch(0.72 0.02 264);
+    --muted: oklch(0.235 0.02 266);
+    --muted-foreground: oklch(0.72 0.02 266);
 
     /* Status */
     --destructive: oklch(0.7 0.17 25);
 
     /* Inputs */
-    --border: oklch(0.34 0.03 264);
-    --input: oklch(0.3 0.03 264);
-    --ring: oklch(0.72 0.155 264);
+    --border: oklch(0.28 0.02 266);
+    --input: oklch(0.265 0.02 266);
+    --ring: oklch(0.72 0.15 266);
 
     /* Charts — angelic spectrum */
-    --chart-1: oklch(0.7 0.17 264);
-    --chart-2: oklch(0.84 0.13 85);
-    --chart-3: oklch(0.84 0.1 180);
-    --chart-4: oklch(0.74 0.16 300);
-    --chart-5: oklch(0.8 0.12 12);
+    --chart-1: oklch(0.71 0.16 266);
+    --chart-2: oklch(0.84 0.13 90);
+    --chart-3: oklch(0.84 0.1 185);
+    --chart-4: oklch(0.74 0.16 305);
+    --chart-5: oklch(0.8 0.12 14);
 
     /* Sidebar */
-    --sidebar: oklch(0.175 0.03 264);
-    --sidebar-foreground: oklch(0.96 0.008 264);
+    --sidebar: oklch(0.18 0.026 266);
+    --sidebar-foreground: oklch(0.96 0.008 266);
 
-    --sidebar-primary: oklch(0.72 0.155 264);
-    --sidebar-primary-foreground: oklch(0.17 0.04 264);
+    --sidebar-primary: oklch(0.72 0.15 266);
+    --sidebar-primary-foreground: oklch(0.18 0.04 266);
 
-    --sidebar-accent: oklch(0.3 0.05 264);
-    --sidebar-accent-foreground: oklch(0.86 0.06 264);
+    --sidebar-accent: oklch(0.3 0.045 266);
+    --sidebar-accent-foreground: oklch(0.85 0.055 266);
 
-    --sidebar-border: oklch(0.3 0.03 264);
-    --sidebar-ring: oklch(0.72 0.155 264);
+    --sidebar-border: oklch(0.265 0.02 266);
+    --sidebar-ring: oklch(0.72 0.15 266);
 
     /* Syntax Highlighting */
-    --syntax-plain: oklch(0.93 0.01 264);
-    --syntax-punctuation: oklch(0.65 0.02 264);
-    --syntax-keyword: oklch(0.78 0.14 300);
-    --syntax-property: oklch(0.83 0.12 85);
-    --syntax-string: oklch(0.8 0.13 165);
-    --syntax-comment: oklch(0.58 0.02 264);
-    --syntax-number: oklch(0.8 0.12 220);
+    --syntax-plain: oklch(0.935 0.01 266);
+    --syntax-punctuation: oklch(0.65 0.02 266);
+    --syntax-keyword: oklch(0.78 0.14 302);
+    --syntax-property: oklch(0.83 0.12 90);
+    --syntax-string: oklch(0.8 0.13 168);
+    --syntax-comment: oklch(0.58 0.02 266);
+    --syntax-number: oklch(0.8 0.12 224);
 
     /* Code blocks */
-    --code-block: oklch(0.18 0.025 264);
-    --code-block-foreground: oklch(0.93 0.01 264);
-    --code-block-border: oklch(0.28 0.03 264);
+    --code-block: oklch(0.185 0.024 266);
+    --code-block-foreground: oklch(0.935 0.01 266);
+    --code-block-border: oklch(0.26 0.02 266);
 
     /* Inline code */
-    --inline-code-bg: oklch(0.27 0.04 264);
-    --inline-code-fg: oklch(0.86 0.08 264);
-    --inline-code-border: oklch(0.4 0.05 264);
+    --inline-code-bg: oklch(0.28 0.038 266);
+    --inline-code-fg: oklch(0.86 0.08 266);
+    --inline-code-border: oklch(0.36 0.04 266);
 
     /* Search */
-    --search-bg: oklch(0.19 0.025 264);
-    --search-fg: oklch(0.88 0.01 264);
-    --search-border: oklch(0.34 0.03 264);
-    --search-kbd-bg: oklch(0.27 0.03 264);
-    --search-kbd-fg: oklch(0.86 0.08 264);
-    --search-placeholder: oklch(0.62 0.02 264);
+    --search-bg: oklch(0.195 0.026 266);
+    --search-fg: oklch(0.885 0.01 266);
+    --search-border: oklch(0.28 0.02 266);
+    --search-kbd-bg: oklch(0.28 0.024 266);
+    --search-kbd-fg: oklch(0.86 0.08 266);
+    --search-placeholder: oklch(0.62 0.02 266);
 
     /* Theme panel */
-    --theme-panel-bg: oklch(0.19 0.025 264);
-    --theme-panel-border: oklch(0.34 0.03 264);
-    --theme-panel-fg: oklch(0.65 0.02 264);
-    --theme-panel-active-bg: oklch(0.27 0.04 264);
-    --theme-panel-active-fg: oklch(0.72 0.155 264);
+    --theme-panel-bg: oklch(0.195 0.026 266);
+    --theme-panel-border: oklch(0.28 0.02 266);
+    --theme-panel-fg: oklch(0.65 0.02 266);
+    --theme-panel-active-bg: oklch(0.28 0.038 266);
+    --theme-panel-active-fg: oklch(0.72 0.15 266);
 
     /* Shadows */
     --shadow-2xs: 0 1px 2px rgb(0 0 0 / 0.12);
@@ -122,8 +122,8 @@
     --color-destructive-fg: oklch(1 0 0);
 
     /* Effects — sRGB triplets tracking --primary for rgba() consumers */
-    --glow-highlight: 150, 178, 245;
-    --color-primary-rgb: 150, 178, 245;
+    --glow-highlight: 120, 160, 255;
+    --color-primary-rgb: 120, 160, 255;
 
     --radius-md: calc(var(--radius) - 2px);
     --radius-lg: var(--radius);
@@ -131,99 +131,99 @@
     /* GOD UI Brand — sapphire → light → divine gold */
     --god-gradient: linear-gradient(
       135deg,
-      oklch(0.72 0.155 264) 0%,
+      oklch(0.72 0.15 266) 0%,
       oklch(1 0 0) 50%,
-      oklch(0.86 0.12 85) 100%
+      oklch(0.86 0.12 90) 100%
     );
 
     --god-glow:
-      0 0 24px oklch(0.72 0.155 264 / 0.28),
-      0 0 80px oklch(0.86 0.12 85 / 0.12);
+      0 0 24px oklch(0.72 0.15 266 / 0.28),
+      0 0 80px oklch(0.86 0.12 90 / 0.12);
 
-    --rainbow-1: oklch(0.72 0.155 264);
-    --rainbow-2: oklch(0.74 0.16 300);
-    --rainbow-3: oklch(0.84 0.1 180);
-    --rainbow-4: oklch(0.8 0.12 12);
-    --rainbow-5: oklch(0.84 0.13 85);
+    --rainbow-1: oklch(0.72 0.15 266);
+    --rainbow-2: oklch(0.74 0.16 305);
+    --rainbow-3: oklch(0.84 0.1 185);
+    --rainbow-4: oklch(0.8 0.12 14);
+    --rainbow-5: oklch(0.84 0.13 90);
 
     --rainbow-speed: 2s;
   }
 }
 
 .dark {
-  --background: oklch(0.155 0.028 264);
-  --foreground: oklch(0.96 0.008 264);
+  --background: oklch(0.16 0.026 266);
+  --foreground: oklch(0.96 0.008 266);
 
-  --card: oklch(0.2 0.03 264);
-  --card-foreground: oklch(0.96 0.008 264);
+  --card: oklch(0.205 0.027 266);
+  --card-foreground: oklch(0.96 0.008 266);
 
-  --popover: oklch(0.2 0.03 264);
-  --popover-foreground: oklch(0.96 0.008 264);
+  --popover: oklch(0.235 0.028 266);
+  --popover-foreground: oklch(0.96 0.008 266);
 
-  --primary: oklch(0.72 0.155 264);
-  --primary-foreground: oklch(0.17 0.04 264);
+  --primary: oklch(0.72 0.15 266);
+  --primary-foreground: oklch(0.18 0.04 266);
 
-  --secondary: oklch(0.27 0.035 290);
-  --secondary-foreground: oklch(0.9 0.06 88);
+  --secondary: oklch(0.275 0.038 290);
+  --secondary-foreground: oklch(0.9 0.07 90);
 
-  --accent: oklch(0.3 0.05 264);
-  --accent-foreground: oklch(0.86 0.06 264);
+  --accent: oklch(0.3 0.045 266);
+  --accent-foreground: oklch(0.85 0.055 266);
 
-  --muted: oklch(0.225 0.02 264);
-  --muted-foreground: oklch(0.72 0.02 264);
+  --muted: oklch(0.235 0.02 266);
+  --muted-foreground: oklch(0.72 0.02 266);
 
   --destructive: oklch(0.7 0.17 25);
 
-  --border: oklch(0.34 0.03 264);
-  --input: oklch(0.3 0.03 264);
-  --ring: oklch(0.72 0.155 264);
+  --border: oklch(0.28 0.02 266);
+  --input: oklch(0.265 0.02 266);
+  --ring: oklch(0.72 0.15 266);
 
-  --chart-1: oklch(0.7 0.17 264);
-  --chart-2: oklch(0.84 0.13 85);
-  --chart-3: oklch(0.84 0.1 180);
-  --chart-4: oklch(0.74 0.16 300);
-  --chart-5: oklch(0.8 0.12 12);
+  --chart-1: oklch(0.71 0.16 266);
+  --chart-2: oklch(0.84 0.13 90);
+  --chart-3: oklch(0.84 0.1 185);
+  --chart-4: oklch(0.74 0.16 305);
+  --chart-5: oklch(0.8 0.12 14);
 
-  --sidebar: oklch(0.175 0.03 264);
-  --sidebar-foreground: oklch(0.96 0.008 264);
+  --sidebar: oklch(0.18 0.026 266);
+  --sidebar-foreground: oklch(0.96 0.008 266);
 
-  --sidebar-primary: oklch(0.72 0.155 264);
-  --sidebar-primary-foreground: oklch(0.17 0.04 264);
+  --sidebar-primary: oklch(0.72 0.15 266);
+  --sidebar-primary-foreground: oklch(0.18 0.04 266);
 
-  --sidebar-accent: oklch(0.3 0.05 264);
-  --sidebar-accent-foreground: oklch(0.86 0.06 264);
+  --sidebar-accent: oklch(0.3 0.045 266);
+  --sidebar-accent-foreground: oklch(0.85 0.055 266);
 
-  --sidebar-border: oklch(0.3 0.03 264);
-  --sidebar-ring: oklch(0.72 0.155 264);
+  --sidebar-border: oklch(0.265 0.02 266);
+  --sidebar-ring: oklch(0.72 0.15 266);
 
-  --syntax-plain: oklch(0.93 0.01 264);
-  --syntax-punctuation: oklch(0.65 0.02 264);
-  --syntax-keyword: oklch(0.78 0.14 300);
-  --syntax-property: oklch(0.83 0.12 85);
-  --syntax-string: oklch(0.8 0.13 165);
-  --syntax-comment: oklch(0.58 0.02 264);
-  --syntax-number: oklch(0.8 0.12 220);
+  --syntax-plain: oklch(0.935 0.01 266);
+  --syntax-punctuation: oklch(0.65 0.02 266);
+  --syntax-keyword: oklch(0.78 0.14 302);
+  --syntax-property: oklch(0.83 0.12 90);
+  --syntax-string: oklch(0.8 0.13 168);
+  --syntax-comment: oklch(0.58 0.02 266);
+  --syntax-number: oklch(0.8 0.12 224);
 
-  --code-block: oklch(0.18 0.025 264);
-  --code-block-foreground: oklch(0.93 0.01 264);
-  --code-block-border: oklch(0.28 0.03 264);
+  --code-block: oklch(0.185 0.024 266);
+  --code-block-foreground: oklch(0.935 0.01 266);
+  --code-block-border: oklch(0.26 0.02 266);
 
-  --inline-code-bg: oklch(0.27 0.04 264);
-  --inline-code-fg: oklch(0.86 0.08 264);
-  --inline-code-border: oklch(0.4 0.05 264);
+  --inline-code-bg: oklch(0.28 0.038 266);
+  --inline-code-fg: oklch(0.86 0.08 266);
+  --inline-code-border: oklch(0.36 0.04 266);
 
-  --search-bg: oklch(0.19 0.025 264);
-  --search-fg: oklch(0.88 0.01 264);
-  --search-border: oklch(0.34 0.03 264);
-  --search-kbd-bg: oklch(0.27 0.03 264);
-  --search-kbd-fg: oklch(0.86 0.08 264);
-  --search-placeholder: oklch(0.62 0.02 264);
+  --search-bg: oklch(0.195 0.026 266);
+  --search-fg: oklch(0.885 0.01 266);
+  --search-border: oklch(0.28 0.02 266);
+  --search-kbd-bg: oklch(0.28 0.024 266);
+  --search-kbd-fg: oklch(0.86 0.08 266);
+  --search-placeholder: oklch(0.62 0.02 266);
 
-  --theme-panel-bg: oklch(0.19 0.025 264);
-  --theme-panel-border: oklch(0.34 0.03 264);
-  --theme-panel-fg: oklch(0.65 0.02 264);
-  --theme-panel-active-bg: oklch(0.27 0.04 264);
-  --theme-panel-active-fg: oklch(0.72 0.155 264);
+  --theme-panel-bg: oklch(0.195 0.026 266);
+  --theme-panel-border: oklch(0.28 0.02 266);
+  --theme-panel-fg: oklch(0.65 0.02 266);
+  --theme-panel-active-bg: oklch(0.28 0.038 266);
+  --theme-panel-active-fg: oklch(0.72 0.15 266);
 
   --shadow-2xs: 0 1px 2px rgb(0 0 0 / 0.12);
   --shadow-xs: 0 1px 3px rgb(0 0 0 / 0.15);
@@ -248,27 +248,27 @@
   --color-destructive: var(--destructive);
   --color-destructive-fg: oklch(1 0 0);
 
-  --glow-highlight: 150, 178, 245;
-  --color-primary-rgb: 150, 178, 245;
+  --glow-highlight: 120, 160, 255;
+  --color-primary-rgb: 120, 160, 255;
 
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
 
   --god-gradient: linear-gradient(
     135deg,
-    oklch(0.72 0.155 264) 0%,
+    oklch(0.72 0.15 266) 0%,
     oklch(1 0 0) 50%,
-    oklch(0.86 0.12 85) 100%
+    oklch(0.86 0.12 90) 100%
   );
 
   --god-glow:
-    0 0 24px oklch(0.72 0.155 264 / 0.28),
-    0 0 80px oklch(0.86 0.12 85 / 0.12);
+    0 0 24px oklch(0.72 0.15 266 / 0.28),
+    0 0 80px oklch(0.86 0.12 90 / 0.12);
 
-  --rainbow-1: oklch(0.72 0.155 264);
-  --rainbow-2: oklch(0.74 0.16 300);
-  --rainbow-3: oklch(0.84 0.1 180);
-  --rainbow-4: oklch(0.8 0.12 12);
-  --rainbow-5: oklch(0.84 0.13 85);
+  --rainbow-1: oklch(0.72 0.15 266);
+  --rainbow-2: oklch(0.74 0.16 305);
+  --rainbow-3: oklch(0.84 0.1 185);
+  --rainbow-4: oklch(0.8 0.12 14);
+  --rainbow-5: oklch(0.84 0.13 90);
   --rainbow-speed: 2s;
 }

--- a/packages/components/theme/light.css
+++ b/packages/components/theme/light.css
@@ -1,59 +1,59 @@
 :root,
 .light {
   /* Base — luminous cool-white */
-  --background: oklch(0.991 0.003 264);
-  --foreground: oklch(0.21 0.035 264);
+  --background: oklch(0.992 0.004 266);
+  --foreground: oklch(0.2 0.036 266);
 
   /* Surfaces */
   --card: oklch(1 0 0);
-  --card-foreground: oklch(0.21 0.035 264);
+  --card-foreground: oklch(0.2 0.036 266);
 
   --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.21 0.035 264);
+  --popover-foreground: oklch(0.2 0.036 266);
 
   /* Brand — Celestial Sapphire (AA-safe with white) */
-  --primary: oklch(0.545 0.205 264);
+  --primary: oklch(0.55 0.19 266);
   --primary-foreground: oklch(1 0 0);
 
   /* Heavenly Gold */
-  --secondary: oklch(0.965 0.035 88);
-  --secondary-foreground: oklch(0.43 0.085 75);
+  --secondary: oklch(0.97 0.04 90);
+  --secondary-foreground: oklch(0.42 0.09 80);
 
   /* Celestial Accent */
-  --accent: oklch(0.96 0.03 264);
-  --accent-foreground: oklch(0.45 0.15 264);
+  --accent: oklch(0.965 0.025 266);
+  --accent-foreground: oklch(0.46 0.155 266);
 
   /* Neutral */
-  --muted: oklch(0.965 0.004 264);
-  --muted-foreground: oklch(0.52 0.02 264);
+  --muted: oklch(0.97 0.005 266);
+  --muted-foreground: oklch(0.51 0.022 266);
 
   /* Status */
-  --destructive: oklch(0.58 0.22 27);
+  --destructive: oklch(0.57 0.21 25);
 
   /* Inputs */
-  --border: oklch(0.92 0.008 264);
-  --input: oklch(0.92 0.008 264);
-  --ring: oklch(0.545 0.205 264);
+  --border: oklch(0.925 0.01 266);
+  --input: oklch(0.925 0.01 266);
+  --ring: oklch(0.55 0.19 266);
 
   /* Charts — angelic spectrum */
-  --chart-1: oklch(0.55 0.2 264);
-  --chart-2: oklch(0.8 0.13 85);
-  --chart-3: oklch(0.82 0.1 180);
-  --chart-4: oklch(0.68 0.16 300);
-  --chart-5: oklch(0.78 0.12 12);
+  --chart-1: oklch(0.55 0.19 266);
+  --chart-2: oklch(0.8 0.13 90);
+  --chart-3: oklch(0.82 0.1 185);
+  --chart-4: oklch(0.68 0.16 305);
+  --chart-5: oklch(0.78 0.12 14);
 
   /* Sidebar */
   --sidebar: oklch(1 0 0);
-  --sidebar-foreground: oklch(0.21 0.035 264);
+  --sidebar-foreground: oklch(0.2 0.036 266);
 
-  --sidebar-primary: oklch(0.545 0.205 264);
+  --sidebar-primary: oklch(0.55 0.19 266);
   --sidebar-primary-foreground: oklch(1 0 0);
 
-  --sidebar-accent: oklch(0.97 0.02 264);
-  --sidebar-accent-foreground: oklch(0.45 0.15 264);
+  --sidebar-accent: oklch(0.97 0.018 266);
+  --sidebar-accent-foreground: oklch(0.46 0.155 266);
 
-  --sidebar-border: oklch(0.92 0.008 264);
-  --sidebar-ring: oklch(0.545 0.205 264);
+  --sidebar-border: oklch(0.925 0.01 266);
+  --sidebar-ring: oklch(0.55 0.19 266);
 
   /* Typography — set --font-geist-* in your app (see @godui/components/fonts) */
   --font-sans: var(
@@ -116,38 +116,38 @@
   --shadow-2xl: 0 40px 80px rgb(0 0 0 / 0.16);
 
   /* Syntax Highlighting */
-  --syntax-plain: oklch(0.21 0.035 264);
-  --syntax-punctuation: oklch(0.55 0.02 264);
-  --syntax-keyword: oklch(0.52 0.19 300);
-  --syntax-property: oklch(0.56 0.11 85);
-  --syntax-string: oklch(0.52 0.13 165);
-  --syntax-comment: oklch(0.64 0.015 264);
-  --syntax-number: oklch(0.54 0.13 230);
+  --syntax-plain: oklch(0.2 0.036 266);
+  --syntax-punctuation: oklch(0.54 0.022 266);
+  --syntax-keyword: oklch(0.52 0.19 302);
+  --syntax-property: oklch(0.56 0.11 90);
+  --syntax-string: oklch(0.52 0.13 168);
+  --syntax-comment: oklch(0.63 0.016 266);
+  --syntax-number: oklch(0.54 0.13 235);
 
   /* Inline code */
-  --inline-code-bg: oklch(0.95 0.03 264);
-  --inline-code-fg: oklch(0.45 0.17 264);
-  --inline-code-border: oklch(0.8 0.08 264);
+  --inline-code-bg: oklch(0.955 0.028 266);
+  --inline-code-fg: oklch(0.46 0.165 266);
+  --inline-code-border: oklch(0.82 0.07 266);
 
   /* Code blocks */
-  --code-block: oklch(0.975 0.006 264);
-  --code-block-foreground: oklch(0.21 0.035 264);
-  --code-block-border: oklch(0.92 0.008 264);
+  --code-block: oklch(0.978 0.006 266);
+  --code-block-foreground: oklch(0.2 0.036 266);
+  --code-block-border: oklch(0.925 0.01 266);
 
   /* Search */
   --search-bg: oklch(1 0 0);
-  --search-fg: oklch(0.3 0.025 264);
-  --search-border: oklch(0.88 0.01 264);
-  --search-kbd-bg: oklch(0.96 0.006 264);
-  --search-kbd-fg: oklch(0.21 0.035 264);
-  --search-placeholder: oklch(0.55 0.02 264);
+  --search-fg: oklch(0.29 0.026 266);
+  --search-border: oklch(0.89 0.011 266);
+  --search-kbd-bg: oklch(0.965 0.006 266);
+  --search-kbd-fg: oklch(0.2 0.036 266);
+  --search-placeholder: oklch(0.54 0.022 266);
 
   /* Theme panel */
   --theme-panel-bg: oklch(1 0 0);
-  --theme-panel-border: oklch(0.88 0.01 264);
-  --theme-panel-fg: oklch(0.4 0.02 264);
-  --theme-panel-active-bg: oklch(0.95 0.03 264);
-  --theme-panel-active-fg: oklch(0.45 0.17 264);
+  --theme-panel-border: oklch(0.89 0.011 266);
+  --theme-panel-fg: oklch(0.4 0.022 266);
+  --theme-panel-active-bg: oklch(0.955 0.028 266);
+  --theme-panel-active-fg: oklch(0.46 0.165 266);
 
   /* Z-index */
   --z-base: 0;
@@ -174,8 +174,8 @@
   --color-destructive-fg: oklch(1 0 0);
 
   /* Effects — sRGB triplets tracking --primary for rgba() consumers */
-  --glow-highlight: 59, 91, 217;
-  --color-primary-rgb: 59, 91, 217;
+  --glow-highlight: 61, 102, 223;
+  --color-primary-rgb: 61, 102, 223;
 
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
@@ -183,21 +183,21 @@
   /* GOD UI Brand — sapphire → light → divine gold */
   --god-gradient: linear-gradient(
     135deg,
-    oklch(0.545 0.205 264) 0%,
+    oklch(0.55 0.19 266) 0%,
     oklch(1 0 0) 50%,
-    oklch(0.85 0.12 85) 100%
+    oklch(0.85 0.12 90) 100%
   );
 
   --god-glow:
-    0 0 24px oklch(0.545 0.205 264 / 0.14),
-    0 0 80px oklch(0.85 0.12 85 / 0.06);
+    0 0 24px oklch(0.55 0.19 266 / 0.14),
+    0 0 80px oklch(0.85 0.12 90 / 0.06);
 
   /* Rainbow — sapphire, iris, aqua, rose, gold */
-  --rainbow-1: oklch(0.55 0.2 264);
-  --rainbow-2: oklch(0.68 0.16 300);
-  --rainbow-3: oklch(0.82 0.1 180);
-  --rainbow-4: oklch(0.78 0.12 12);
-  --rainbow-5: oklch(0.8 0.13 85);
+  --rainbow-1: oklch(0.55 0.19 266);
+  --rainbow-2: oklch(0.68 0.16 305);
+  --rainbow-3: oklch(0.82 0.1 185);
+  --rainbow-4: oklch(0.78 0.12 14);
+  --rainbow-5: oklch(0.8 0.13 90);
 
   --rainbow-speed: 2s;
 }


### PR DESCRIPTION
## Summary

- Remove all inset `box-shadow` highlight effects from ShimmerButton (top highlight on primary/secondary, bottom glow on outline)
- Add hover interaction that speeds up the shimmer animation 3× using Web Animations API `playbackRate` — animation continues from current position without restarting
- Add `"use client"` directive required by Next.js since the component now uses `useRef`
- Theme: minor OKLCH color system refinements (hue shift 264→266, small chroma/lightness tweaks) from a previous commit