### PR TITLE
fix(buttons): unify keyboard focus and activation states

### DIFF
--- a/packages/components/src/magic-button.tsx
+++ b/packages/components/src/magic-button.tsx
@@ -24,15 +24,36 @@ const MagicButton = React.forwardRef<HTMLButtonElement, MagicButtonProps>(
       size = "md",
       rainbow = true,
       children,
+      onKeyDown,
+      onKeyUp,
       ...props
     },
     ref,
   ) => {
+    const [pressed, setPressed] = React.useState(false);
+
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+      if (event.key === "Enter" || event.key === " ") {
+        setPressed(true);
+      }
+      onKeyDown?.(event);
+    };
+
+    const handleKeyUp = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+      if (event.key === "Enter" || event.key === " ") {
+        setPressed(false);
+      }
+      onKeyUp?.(event);
+    };
+
     return (
       <button
         ref={ref}
         data-variant={variant}
         data-rainbow={rainbow ? "true" : undefined}
+        data-pressed={pressed ? "true" : undefined}
+        onKeyDown={handleKeyDown}
+        onKeyUp={handleKeyUp}
         className={`magic-button font-medium ${className ?? ""}`}
         {...props}
       >

--- a/packages/components/src/mask-button.tsx
+++ b/packages/components/src/mask-button.tsx
@@ -26,25 +26,48 @@ const MaskButton = React.forwardRef<HTMLButtonElement, MaskButtonProps>(
       mask = "nature",
       variant = "primary",
       size = "md",
+      onKeyDown,
+      onKeyUp,
       ...props
     },
     ref,
-  ) => (
-    <button
-      ref={ref}
-      type="button"
-      data-mask={mask}
-      data-variant={variant}
-      data-size={size}
-      className={`mask-button font-medium ${sizeClasses[size]} ${className ?? ""}`}
-      {...props}
-    >
-      <span className="mask-button-label">{children}</span>
-      <span className="mask-button-fill" aria-hidden="true">
-        {children}
-      </span>
-    </button>
-  ),
+  ) => {
+    const [pressed, setPressed] = React.useState(false);
+
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+      if (event.key === "Enter" || event.key === " ") {
+        setPressed(true);
+      }
+      onKeyDown?.(event);
+    };
+
+    const handleKeyUp = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+      if (event.key === "Enter" || event.key === " ") {
+        setPressed(false);
+      }
+      onKeyUp?.(event);
+    };
+
+    return (
+      <button
+        ref={ref}
+        type="button"
+        data-mask={mask}
+        data-variant={variant}
+        data-size={size}
+        data-pressed={pressed ? "true" : undefined}
+        onKeyDown={handleKeyDown}
+        onKeyUp={handleKeyUp}
+        className={`mask-button font-medium ${sizeClasses[size]} ${className ?? ""}`}
+        {...props}
+      >
+        <span className="mask-button-label">{children}</span>
+        <span className="mask-button-fill" aria-hidden="true">
+          {children}
+        </span>
+      </button>
+    );
+  },
 );
 MaskButton.displayName = "MaskButton";
 

