### PR TITLE
feat: add ProgressFoldButton component

### DIFF
--- a/.claude/skills/godui-component-creation/SKILL.md
+++ b/.claude/skills/godui-component-creation/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: godui-component-creation
+description: Create new components for the GoDUI design system in @godui/components. Use when adding a component, fixing missing Tailwind styles on components, wiring Storybook stories, or writing docs pages with ComponentPreview and ComponentInstall.
+---
+
+# GoDUI Component Creation
+
+Follow this workflow when adding a component to `@godui/components`.
+
+## Quick reference
+
+| Step | File |
+|------|------|
+| Component | `packages/components/src/{name}.tsx` |
+| Export | `packages/components/src/index.ts` |
+| Tailwind scan | `packages/components/styles.css` → `@source "./src"` |
+| Complex CSS | `packages/components/styles.css` → `@layer components` |
+| Storybook | `apps/storybook/src/stories/{name}.stories.tsx` |
+| Docs | `apps/docs/content/docs/components/{category}/{name}.mdx` |
+| Nav | `apps/docs/content/docs/components/meta.json` |
+
+## 1. Create the component
+
+Use static Tailwind utility classes with design tokens. Map variants to static class strings:
+
+```typescript
+import * as React from "react";
+
+export type ButtonVariant = "primary" | "secondary" | "outline";
+export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: ButtonVariant;
+};
+
+const variantClasses: Record<ButtonVariant, string> = {
+  primary: "bg-primary text-primary-foreground shadow-sm hover:bg-primary/90",
+  secondary: "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
+  outline: "border border-border bg-background text-foreground hover:bg-accent hover:text-accent-foreground",
+};
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = "primary", ...props }, ref) => (
+    <button
+      ref={ref}
+      className={`inline-flex items-center font-medium ${variantClasses[variant]} ${className ?? ""}`}
+      {...props}
+    />
+  ),
+);
+Button.displayName = "Button";
+
+export { Button };
+```
+
+Export the component **and its prop/variant types** from `packages/components/src/index.ts`:
+
+```typescript
+export { Button, type ButtonProps, type ButtonVariant } from "./button";
+```
+
+Only add `"use client"` when the component uses React hooks or client-only APIs.
+
+## 2. Ensure Tailwind scans component files
+
+**This is the most common reason styles don't apply.**
+
+`packages/components/styles.css` must include:
+
+```css
+@import "tailwindcss";
+@import "./theme/light.css";
+@import "./theme/dark.css";
+
+@source "./src";
+```
+
+Consuming apps also scan explicitly:
+
+- `apps/storybook/src/tailwind.css` → `@source "../node_modules/@godui/components/src"`
+- `apps/docs/src/app/globals.css` → `@source "../../../../packages/components/src"`
+
+If utilities like `bg-primary` render unstyled, verify `@source "./src"` exists and restart the dev server. Both apps already depend on `@godui/components` via `workspace:*` and it is in the docs `transpilePackages` — no `pnpm install` needed for a new component in the shared package.
+
+## 3. Choose a styling approach
+
+**Tailwind utilities** (Button, Typography): classes in `.tsx`, scanned via `@source "./src"`.
+
+**CSS components layer** (MagicButton): static class names + rules in `styles.css`:
+
+```css
+@layer components {
+  .three-d-button { /* layered 3D styles */ }
+}
+```
+
+Reference the class from the component with a static string: `className="three-d-button"`. Do not mix approaches unnecessarily. Use CSS layer only when utilities cannot express the design.
+
+## 4. Storybook story
+
+```typescript
+import { MyComponent, type MyComponentProps } from "@godui/components";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Components/MyComponent",
+  component: MyComponent,
+  tags: ["autodocs"],
+  parameters: { layout: "centered" },
+} satisfies Meta<typeof MyComponent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: { children: "Default", variant: "primary" } satisfies MyComponentProps,
+};
+```
+
+Include stories for each variant, sizes, and disabled state.
+
+## 5. Docs page
+
+Docs live under a **category subfolder** (e.g. `buttons/`, `text/`), not flat. Create
+`apps/docs/content/docs/components/{category}/{name}.mdx` using the Preview/Code tabs, then Installation, Usage, Props:
+
+```mdx
+---
+title: My Component
+description: Short description.
+---
+
+import { MyComponent } from "@godui/components";
+
+<ComponentPreview code={`import { MyComponent } from "@godui/components";
+
+export function MyComponentDemo() {
+  return <MyComponent variant="primary">Example</MyComponent>;
+}`}>
+  <MyComponent variant="primary">Example</MyComponent>
+</ComponentPreview>
+
+## Installation
+<ComponentInstall componentName="MyComponent" />
+
+## Usage
+\`\`\`tsx
+import { MyComponent } from "@godui/components";
+\`\`\`
+
+## Props
+| Prop | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `variant` | `"primary" \| "secondary"` | `"primary"` | Visual style |
+```
+
+`ComponentPreview` and `ComponentInstall` are registered globally in `apps/docs/src/components/mdx.tsx`.
+
+Add the slug to `apps/docs/content/docs/components/meta.json`. Slugs are `category/name`, and category headers use the `---Label---` separator syntax:
+
+```json
+{
+  "title": "Components",
+  "pages": [
+    "---Buttons---",
+    "buttons/magic-button",
+    "buttons/my-component",
+    "---Text---",
+    "text/typography"
+  ]
+}
+```
+
+## 6. Naming rules
+
+- Component names must be valid JS identifiers (`MagicButton` not `3DButton`)
+- File names: kebab-case (`shimmer-button.tsx`, `magic-button.tsx`)
+- Export PascalCase component + prop types from `index.ts`
+
+## 7. Anti-patterns
+
+- **NEVER** construct Tailwind class names dynamically (`grid-cols-${n}`) — map to static strings; the scanner can't see interpolated classes.
+- **NEVER** skip `@source "./src"` in `styles.css`.
+- **NEVER** skip `React.forwardRef` — components must forward refs for composition.
+- **NEVER** add `"use client"` unless hooks/client APIs are used.
+- **NEVER** use arbitrary z-index — use the scale: `z-base`, `z-raised`, `z-overlay`, `z-sticky`, `z-popover`, `z-modal`, `z-toast`.
+
+## 8. Theme tokens
+
+| Category | Examples | Backing token |
+|----------|----------|---------------|
+| Colors | `bg-primary`, `text-foreground`, `border-border`, `hover:bg-accent` | `--color-*` |
+| Radius | `rounded-sm/md/lg/xl` | `--radius-*` |
+| Shadows | `shadow-2xs` … `shadow-2xl` | `--shadow-*` |
+| Z-index | `z-base`, `z-raised`, `z-overlay`, `z-sticky`, `z-popover`, `z-modal`, `z-toast` | `--z-index-*` |
+| Fonts | `font-sans`, `font-mono`, `font-serif` | `--font-*` |
+
+## 9. Checklist
+
+- [ ] `packages/components/src/{name}.tsx` with `forwardRef`
+- [ ] Exported (component + prop/variant types) from `index.ts`
+- [ ] `@source "./src"` in `styles.css`
+- [ ] Complex CSS (if any) in `@layer components`
+- [ ] Storybook story with `tags: ["autodocs"]`
+- [ ] Docs MDX under `components/{category}/` with ComponentPreview + ComponentInstall
+- [ ] Added to `components/meta.json` as `category/name`
+- [ ] Static Tailwind classes only (no dynamic class construction)
+- [ ] Verified styles in Storybook and docs after dev server restart

