### PR TITLE
feat(highlighter): add Highlighter text component

### DIFF
--- a/apps/docs/content/docs/components/meta.json
+++ b/apps/docs/content/docs/components/meta.json
@@ -8,6 +8,7 @@
     "---Text---",
     "text/typography",
     "text/variable-text",
-    "text/text-animate"
+    "text/text-animate",
+    "text/highlighter"
   ]
 }

--- a/apps/docs/content/docs/components/text/highlighter.mdx
+++ b/apps/docs/content/docs/components/text/highlighter.mdx
@@ -1,0 +1,122 @@
+---
+title: Highlighter
+description: Draw hand-drawn sketch annotations over inline text — highlight, underline, box, circle, and more. Powered by Rough Notation.
+---
+
+import { Highlighter } from "@godui/components";
+
+Draw hand-drawn sketch annotations over inline text, powered by
+[Rough Notation](https://roughnotation.com/).
+
+<ComponentPreview
+  code={`import { Highlighter } from "@godui/components";
+
+export function HighlighterDemo() {
+  return (
+    <p className="text-2xl leading-relaxed">
+      <Highlighter action="highlight">highlight</Highlighter>{" "}
+      <Highlighter action="underline" color="#60a5fa">underline</Highlighter>{" "}
+      <Highlighter action="box" color="#f59e0b">box</Highlighter>{" "}
+      <Highlighter action="circle" color="#34d399">circle</Highlighter>{" "}
+      <Highlighter action="strike-through" color="#f87171">strike-through</Highlighter>{" "}
+      <Highlighter action="crossed-off" color="#a78bfa">crossed-off</Highlighter>{" "}
+      <Highlighter action="bracket" color="#fb7185">bracket</Highlighter>
+    </p>
+  );
+}`}
+>
+  <p className="text-2xl leading-relaxed">
+    <Highlighter action="highlight">highlight</Highlighter>{" "}
+    <Highlighter action="underline" color="#60a5fa">underline</Highlighter>{" "}
+    <Highlighter action="box" color="#f59e0b">box</Highlighter>{" "}
+    <Highlighter action="circle" color="#34d399">circle</Highlighter>{" "}
+    <Highlighter action="strike-through" color="#f87171">strike-through</Highlighter>{" "}
+    <Highlighter action="crossed-off" color="#a78bfa">crossed-off</Highlighter>{" "}
+    <Highlighter action="bracket" color="#fb7185">bracket</Highlighter>
+  </p>
+</ComponentPreview>
+
+## Installation
+
+<ComponentInstall componentName="Highlighter" />
+
+`Highlighter` draws its sketch annotations with [`rough-notation`](https://github.com/linktohack/rough-notation)
+and uses `framer-motion` for the optional in-view trigger. Both are peer dependencies:
+
+```bash
+npm install rough-notation framer-motion
+```
+
+## Usage
+
+```tsx
+import { Highlighter } from "@godui/components";
+```
+
+Wrap any inline text. The annotation is drawn over the element on mount.
+
+```tsx
+<p>
+  The quick brown <Highlighter>fox</Highlighter> jumps over the lazy dog.
+</p>
+```
+
+### Actions
+
+```tsx
+<Highlighter action="highlight">highlight</Highlighter>
+<Highlighter action="underline" color="#60a5fa">underline</Highlighter>
+<Highlighter action="box" color="#f59e0b">box</Highlighter>
+<Highlighter action="circle" color="#34d399">circle</Highlighter>
+<Highlighter action="strike-through" color="#f87171">strike-through</Highlighter>
+<Highlighter action="crossed-off" color="#a78bfa">crossed-off</Highlighter>
+<Highlighter action="bracket" color="#fb7185">bracket</Highlighter>
+```
+
+The `highlight` action paints a pale marker behind the text and renders it in
+dark ink — like a real highlighter pen — so it stays legible in both light and
+dark mode. The other actions draw around the text and keep the inherited color.
+
+### Animate on scroll
+
+Set `isView` to defer the draw-in animation until the element scrolls into view.
+
+```tsx
+<Highlighter action="underline" isView>
+  Reveals as you scroll
+</Highlighter>
+```
+
+### Tuning the sketch
+
+```tsx
+<Highlighter
+  action="box"
+  color="#22d3ee"
+  strokeWidth={2.5}
+  iterations={3}
+  padding={6}
+  animationDuration={900}
+>
+  Bolder, looser, slower
+</Highlighter>
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `children` | `ReactNode` | — | Inline text to annotate |
+| `action` | `"highlight" \| "underline" \| "box" \| "circle" \| "strike-through" \| "crossed-off" \| "bracket"` | `"highlight"` | Annotation style |
+| `color` | `string` | `"#ffd1dc"` | Annotation color (any CSS color string) |
+| `strokeWidth` | `number` | `1.5` | Stroke width of the annotation |
+| `animationDuration` | `number` | `600` | Draw-in animation duration in milliseconds |
+| `iterations` | `number` | `2` | Number of sketch passes (higher = more hand-drawn) |
+| `padding` | `number` | `2` | Gap between the text and the annotation |
+| `multiline` | `boolean` | `true` | Allow the annotation to wrap across lines |
+| `isView` | `boolean` | `false` | Defer the animation until scrolled into view |
+
+## Accessibility
+
+The annotation is a decorative SVG overlay; it does not alter the text content,
+so the underlying text remains fully readable and selectable by screen readers.

--- a/apps/storybook/src/stories/highlighter.stories.tsx
+++ b/apps/storybook/src/stories/highlighter.stories.tsx
@@ -1,0 +1,101 @@
+import { Highlighter, type HighlighterProps } from "@godui/components";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Text/Highlighter",
+  component: Highlighter,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+  },
+  args: {
+    children: "highlight",
+    action: "highlight",
+    className: "text-3xl font-sans",
+  } satisfies HighlighterProps,
+} satisfies Meta<typeof Highlighter>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Highlight: Story = {
+  args: {
+    action: "highlight",
+    children: "highlight",
+  },
+};
+
+export const Underline: Story = {
+  args: {
+    action: "underline",
+    color: "#60a5fa",
+    children: "underline",
+  },
+};
+
+export const Box: Story = {
+  args: {
+    action: "box",
+    color: "#f59e0b",
+    children: "box",
+  },
+};
+
+export const Circle: Story = {
+  args: {
+    action: "circle",
+    color: "#34d399",
+    children: "circle",
+  },
+};
+
+export const StrikeThrough: Story = {
+  args: {
+    action: "strike-through",
+    color: "#f87171",
+    children: "strike-through",
+  },
+};
+
+export const CrossedOff: Story = {
+  args: {
+    action: "crossed-off",
+    color: "#a78bfa",
+    children: "crossed-off",
+  },
+};
+
+export const Bracket: Story = {
+  args: {
+    action: "bracket",
+    color: "#fb7185",
+    children: "bracket",
+  },
+};
+
+export const CustomColor: Story = {
+  args: {
+    action: "highlight",
+    color: "#22d3ee",
+    children: "custom color",
+  },
+};
+
+export const InView: Story = {
+  args: {
+    action: "underline",
+    isView: true,
+    children: "Scroll into view to animate",
+    className: "text-3xl font-sans",
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ height: "200vh", paddingTop: "120vh" }}>
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    layout: "padded",
+  },
+};

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -35,7 +35,8 @@
     "react": "^18 || ^19"
   },
   "dependencies": {
-    "@fontsource-variable/roboto-flex": "^5.2.8"
+    "@fontsource-variable/roboto-flex": "^5.2.8",
+    "rough-notation": "^0.5.1"
   },
   "peerDependenciesMeta": {
     "geist": {

--- a/packages/components/src/highlighter.tsx
+++ b/packages/components/src/highlighter.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useInView } from "framer-motion";
+import * as React from "react";
+import { annotate } from "rough-notation";
+import type { RoughAnnotation } from "rough-notation/lib/model";
+
+export type HighlighterAction =
+  | "highlight"
+  | "underline"
+  | "box"
+  | "circle"
+  | "strike-through"
+  | "crossed-off"
+  | "bracket";
+
+export type HighlighterProps = React.HTMLAttributes<HTMLSpanElement> & {
+  children: React.ReactNode;
+  /** Annotation style drawn over the text */
+  action?: HighlighterAction;
+  /** Annotation color (any CSS color string) */
+  color?: string;
+  /** Stroke width of the sketch annotation */
+  strokeWidth?: number;
+  /** Duration of the draw-in animation in milliseconds */
+  animationDuration?: number;
+  /** Number of sketch passes (higher looks more hand-drawn) */
+  iterations?: number;
+  /** Padding between the text and the annotation */
+  padding?: number;
+  /** Allow the annotation to wrap across multiple lines */
+  multiline?: boolean;
+  /** Only draw the annotation once the element scrolls into view */
+  isView?: boolean;
+};
+
+const Highlighter = React.forwardRef<HTMLSpanElement, HighlighterProps>(
+  (
+    {
+      children,
+      className,
+      action = "highlight",
+      color = "#ffd1dc",
+      strokeWidth = 1.5,
+      animationDuration = 600,
+      iterations = 2,
+      padding = 2,
+      multiline = true,
+      isView = false,
+      ...props
+    },
+    ref,
+  ) => {
+    const elementRef = React.useRef<HTMLSpanElement>(null);
+    const mergedRef = React.useCallback(
+      (node: HTMLSpanElement | null) => {
+        elementRef.current = node;
+        if (typeof ref === "function") {
+          ref(node);
+        } else if (ref) {
+          ref.current = node;
+        }
+      },
+      [ref],
+    );
+
+    const isInView = useInView(elementRef, {
+      once: true,
+      margin: "-10%",
+    });
+
+    const shouldShow = !isView || isInView;
+
+    React.useLayoutEffect(() => {
+      const element = elementRef.current;
+      let annotation: RoughAnnotation | null = null;
+      let resizeObserver: ResizeObserver | null = null;
+
+      if (shouldShow && element) {
+        const currentAnnotation = annotate(element, {
+          type: action,
+          color,
+          strokeWidth,
+          animationDuration,
+          iterations,
+          padding,
+          multiline,
+        });
+        annotation = currentAnnotation;
+        currentAnnotation.show();
+
+        resizeObserver = new ResizeObserver(() => {
+          currentAnnotation.hide();
+          currentAnnotation.show();
+        });
+
+        resizeObserver.observe(element);
+        resizeObserver.observe(document.body);
+      }
+
+      return () => {
+        annotation?.remove();
+        resizeObserver?.disconnect();
+      };
+    }, [
+      shouldShow,
+      action,
+      color,
+      strokeWidth,
+      animationDuration,
+      iterations,
+      padding,
+      multiline,
+    ]);
+
+    // The highlight marker paints a pale fill *behind* the text, so it needs
+    // dark text to stay legible on any theme (like a real highlighter pen).
+    // Other actions draw around the text, which keeps the inherited color.
+    const actionTextClass = action === "highlight" ? "text-neutral-950" : "";
+
+    return (
+      <span
+        ref={mergedRef}
+        className={`relative inline-block bg-transparent ${actionTextClass} ${className ?? ""}`}
+        {...props}
+      >
+        {children}
+      </span>
+    );
+  },
+);
+Highlighter.displayName = "Highlighter";
+
+export { Highlighter };

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -36,3 +36,8 @@ export {
   type TextAnimateBy,
   type TextAnimateElement,
 } from "./text-animate";
+export {
+  Highlighter,
+  type HighlighterProps,
+  type HighlighterAction,
+} from "./highlighter";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,6 +148,9 @@ importers:
       react:
         specifier: ^18 || ^19
         version: 19.2.4
+      rough-notation:
+        specifier: ^0.5.1
+        version: 0.5.1
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4.1.6
@@ -4206,6 +4209,9 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rough-notation@0.5.1:
+    resolution: {integrity: sha512-ITHofTzm13cWFVfoGsh/4c/k2Mg8geKgBCwex71UZLnNuw403tCRjYPQ68jSAd37DMbZIePXPjDgY0XdZi9HPw==}
+
   run-applescript@7.1.0:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
@@ -7059,8 +7065,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.6
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
@@ -7082,7 +7088,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -7093,22 +7099,22 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -7119,7 +7125,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -9039,6 +9045,8 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.62.0
       '@rollup/rollup-win32-x64-msvc': 4.62.0
       fsevents: 2.3.3
+
+  rough-notation@0.5.1: {}
 
   run-applescript@7.1.0: {}
 


### PR DESCRIPTION
Adds a `Highlighter` text component to `@godui/components` that draws hand-drawn sketch annotations over inline text, powered by [Rough Notation](https://roughnotation.com/) (added as a dependency). It supports 7 actions — highlight, underline, box, circle, strike-through, crossed-off, bracket — plus an `isView` scroll trigger and sketch-tuning props (color, strokeWidth, iterations, padding, animationDuration). The `highlight` action renders dark ink over its pale marker so it stays legible in both light and dark mode. Ships with Storybook stories for every action and a docs page whose preview demos all variants at once.