### PR TITLE
feat(buttons): unify 3-size scale (sm/md/lg) across all buttons

### DIFF
--- a/apps/storybook/src/stories/magic-button.stories.tsx
+++ b/apps/storybook/src/stories/magic-button.stories.tsx
@@ -39,7 +39,7 @@ export const Sizes: Story = {
   render: () => (
     <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
       <MagicButton size="sm">Small</MagicButton>
-      <MagicButton size="default">Default</MagicButton>
+      <MagicButton size="md">Medium</MagicButton>
       <MagicButton size="lg">Large</MagicButton>
     </div>
   ),
@@ -49,7 +49,7 @@ export const Playground: Story = {
   args: {
     children: "Push me",
     variant: "default",
-    size: "default",
+    size: "md",
     rainbow: true,
   } satisfies MagicButtonProps,
 };

--- a/apps/storybook/src/stories/progress-fold-button.stories.tsx
+++ b/apps/storybook/src/stories/progress-fold-button.stories.tsx
@@ -37,3 +37,13 @@ export const Disabled: Story = {
     disabled: true,
   } satisfies ProgressFoldButtonProps,
 };
+
+export const Sizes: Story = {
+  render: () => (
+    <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
+      <ProgressFoldButton size="sm">Small</ProgressFoldButton>
+      <ProgressFoldButton size="md">Medium</ProgressFoldButton>
+      <ProgressFoldButton size="lg">Large</ProgressFoldButton>
+    </div>
+  ),
+};