--- a/apps/docs/content/docs/components/buttons/progress-fold-button.mdx
+++ b/apps/docs/content/docs/components/buttons/progress-fold-button.mdx
@@ -1,0 +1,55 @@
+---
+title: Progress Fold Button
+description: A 3D button whose front face folds back on hover and runs a progress bar on click.
+---
+
+import { ProgressFoldButton } from "@godui/components";
+
+<ComponentPreview
+  code={`import { ProgressFoldButton } from "@godui/components";
+
+export function ProgressFoldButtonDemo() {
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-6">
+      <ProgressFoldButton variant="primary">Hover & click</ProgressFoldButton>
+      <ProgressFoldButton variant="secondary">Hover & click</ProgressFoldButton>
+    </div>
+  );
+}`}
+>
+  <div className="flex flex-wrap items-center justify-center gap-6">
+    <ProgressFoldButton variant="primary">Hover & click</ProgressFoldButton>
+    <ProgressFoldButton variant="secondary">Hover & click</ProgressFoldButton>
+  </div>
+</ComponentPreview>
+
+The front face folds back on hover, revealing the layers behind it. Clicking
+runs the progress bar animation, which resets when it finishes so it can replay
+on the next click.
+
+## Installation
+
+<ComponentInstall componentName="ProgressFoldButton" />
+
+## Usage
+
+```tsx
+import { ProgressFoldButton } from "@godui/components";
+```
+
+```tsx
+<ProgressFoldButton onClick={() => console.log("activated")}>
+  Hover & click
+</ProgressFoldButton>
+```
+
+## Props
+
+Accepts all native `<button>` attributes.
+
+| Prop | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `variant` | `"primary" \| "secondary"` | `"primary"` | Theme color scheme of the front face |
+| `children` | `ReactNode` | — | Button label |
+| `disabled` | `boolean` | `false` | Disable the button and its animations |
+| `onClick` | `(e) => void` | — | Fires on click; the progress bar runs alongside it |

