### PR TITLE
feat(dev): add portless for conflict-free dev URLs

### DIFF
--- a/apps/docs/content/docs/components/meta.json
+++ b/apps/docs/content/docs/components/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "Components",
+  "defaultOpen": true,
   "pages": [
     "---Buttons---",
     "buttons/magic-button",

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -4,9 +4,13 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "storybook dev -p 6006 --no-open",
+    "dev": "storybook dev -p ${PORT:-6006} --no-open",
+    "dev:portless": "portless",
     "build": "storybook build -o storybook-static && shx rm -rf ../docs/public/design-system && shx mkdir -p ../docs/public && shx cp -R storybook-static ../docs/public/design-system",
     "lint": "tsc -p tsconfig.json --noEmit"
+  },
+  "portless": {
+    "name": "godui-storybook"
   },
   "dependencies": {
     "@godui/components": "workspace:*",
@@ -24,6 +28,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.0.4",
     "non.geist": "^2.0.1",
+    "portless": "^0.14.0",
     "shx": "^0.4.0",
     "storybook": "^10.3.1",
     "typescript": "^5.9.3",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "build": "turbo build",
     "build:registry": "shadcn build --output apps/docs/public/r",
     "dev": "turbo dev",
+    "dev:portless": "portless",
     "lint": "turbo lint",
     "check": "biome check .",
     "check:fix": "biome check --write .",
@@ -12,6 +13,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.8",
+    "portless": "^0.14.0",
     "shadcn": "^3.8.5",
     "tsup": "^8.3.5",
     "turbo": "^2.8.20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@biomejs/biome':
         specifier: ^2.4.8
         version: 2.5.0
+      portless:
+        specifier: ^0.14.0
+        version: 0.14.0
       shadcn:
         specifier: ^3.8.5
         version: 3.8.5(@types/node@25.9.3)(typescript@5.9.3)
@@ -130,6 +133,9 @@ importers:
       non.geist:
         specifier: ^2.0.1
         version: 2.0.1
+      portless:
+        specifier: ^0.14.0
+        version: 0.14.0
       shx:
         specifier: ^0.4.0
         version: 0.4.0
@@ -4745,6 +4751,12 @@ packages:
   pkg-up@3.1.0:
     resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
     engines: {node: '>=8'}
+
+  portless@0.14.0:
+    resolution: {integrity: sha512-kKxmxB1DQ9gI8t+V13VhuwTXu31io5nbFubvZAE82AxzXBsvcJV7qQJbmomrQUpbVxo2UVHqs14iX4YK0BClmQ==}
+    engines: {node: '>=24'}
+    os: [darwin, linux, win32]
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -10487,6 +10499,8 @@ snapshots:
   pkg-up@3.1.0:
     dependencies:
       find-up: 3.0.0
+
+  portless@0.14.0: {}
 
   possible-typed-array-names@1.1.0: {}
 

--- a/portless.json
+++ b/portless.json
@@ -1,0 +1,6 @@
+{
+  "apps": {
+    "apps/docs": { "name": "godui-docs" },
+    "apps/storybook": { "name": "godui-storybook" }
+  }
+}


### PR DESCRIPTION
Adds [portless](https://portless.sh/) so dev servers get a free port (4000-4999) and a stable `.localhost` URL instead of Storybook prompting to pick a new port when 6006 is busy. Run all workspace apps at once with `pnpm dev:portless`; `portless.json` names the docs and storybook apps. Storybook's `dev` script now reads `${PORT:-6006}` so portless can override the port (and still defaults to 6006 standalone). Also expands the Components sidebar group by default in the docs site.

Note: portless requires Node 24+ and, on first run, starts an HTTPS proxy on port 443 (auto-sudo) plus a one-time local CA trust install.