--- a/apps/storybook/src/stories/shimmer-button.stories.tsx
+++ b/apps/storybook/src/stories/shimmer-button.stories.tsx
@@ -46,7 +46,7 @@ export const Sizes: Story = {
   render: () => (
     <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
       <ShimmerButton size="sm">Small</ShimmerButton>
-      <ShimmerButton size="default">Default</ShimmerButton>
+      <ShimmerButton size="md">Medium</ShimmerButton>
       <ShimmerButton size="lg">Large</ShimmerButton>
     </div>
   ),

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -7,6 +7,7 @@ export {
 export {
   ProgressFoldButton,
   type ProgressFoldButtonProps,
+  type ProgressFoldButtonSize,
   type ProgressFoldButtonVariant,
 } from "./progress-fold-button";
 export {
@@ -16,23 +17,23 @@ export {
   type ShimmerButtonVariant,
 } from "./shimmer-button";
 export {
+  TextAnimate,
+  type TextAnimateBy,
+  type TextAnimateElement,
+  type TextAnimatePreset,
+  type TextAnimateProps,
+} from "./text-animate";
+export {
   Typography,
   type TypographyProps,
   type TypographyVariant,
 } from "./typography";
 export {
+  type AxisValue,
   VariableText,
-  type VariableTextProps,
   type VariableTextPreset,
-  type VariableTextTrigger,
+  type VariableTextProps,
   type VariableTextSplitBy,
   type VariableTextSpring,
-  type AxisValue,
+  type VariableTextTrigger,
 } from "./variable-text";
-export {
-  TextAnimate,
-  type TextAnimateProps,
-  type TextAnimatePreset,
-  type TextAnimateBy,
-  type TextAnimateElement,
-} from "./text-animate";

--- a/packages/components/src/magic-button.tsx
+++ b/packages/components/src/magic-button.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 export type MagicButtonVariant = "default" | "secondary";
-export type MagicButtonSize = "default" | "sm" | "lg";
+export type MagicButtonSize = "sm" | "md" | "lg";
 
 export type MagicButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   variant?: MagicButtonVariant;
@@ -12,7 +12,7 @@ export type MagicButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
 
 const sizeClasses: Record<MagicButtonSize, string> = {
   sm: "magic-button-front--sm",
-  default: "magic-button-front--default",
+  md: "magic-button-front--md",
   lg: "magic-button-front--lg",
 };
 
@@ -21,7 +21,7 @@ const MagicButton = React.forwardRef<HTMLButtonElement, MagicButtonProps>(
     {
       className,
       variant = "default",
-      size = "default",
+      size = "md",
       rainbow = true,
       children,
       ...props

--- a/packages/components/src/progress-fold-button.tsx
+++ b/packages/components/src/progress-fold-button.tsx
@@ -3,11 +3,19 @@
 import * as React from "react";
 
 export type ProgressFoldButtonVariant = "primary" | "secondary";
+export type ProgressFoldButtonSize = "sm" | "md" | "lg";
 
 export type ProgressFoldButtonProps =
   React.ButtonHTMLAttributes<HTMLButtonElement> & {
     variant?: ProgressFoldButtonVariant;
+    size?: ProgressFoldButtonSize;
   };
+
+const sizeClasses: Record<ProgressFoldButtonSize, string> = {
+  sm: "progress-fold-button--sm",
+  md: "progress-fold-button--md",
+  lg: "progress-fold-button--lg",
+};
 
 const frontClasses: Record<ProgressFoldButtonVariant, string> = {
   primary: "bg-primary text-primary-foreground",
@@ -30,37 +38,52 @@ const barClasses: Record<ProgressFoldButtonVariant, string> = {
 const ProgressFoldButton = React.forwardRef<
   HTMLButtonElement,
   ProgressFoldButtonProps
->(({ className, children, onClick, variant = "primary", ...props }, ref) => {
-  const [active, setActive] = React.useState(false);
+>(
+  (
+    {
+      className,
+      children,
+      onClick,
+      variant = "primary",
+      size = "md",
+      ...props
+    },
+    ref,
+  ) => {
+    const [active, setActive] = React.useState(false);
 
-  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    setActive(true);
-    onClick?.(event);
-  };
+    const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+      setActive(true);
+      onClick?.(event);
+    };
 
-  return (
-    <button
-      ref={ref}
-      type="button"
-      data-variant={variant}
-      data-active={active ? "true" : undefined}
-      onClick={handleClick}
-      className={`progress-fold-button text-sm font-medium ${className ?? ""}`}
-      {...props}
-    >
-      <span className="progress-fold-button-layers" aria-hidden="true">
-        <span className={`progress-fold-button-back ${backClasses[variant]}`} />
-        <span
-          className={`progress-fold-button-bar ${barClasses[variant]}`}
-          onAnimationEnd={() => setActive(false)}
-        />
-      </span>
-      <span className={`progress-fold-button-front ${frontClasses[variant]}`}>
-        {children}
-      </span>
-    </button>
-  );
-});
+    return (
+      <button
+        ref={ref}
+        type="button"
+        data-variant={variant}
+        data-size={size}
+        data-active={active ? "true" : undefined}
+        onClick={handleClick}
+        className={`progress-fold-button font-medium ${sizeClasses[size]} ${className ?? ""}`}
+        {...props}
+      >
+        <span className="progress-fold-button-layers" aria-hidden="true">
+          <span
+            className={`progress-fold-button-back ${backClasses[variant]}`}
+          />
+          <span
+            className={`progress-fold-button-bar ${barClasses[variant]}`}
+            onAnimationEnd={() => setActive(false)}
+          />
+        </span>
+        <span className={`progress-fold-button-front ${frontClasses[variant]}`}>
+          {children}
+        </span>
+      </button>
+    );
+  },
+);
 ProgressFoldButton.displayName = "ProgressFoldButton";
 
 export { ProgressFoldButton };

--- a/packages/components/src/shimmer-button.tsx
+++ b/packages/components/src/shimmer-button.tsx
@@ -4,7 +4,7 @@ import type { CSSProperties } from "react";
 import * as React from "react";
 
 export type ShimmerButtonVariant = "primary" | "secondary" | "outline";
-export type ShimmerButtonSize = "default" | "sm" | "lg";
+export type ShimmerButtonSize = "sm" | "md" | "lg";
 
 export type ShimmerButtonProps =
   React.ButtonHTMLAttributes<HTMLButtonElement> & {
@@ -24,16 +24,12 @@ export type ShimmerButtonProps =
     background?: string;
   };
 
-const sizeClasses: Record<ShimmerButtonSize, string> = {
-  sm: "px-4 py-2 text-xs",
-  default: "px-6 py-3 text-sm",
-  lg: "px-8 py-3.5 text-base",
-};
-
+// Padding and font-size come from the shared button size scale via
+// `.shimmer-button[data-size="…"]` rules in styles.css.
 const radiusBySize: Record<ShimmerButtonSize, string> = {
-  sm: "var(--radius-md)",
-  default: "var(--radius-lg)",
-  lg: "var(--radius-xl)",
+  sm: "var(--button-radius-sm)",
+  md: "var(--button-radius-md)",
+  lg: "var(--button-radius-lg)",
 };
 
 const variantDefaults: Record<
@@ -75,7 +71,7 @@ const ShimmerButton = React.forwardRef<HTMLButtonElement, ShimmerButtonProps>(
     {
       className,
       variant = "primary",
-      size = "default",
+      size = "md",
       shimmer = true,
       shimmerColor,
       shimmerSize = "0.05em",
@@ -124,7 +120,7 @@ const ShimmerButton = React.forwardRef<HTMLButtonElement, ShimmerButtonProps>(
         data-size={size}
         data-shimmer={shimmer ? "true" : undefined}
         style={style}
-        className={`group shimmer-button relative z-0 flex cursor-pointer items-center justify-center overflow-hidden [border-radius:var(--radius)] border whitespace-nowrap [background:var(--bg)] transform-gpu transition-transform duration-300 ease-in-out active:translate-y-px focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ${defaults.textClass} ${defaults.borderClass} ${sizeClasses[size]} ${className ?? ""}`}
+        className={`group shimmer-button relative z-0 flex cursor-pointer items-center justify-center overflow-hidden [border-radius:var(--radius)] border whitespace-nowrap [background:var(--bg)] transform-gpu transition-transform duration-300 ease-in-out active:translate-y-px focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ${defaults.textClass} ${defaults.borderClass} ${className ?? ""}`}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
         {...props}

--- a/packages/components/styles.css
+++ b/packages/components/styles.css
@@ -54,6 +54,25 @@
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) + 4px);
 
+  /* Shared button size scale — single source of truth for all buttons (sm/md/lg) */
+  --button-py-sm: 0.5rem;
+  --button-px-sm: 1rem;
+  --button-text-sm: 0.875rem;
+  --button-leading-sm: 1.25rem;
+  --button-radius-sm: var(--radius-md);
+
+  --button-py-md: 0.75rem;
+  --button-px-md: 1.5rem;
+  --button-text-md: 0.875rem;
+  --button-leading-md: 1.25rem;
+  --button-radius-md: var(--radius-lg);
+
+  --button-py-lg: 1rem;
+  --button-px-lg: 2rem;
+  --button-text-lg: 1rem;
+  --button-leading-lg: 1.5rem;
+  --button-radius-lg: var(--radius-xl);
+
   --shadow-2xs: var(--shadow-2xs);
   --shadow-xs: var(--shadow-xs);
   --shadow-sm: var(--shadow-sm);
@@ -262,21 +281,40 @@
   }
 
   .magic-button-front--sm {
-    padding: 8px 20px;
-    font-size: 0.875rem;
-    line-height: 1.25rem;
+    padding: var(--button-py-sm) var(--button-px-sm);
+    font-size: var(--button-text-sm);
+    line-height: var(--button-leading-sm);
   }
 
-  .magic-button-front--default {
-    padding: 12px 32px;
-    font-size: 0.875rem;
-    line-height: 1.25rem;
+  .magic-button-front--md {
+    padding: var(--button-py-md) var(--button-px-md);
+    font-size: var(--button-text-md);
+    line-height: var(--button-leading-md);
   }
 
   .magic-button-front--lg {
-    padding: 14px 42px;
-    font-size: 1rem;
-    line-height: 1.5rem;
+    padding: var(--button-py-lg) var(--button-px-lg);
+    font-size: var(--button-text-lg);
+    line-height: var(--button-leading-lg);
+  }
+
+  /* Shimmer button size scale (shared --button-* tokens; radius via --radius) */
+  .shimmer-button[data-size="sm"] {
+    padding: var(--button-py-sm) var(--button-px-sm);
+    font-size: var(--button-text-sm);
+    line-height: var(--button-leading-sm);
+  }
+
+  .shimmer-button[data-size="md"] {
+    padding: var(--button-py-md) var(--button-px-md);
+    font-size: var(--button-text-md);
+    line-height: var(--button-leading-md);
+  }
+
+  .shimmer-button[data-size="lg"] {
+    padding: var(--button-py-lg) var(--button-px-lg);
+    font-size: var(--button-text-lg);
+    line-height: var(--button-leading-lg);
   }
 
   .shimmer-button-highlight {
@@ -373,11 +411,41 @@
     display: grid;
     place-items: center;
     width: 100%;
-    padding: 0.75rem 1.5rem;
-    border-radius: var(--radius-lg);
+    border-radius: inherit;
     transform: rotateX(0deg);
     transform-origin: top center;
     transition: transform 0.2s;
+  }
+
+  /* Size scale — shared --button-* tokens drive padding/font; radius per size */
+  .progress-fold-button--sm,
+  .progress-fold-button--sm .progress-fold-button-layers {
+    border-radius: var(--button-radius-sm);
+  }
+  .progress-fold-button--sm .progress-fold-button-front {
+    padding: var(--button-py-sm) var(--button-px-sm);
+    font-size: var(--button-text-sm);
+    line-height: var(--button-leading-sm);
+  }
+
+  .progress-fold-button--md,
+  .progress-fold-button--md .progress-fold-button-layers {
+    border-radius: var(--button-radius-md);
+  }
+  .progress-fold-button--md .progress-fold-button-front {
+    padding: var(--button-py-md) var(--button-px-md);
+    font-size: var(--button-text-md);
+    line-height: var(--button-leading-md);
+  }
+
+  .progress-fold-button--lg,
+  .progress-fold-button--lg .progress-fold-button-layers {
+    border-radius: var(--button-radius-lg);
+  }
+  .progress-fold-button--lg .progress-fold-button-front {
+    padding: var(--button-py-lg) var(--button-px-lg);
+    font-size: var(--button-text-lg);
+    line-height: var(--button-leading-lg);
   }
 
   .progress-fold-button:hover:not(:disabled) .progress-fold-button-front {


### PR DESCRIPTION
Adds a shared `--button-*` size token scale to the theme as a single source of truth, and routes MagicButton, ShimmerButton, and ProgressFoldButton through it so padding, typography, and radius stay consistent across all three. ProgressFoldButton gains a new `size` prop, and size names standardize to `sm`/`md`/`lg` (default `md`, renamed from the previous `"default"` — breaking). Each button now has a Storybook **Sizes** story showing all three sizes.