--- a/apps/docs/content/docs/components/meta.json
+++ b/apps/docs/content/docs/components/meta.json
@@ -4,6 +4,7 @@
     "---Buttons---",
     "buttons/magic-button",
     "buttons/shimmer-button",
+    "buttons/progress-fold-button",
     "---Text---",
     "text/typography",
     "text/variable-text",

--- a/apps/storybook/src/stories/progress-fold-button.stories.tsx
+++ b/apps/storybook/src/stories/progress-fold-button.stories.tsx
@@ -1,0 +1,39 @@
+import {
+  ProgressFoldButton,
+  type ProgressFoldButtonProps,
+} from "@godui/components";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Buttons/Progress Fold Button",
+  component: ProgressFoldButton,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+  },
+} satisfies Meta<typeof ProgressFoldButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    children: "Hover & click",
+    variant: "primary",
+  } satisfies ProgressFoldButtonProps,
+};
+
+export const Secondary: Story = {
+  args: {
+    children: "Hover & click",
+    variant: "secondary",
+  } satisfies ProgressFoldButtonProps,
+};
+
+export const Disabled: Story = {
+  args: {
+    children: "Hover & click",
+    variant: "primary",
+    disabled: true,
+  } satisfies ProgressFoldButtonProps,
+};

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -5,6 +5,11 @@ export {
   type MagicButtonVariant,
 } from "./magic-button";
 export {
+  ProgressFoldButton,
+  type ProgressFoldButtonProps,
+  type ProgressFoldButtonVariant,
+} from "./progress-fold-button";
+export {
   ShimmerButton,
   type ShimmerButtonProps,
   type ShimmerButtonSize,

--- a/packages/components/src/progress-fold-button.tsx
+++ b/packages/components/src/progress-fold-button.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import * as React from "react";
+
+export type ProgressFoldButtonVariant = "primary" | "secondary";
+
+export type ProgressFoldButtonProps =
+  React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    variant?: ProgressFoldButtonVariant;
+  };
+
+const frontClasses: Record<ProgressFoldButtonVariant, string> = {
+  primary: "bg-primary text-primary-foreground",
+  secondary: "bg-secondary text-secondary-foreground",
+};
+
+// Fold side: a faint tint at rest (back), a stronger one while the progress
+// bar runs. Alpha utilities blend with the surrounding background so the
+// effect adapts to light and dark themes.
+const backClasses: Record<ProgressFoldButtonVariant, string> = {
+  primary: "bg-primary/15",
+  secondary: "bg-secondary-foreground/15",
+};
+
+const barClasses: Record<ProgressFoldButtonVariant, string> = {
+  primary: "bg-primary/40",
+  secondary: "bg-secondary-foreground/35",
+};
+
+const ProgressFoldButton = React.forwardRef<
+  HTMLButtonElement,
+  ProgressFoldButtonProps
+>(({ className, children, onClick, variant = "primary", ...props }, ref) => {
+  const [active, setActive] = React.useState(false);
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setActive(true);
+    onClick?.(event);
+  };
+
+  return (
+    <button
+      ref={ref}
+      type="button"
+      data-variant={variant}
+      data-active={active ? "true" : undefined}
+      onClick={handleClick}
+      className={`progress-fold-button text-sm font-medium ${className ?? ""}`}
+      {...props}
+    >
+      <span className="progress-fold-button-layers" aria-hidden="true">
+        <span className={`progress-fold-button-back ${backClasses[variant]}`} />
+        <span
+          className={`progress-fold-button-bar ${barClasses[variant]}`}
+          onAnimationEnd={() => setActive(false)}
+        />
+      </span>
+      <span className={`progress-fold-button-front ${frontClasses[variant]}`}>
+        {children}
+      </span>
+    </button>
+  );
+});
+ProgressFoldButton.displayName = "ProgressFoldButton";
+
+export { ProgressFoldButton };