--- a/packages/components/src/shimmer-button.tsx
+++ b/packages/components/src/shimmer-button.tsx
@@ -82,12 +82,17 @@ const ShimmerButton = React.forwardRef<HTMLButtonElement, ShimmerButtonProps>(
       type = "button",
       onMouseEnter,
       onMouseLeave,
+      onKeyDown,
+      onKeyUp,
+      onFocus,
+      onBlur,
       ...props
     },
     ref,
   ) => {
     const defaults = variantDefaults[variant];
     const sparkRef = React.useRef<HTMLDivElement>(null);
+    const [pressed, setPressed] = React.useState(false);
 
     const style = {
       "--spread": defaults.shimmerSpread,
@@ -98,18 +103,50 @@ const ShimmerButton = React.forwardRef<HTMLButtonElement, ShimmerButtonProps>(
       "--bg": background ?? defaults.background,
     } as CSSProperties;
 
-    const handleMouseEnter = (e: React.MouseEvent<HTMLButtonElement>) => {
+    const setSparkRate = (rate: number) => {
       sparkRef.current?.getAnimations({ subtree: true }).forEach((a) => {
-        a.playbackRate = 3;
+        a.playbackRate = rate;
       });
+    };
+
+    const handleMouseEnter = (e: React.MouseEvent<HTMLButtonElement>) => {
+      setSparkRate(3);
       onMouseEnter?.(e);
     };
 
     const handleMouseLeave = (e: React.MouseEvent<HTMLButtonElement>) => {
-      sparkRef.current?.getAnimations({ subtree: true }).forEach((a) => {
-        a.playbackRate = 1;
-      });
+      setSparkRate(1);
       onMouseLeave?.(e);
+    };
+
+    // Keyboard focus matches the hover speed-up; ignore non-visible focus
+    // (programmatic / pointer) so it stays a keyboard affordance.
+    const handleFocus = (e: React.FocusEvent<HTMLButtonElement>) => {
+      if (e.target.matches(":focus-visible")) {
+        setSparkRate(3);
+      }
+      onFocus?.(e);
+    };
+
+    const handleBlur = (e: React.FocusEvent<HTMLButtonElement>) => {
+      setSparkRate(1);
+      onBlur?.(e);
+    };
+
+    // Enter fires the native click but never sets :active, so mirror the
+    // pointer press cue while the key is held.
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+      if (e.key === "Enter" || e.key === " ") {
+        setPressed(true);
+      }
+      onKeyDown?.(e);
+    };
+
+    const handleKeyUp = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+      if (e.key === "Enter" || e.key === " ") {
+        setPressed(false);
+      }
+      onKeyUp?.(e);
     };
 
     return (
@@ -119,10 +156,15 @@ const ShimmerButton = React.forwardRef<HTMLButtonElement, ShimmerButtonProps>(
         data-variant={variant}
         data-size={size}
         data-shimmer={shimmer ? "true" : undefined}
+        data-pressed={pressed ? "true" : undefined}
         style={style}
-        className={`group shimmer-button relative z-0 flex cursor-pointer items-center justify-center overflow-hidden [border-radius:var(--radius)] border whitespace-nowrap [background:var(--bg)] transform-gpu transition-transform duration-300 ease-in-out active:translate-y-px focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ${defaults.textClass} ${defaults.borderClass} ${className ?? ""}`}
+        className={`group shimmer-button relative z-0 flex cursor-pointer items-center justify-center overflow-hidden [border-radius:var(--radius)] border whitespace-nowrap [background:var(--bg)] transform-gpu transition-transform duration-300 ease-in-out active:translate-y-px data-[pressed=true]:translate-y-px focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ${defaults.textClass} ${defaults.borderClass} ${className ?? ""}`}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
+        onKeyDown={handleKeyDown}
+        onKeyUp={handleKeyUp}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
         {...props}
       >
         <div

--- a/packages/components/styles.css
+++ b/packages/components/styles.css
@@ -189,7 +189,8 @@
     user-select: none;
   }
 
-  .magic-button:hover {
+  .magic-button:hover,
+  .magic-button:focus-visible {
     filter: brightness(110%);
     transition: filter 250ms;
   }
@@ -234,12 +235,14 @@
     transition: transform 600ms cubic-bezier(0.3, 0.7, 0.4, 1);
   }
 
-  .magic-button:hover .magic-button-shadow {
+  .magic-button:hover .magic-button-shadow,
+  .magic-button:focus-visible .magic-button-shadow {
     transform: translateY(4px);
     transition: transform 250ms cubic-bezier(0.3, 0.7, 0.4, 1.5);
   }
 
-  .magic-button:active .magic-button-shadow {
+  .magic-button:active .magic-button-shadow,
+  .magic-button[data-pressed="true"] .magic-button-shadow {
     transform: translateY(1px);
     transition: transform 34ms;
   }
@@ -320,12 +323,14 @@
     background: var(--secondary);
   }
 
-  .magic-button:hover .magic-button-front {
+  .magic-button:hover .magic-button-front,
+  .magic-button:focus-visible .magic-button-front {
     transform: translateY(-6px);
     transition: transform 250ms cubic-bezier(0.3, 0.7, 0.4, 1.5);
   }
 
-  .magic-button:active .magic-button-front {
+  .magic-button:active .magic-button-front,
+  .magic-button[data-pressed="true"] .magic-button-front {
     transform: translateY(-2px);
     transition: transform 34ms;
   }
@@ -914,7 +919,8 @@
     line-height: var(--button-leading-lg);
   }
 
-  .progress-fold-button:hover:not(:disabled) .progress-fold-button-front {
+  .progress-fold-button:hover:not(:disabled) .progress-fold-button-front,
+  .progress-fold-button:focus-visible:not(:disabled) .progress-fold-button-front {
     transform: rotateX(35deg);
   }
 
@@ -975,11 +981,22 @@
     white-space: nowrap;
     user-select: none;
     -webkit-tap-highlight-color: transparent;
+    transition: transform 100ms ease;
+  }
+
+  .mask-button:focus:not(:focus-visible) {
+    outline: none;
   }
 
   .mask-button:focus-visible {
     outline: 2px solid var(--ring);
     outline-offset: 4px;
+  }
+
+  /* Pointer press + keyboard activation (Enter/Space) share a press cue */
+  .mask-button:active:not(:disabled),
+  .mask-button[data-pressed="true"]:not(:disabled) {
+    transform: scale(0.97);
   }
 
   .mask-button:disabled {
@@ -1023,7 +1040,8 @@
     mask-size: 2300% 100%;
     animation: mask-button-out 0.7s steps(22) forwards;
   }
-  .mask-button[data-mask="nature"]:hover:not(:disabled) .mask-button-fill {
+  .mask-button[data-mask="nature"]:hover:not(:disabled) .mask-button-fill,
+  .mask-button[data-mask="nature"]:focus-visible:not(:disabled) .mask-button-fill {
     animation: mask-button-in 0.7s steps(22) forwards;
   }
 
@@ -1034,7 +1052,8 @@
     mask-size: 3000% 100%;
     animation: mask-button-out 0.7s steps(29) forwards;
   }
-  .mask-button[data-mask="urban"]:hover:not(:disabled) .mask-button-fill {
+  .mask-button[data-mask="urban"]:hover:not(:disabled) .mask-button-fill,
+  .mask-button[data-mask="urban"]:focus-visible:not(:disabled) .mask-button-fill {
     animation: mask-button-in 0.7s steps(29) forwards;
   }
 
@@ -1045,7 +1064,8 @@
     mask-size: 7100% 100%;
     animation: mask-button-out 0.7s steps(70) forwards;
   }
-  .mask-button[data-mask="forest"]:hover:not(:disabled) .mask-button-fill {
+  .mask-button[data-mask="forest"]:hover:not(:disabled) .mask-button-fill,
+  .mask-button[data-mask="forest"]:focus-visible:not(:disabled) .mask-button-fill {
     animation: mask-button-in 0.7s steps(70) forwards;
   }
 
@@ -1076,7 +1096,8 @@
       -webkit-mask-position: 0 0;
       mask-position: 0 0;
     }
-    .mask-button:hover:not(:disabled) .mask-button-fill {
+    .mask-button:hover:not(:disabled) .mask-button-fill,
+    .mask-button:focus-visible:not(:disabled) .mask-button-fill {
       animation: none;
       -webkit-mask-position: 100% 0;
       mask-position: 100% 0;


### PR DESCRIPTION
Makes the magic, mask, shimmer, and progress-fold buttons respond to keyboard input the same way they respond to pointer input. Keyboard focus (`:focus-visible`) now triggers the hover visual — magic lift, mask reveal, fold tilt, shimmer speed-up — while keeping the outline ring. Enter and Space mirror the pointer press cue through a `data-pressed` flag, since native buttons fire click on Enter without ever setting `:active`. Pure interaction-state change; no API or visual changes for pointer users.