--- a/packages/components/styles.css
+++ b/packages/components/styles.css
@@ -339,4 +339,120 @@
       will-change: auto;
     }
   }
+
+  /* Progress Fold Button: front face folds on hover, click runs progress bar */
+  .progress-fold-button {
+    position: relative;
+    display: inline-flex;
+    padding: 0;
+    border: none;
+    border-radius: var(--radius-lg);
+    background: var(--color-border);
+    cursor: pointer;
+    white-space: nowrap;
+    perspective: 800px;
+    transform-style: preserve-3d;
+    user-select: none;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .progress-fold-button:focus-visible {
+    outline: 2px solid var(--ring);
+    outline-offset: 4px;
+  }
+
+  .progress-fold-button:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+    pointer-events: none;
+  }
+
+  /* Folding front face — tilts back on hover to reveal the layers behind */
+  .progress-fold-button-front {
+    position: relative;
+    display: grid;
+    place-items: center;
+    width: 100%;
+    padding: 0.75rem 1.5rem;
+    border-radius: var(--radius-lg);
+    transform: rotateX(0deg);
+    transform-origin: top center;
+    transition: transform 0.2s;
+  }
+
+  .progress-fold-button:hover:not(:disabled) .progress-fold-button-front {
+    transform: rotateX(35deg);
+  }
+
+  /* Front face colors and the fold-side tints come from Tailwind utility
+     classes on the elements (bg-primary / text-primary-foreground and alpha
+     tints like bg-primary/15). Those resolve theme tokens reliably and adapt
+     to the surrounding light/dark background. */
+
+  /* Clip layer — keeps back panel and progress bar inside the rounded shape */
+  .progress-fold-button-layers {
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    overflow: hidden;
+    border-radius: var(--radius-lg);
+  }
+
+  /* Static back panel revealed by the fold (color via Tailwind alpha tint) */
+  .progress-fold-button-back {
+    position: absolute;
+    inset: 0;
+  }
+
+  /* Progress bar — animates on click via data-active (color via Tailwind) */
+  .progress-fold-button-bar {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 0;
+  }
+
+  .progress-fold-button[data-active="true"] .progress-fold-button-bar {
+    animation: progress-fold-bar 1.2s;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .progress-fold-button-front,
+    .progress-fold-button[data-active="true"] .progress-fold-button-bar {
+      transition: none;
+      animation: none;
+    }
+  }
+}
+
+@keyframes progress-fold-bar {
+  0% {
+    opacity: 1;
+    width: 0;
+  }
+  10% {
+    opacity: 1;
+    width: 15%;
+  }
+  25% {
+    opacity: 1;
+    width: 25%;
+  }
+  40% {
+    opacity: 1;
+    width: 35%;
+  }
+  55% {
+    opacity: 1;
+    width: 75%;
+  }
+  60% {
+    opacity: 1;
+    width: 100%;
+  }
+  to {
+    opacity: 0;
+    width: 100%;
+  }
 }


### PR DESCRIPTION
Adds **ProgressFoldButton** to `@godui/components`: a 3D button whose front face folds back on hover and runs a progress bar on click, with `primary` and `secondary` theme variants sized to match `ShimmerButton`. Front colors and fold-side tints use Tailwind utility classes (`bg-primary`, `text-primary-foreground`, alpha tints) so theme tokens resolve reliably and adapt to light/dark — raw `var(--color-*)` inside `@layer components` rendered the wrong theme values. Wires the component into `index.ts`, package `styles.css`, a Storybook story, and a docs page added to `meta.json`. Also adds a `godui-component-creation` Claude skill documenting the component workflow. Verified rest and fold/click states in Storybook for both variants.