### PR TITLE
feat: add ProgressiveCardReveal component

### DIFF
--- a/apps/docs/content/docs/components/layout/progressive-card-reveal.mdx
+++ b/apps/docs/content/docs/components/layout/progressive-card-reveal.mdx
@@ -1,0 +1,121 @@
+---
+title: Progressive Card Reveal
+description: A vertical stack of cards where one card expands to its full view while the rest collapse to compact pills, animating the morph between them.
+---
+
+import { ProgressiveCardRevealDemo } from "@/components/demos/progressive-card-reveal-demo";
+
+A vertical stack of cards. Exactly one card is expanded at a time — the rest
+collapse to compact pills. The parent owns which card is active; clicking a
+collapsed pill asks it to switch, and Framer Motion animates the size morph and
+crossfades the content.
+
+<ComponentPreview
+  code={`import { ProgressiveCardReveal } from "@/components/godui/progressive-card-reveal";
+import { useState } from "react";
+
+const legs = [
+  { icon: "✈️", label: "Flight", meta: "~3 hours", distance: "2,400 miles", time: "~3 hours" },
+  { icon: "🚆", label: "Train", meta: "~12 hours", distance: "1,100 miles", time: "~12 hours" },
+  { icon: "🚗", label: "Driving", meta: "~18 hours", distance: "332 miles", time: "~2 hours" },
+  { icon: "🚴", label: "Cycling", meta: "~2 days", distance: "60 miles", time: "~2 days" },
+  { icon: "🚶", label: "Walking", meta: "~40 minutes", distance: "2 miles", time: "~40 minutes" },
+];
+
+export function ProgressiveCardRevealDemo() {
+  const [active, setActive] = useState(4);
+
+  return (
+    <ProgressiveCardReveal activeIndex={active} onActiveChange={setActive} className="w-[360px]">
+      {legs.map((leg) => (
+        <ProgressiveCardReveal.Card key={leg.label}>
+          <ProgressiveCardReveal.CardCollapsed>
+            <div className="flex items-center justify-between gap-4">
+              <span className="flex items-center gap-2 font-medium">
+                <span aria-hidden>{leg.icon}</span>
+                {leg.label}
+              </span>
+              <span className="text-sm text-muted-foreground">{leg.meta}</span>
+            </div>
+          </ProgressiveCardReveal.CardCollapsed>
+          <ProgressiveCardReveal.CardExpanded>
+            <div className="flex flex-col gap-4">
+              <span className="flex items-center gap-2 font-medium">
+                <span aria-hidden>{leg.icon}</span>
+                {leg.label}
+              </span>
+              <div className="flex items-end justify-between gap-6">
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-muted-foreground">Distance</p>
+                  <p className="text-3xl font-semibold">{leg.distance}</p>
+                </div>
+                <div className="text-right">
+                  <p className="text-xs uppercase tracking-wide text-muted-foreground">Time</p>
+                  <p className="text-3xl font-semibold">{leg.time}</p>
+                </div>
+              </div>
+            </div>
+          </ProgressiveCardReveal.CardExpanded>
+        </ProgressiveCardReveal.Card>
+      ))}
+    </ProgressiveCardReveal>
+  );
+}`}
+>
+  <ProgressiveCardRevealDemo />
+</ComponentPreview>
+
+## Installation
+
+<ComponentInstall componentName="ProgressiveCardReveal" />
+
+## Usage
+
+```tsx
+import { ProgressiveCardReveal } from "@/components/godui/progressive-card-reveal";
+```
+
+`ProgressiveCardReveal` is a compound component. The root is **controlled** via
+`activeIndex` — keep it in state and update it from `onActiveChange`. Each
+`Card` declares two views with the `CardCollapsed` and `CardExpanded` slots; the
+card derives its index from its position, so you never pass an index manually.
+
+```tsx
+const [active, setActive] = useState(0);
+
+<ProgressiveCardReveal activeIndex={active} onActiveChange={setActive}>
+  <ProgressiveCardReveal.Card>
+    <ProgressiveCardReveal.CardCollapsed>Flight — ~3 hours</ProgressiveCardReveal.CardCollapsed>
+    <ProgressiveCardReveal.CardExpanded>{/* full content */}</ProgressiveCardReveal.CardExpanded>
+  </ProgressiveCardReveal.Card>
+  <ProgressiveCardReveal.Card>
+    <ProgressiveCardReveal.CardCollapsed>Driving — ~18 hours</ProgressiveCardReveal.CardCollapsed>
+    <ProgressiveCardReveal.CardExpanded>{/* full content */}</ProgressiveCardReveal.CardExpanded>
+  </ProgressiveCardReveal.Card>
+</ProgressiveCardReveal>
+```
+
+Clicking a collapsed card fires `onActiveChange(index)`. Clicking the
+already-expanded card is a no-op — one card stays open at all times. The
+transition respects `prefers-reduced-motion`, switching instantly when reduced
+motion is requested.
+
+## Props
+
+### ProgressiveCardReveal
+
+| Prop | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `activeIndex` | `number` | — | Index of the expanded card (controlled). |
+| `onActiveChange` | `(index: number) => void` | — | Fired when a collapsed card is activated. |
+
+Also accepts all `div` attributes (e.g. `className`).
+
+### ProgressiveCardReveal.Card
+
+Accepts all `div` attributes. Children must be a `CardCollapsed` and a
+`CardExpanded` slot.
+
+### ProgressiveCardReveal.CardCollapsed / CardExpanded
+
+Slot wrappers — their children are the collapsed (pill) and expanded views.

--- a/apps/docs/content/docs/components/meta.json
+++ b/apps/docs/content/docs/components/meta.json
@@ -12,6 +12,8 @@
     "---Text---",
     "text/elastic-text",
     "text/text-animate",
-    "text/highlighter"
+    "text/highlighter",
+    "---Layout---",
+    "layout/progressive-card-reveal"
   ]
 }

--- a/apps/docs/src/components/demos/progressive-card-reveal-demo.tsx
+++ b/apps/docs/src/components/demos/progressive-card-reveal-demo.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { ProgressiveCardReveal } from "@godui/components";
+import * as React from "react";
+
+type Leg = {
+  icon: string;
+  label: string;
+  meta: string;
+  distance: string;
+  time: string;
+};
+
+const legs: Leg[] = [
+  {
+    icon: "✈️",
+    label: "Flight",
+    meta: "~3 hours",
+    distance: "2,400 miles",
+    time: "~3 hours",
+  },
+  {
+    icon: "🚆",
+    label: "Train",
+    meta: "~12 hours",
+    distance: "1,100 miles",
+    time: "~12 hours",
+  },
+  {
+    icon: "🚗",
+    label: "Driving",
+    meta: "~18 hours",
+    distance: "332 miles",
+    time: "~2 hours",
+  },
+  {
+    icon: "🚴",
+    label: "Cycling",
+    meta: "~2 days",
+    distance: "60 miles",
+    time: "~2 days",
+  },
+  {
+    icon: "🚶",
+    label: "Walking",
+    meta: "~40 minutes",
+    distance: "2 miles",
+    time: "~40 minutes",
+  },
+];
+
+export function ProgressiveCardRevealDemo() {
+  const [active, setActive] = React.useState(4);
+
+  return (
+    <ProgressiveCardReveal
+      activeIndex={active}
+      onActiveChange={setActive}
+      className="w-[360px]"
+    >
+      {legs.map((leg) => (
+        <ProgressiveCardReveal.Card key={leg.label}>
+          <ProgressiveCardReveal.CardCollapsed>
+            <div className="flex items-center justify-between gap-4">
+              <span className="flex items-center gap-2 font-medium">
+                <span aria-hidden>{leg.icon}</span>
+                {leg.label}
+              </span>
+              <span className="text-sm text-muted-foreground">{leg.meta}</span>
+            </div>
+          </ProgressiveCardReveal.CardCollapsed>
+          <ProgressiveCardReveal.CardExpanded>
+            <div className="flex flex-col gap-4">
+              <span className="flex items-center gap-2 font-medium">
+                <span aria-hidden>{leg.icon}</span>
+                {leg.label}
+              </span>
+              <div className="flex items-end justify-between gap-6">
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                    Distance
+                  </p>
+                  <p className="text-3xl font-semibold">{leg.distance}</p>
+                </div>
+                <div className="text-right">
+                  <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                    Time
+                  </p>
+                  <p className="text-3xl font-semibold">{leg.time}</p>
+                </div>
+              </div>
+            </div>
+          </ProgressiveCardReveal.CardExpanded>
+        </ProgressiveCardReveal.Card>
+      ))}
+    </ProgressiveCardReveal>
+  );
+}

--- a/apps/storybook/src/stories/progressive-card-reveal.stories.tsx
+++ b/apps/storybook/src/stories/progressive-card-reveal.stories.tsx
@@ -1,0 +1,151 @@
+import { ProgressiveCardReveal } from "@godui/components";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import * as React from "react";
+
+const meta = {
+  title: "Layout/Progressive Card Reveal",
+  component: ProgressiveCardReveal,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+  },
+} satisfies Meta<typeof ProgressiveCardReveal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+type Leg = {
+  icon: string;
+  label: string;
+  meta: string;
+  distance: string;
+  time: string;
+};
+
+const legs: Leg[] = [
+  {
+    icon: "✈️",
+    label: "Flight",
+    meta: "~3 hours",
+    distance: "2,400 miles",
+    time: "~3 hours",
+  },
+  {
+    icon: "🚆",
+    label: "Train",
+    meta: "~12 hours",
+    distance: "1,100 miles",
+    time: "~12 hours",
+  },
+  {
+    icon: "🚗",
+    label: "Driving",
+    meta: "~18 hours",
+    distance: "332 miles",
+    time: "~2 hours",
+  },
+  {
+    icon: "🚴",
+    label: "Cycling",
+    meta: "~2 days",
+    distance: "60 miles",
+    time: "~2 days",
+  },
+  {
+    icon: "🚶",
+    label: "Walking",
+    meta: "~40 minutes",
+    distance: "2 miles",
+    time: "~40 minutes",
+  },
+];
+
+function CollapsedRow({ icon, label, meta }: Leg) {
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <span className="flex items-center gap-2 font-medium">
+        <span aria-hidden>{icon}</span>
+        {label}
+      </span>
+      <span className="text-sm text-muted-foreground">{meta}</span>
+    </div>
+  );
+}
+
+function ExpandedBody({ icon, label, distance, time }: Leg) {
+  return (
+    <div className="flex flex-col gap-4">
+      <span className="flex items-center gap-2 font-medium">
+        <span aria-hidden>{icon}</span>
+        {label}
+      </span>
+      <div className="flex items-end justify-between gap-6">
+        <div>
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">
+            Distance
+          </p>
+          <p className="text-3xl font-semibold">{distance}</p>
+        </div>
+        <div className="text-right">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">
+            Time
+          </p>
+          <p className="text-3xl font-semibold">{time}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TravelDemo() {
+  const [active, setActive] = React.useState(4);
+
+  return (
+    <ProgressiveCardReveal
+      activeIndex={active}
+      onActiveChange={setActive}
+      className="w-[420px]"
+    >
+      {legs.map((leg) => (
+        <ProgressiveCardReveal.Card key={leg.label}>
+          <ProgressiveCardReveal.CardCollapsed>
+            <CollapsedRow {...leg} />
+          </ProgressiveCardReveal.CardCollapsed>
+          <ProgressiveCardReveal.CardExpanded>
+            <ExpandedBody {...leg} />
+          </ProgressiveCardReveal.CardExpanded>
+        </ProgressiveCardReveal.Card>
+      ))}
+    </ProgressiveCardReveal>
+  );
+}
+
+export const Default: Story = {
+  args: { activeIndex: 4 },
+  render: () => <TravelDemo />,
+};
+
+export const FirstActive: Story = {
+  args: { activeIndex: 0 },
+  render: () => {
+    const [active, setActive] = React.useState(0);
+    return (
+      <ProgressiveCardReveal
+        activeIndex={active}
+        onActiveChange={setActive}
+        className="w-[420px]"
+      >
+        {legs.map((leg) => (
+          <ProgressiveCardReveal.Card key={leg.label}>
+            <ProgressiveCardReveal.CardCollapsed>
+              <CollapsedRow {...leg} />
+            </ProgressiveCardReveal.CardCollapsed>
+            <ProgressiveCardReveal.CardExpanded>
+              <ExpandedBody {...leg} />
+            </ProgressiveCardReveal.CardExpanded>
+          </ProgressiveCardReveal.Card>
+        ))}
+      </ProgressiveCardReveal>
+    );
+  },
+};

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -36,6 +36,11 @@ export {
   type ProgressFoldButtonVariant,
 } from "./progress-fold-button";
 export {
+  ProgressiveCardReveal,
+  type ProgressiveCardRevealCardProps,
+  type ProgressiveCardRevealProps,
+} from "./progressive-card-reveal";
+export {
   ShimmerButton,
   type ShimmerButtonProps,
   type ShimmerButtonSize,

--- a/packages/components/src/progressive-card-reveal/index.ts
+++ b/packages/components/src/progressive-card-reveal/index.ts
@@ -1,0 +1,5 @@
+export {
+  ProgressiveCardReveal,
+  type ProgressiveCardRevealCardProps,
+  type ProgressiveCardRevealProps,
+} from "./progressive-card-reveal";

--- a/packages/components/src/progressive-card-reveal/progressive-card-reveal.test.tsx
+++ b/packages/components/src/progressive-card-reveal/progressive-card-reveal.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ProgressiveCardReveal } from "./progressive-card-reveal";
+
+const labels = ["Flight", "Driving", "Walking"];
+
+function renderReveal(activeIndex: number, onActiveChange = vi.fn()) {
+  const utils = render(
+    <ProgressiveCardReveal
+      activeIndex={activeIndex}
+      onActiveChange={onActiveChange}
+    >
+      {labels.map((label) => (
+        <ProgressiveCardReveal.Card key={label}>
+          <ProgressiveCardReveal.CardCollapsed>
+            {`${label} pill`}
+          </ProgressiveCardReveal.CardCollapsed>
+          <ProgressiveCardReveal.CardExpanded>
+            {`${label} details`}
+          </ProgressiveCardReveal.CardExpanded>
+        </ProgressiveCardReveal.Card>
+      ))}
+    </ProgressiveCardReveal>,
+  );
+  return { ...utils, onActiveChange };
+}
+
+describe("ProgressiveCardReveal", () => {
+  it("expands the active card and collapses the rest", () => {
+    renderReveal(1);
+    expect(screen.getByText("Driving details")).toBeInTheDocument();
+    expect(screen.getByText("Flight pill")).toBeInTheDocument();
+    expect(screen.getByText("Walking pill")).toBeInTheDocument();
+    expect(screen.queryByText("Flight details")).not.toBeInTheDocument();
+    expect(screen.queryByText("Driving pill")).not.toBeInTheDocument();
+  });
+
+  it("renders each collapsed card as a button", () => {
+    renderReveal(1);
+    expect(screen.getAllByRole("button")).toHaveLength(2);
+  });
+
+  it("fires onActiveChange with the clicked card's index", async () => {
+    const { onActiveChange } = renderReveal(1);
+    await userEvent.click(screen.getByText("Flight pill"));
+    expect(onActiveChange).toHaveBeenCalledWith(0);
+    await userEvent.click(screen.getByText("Walking pill"));
+    expect(onActiveChange).toHaveBeenCalledWith(2);
+  });
+
+  it("sets displayName on the compound parts", () => {
+    expect(ProgressiveCardReveal.displayName).toBe("ProgressiveCardReveal");
+    expect(ProgressiveCardReveal.Card.displayName).toBe(
+      "ProgressiveCardReveal.Card",
+    );
+  });
+
+  it("throws when a Card is rendered outside the provider", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() =>
+      render(
+        <ProgressiveCardReveal.Card>
+          <ProgressiveCardReveal.CardCollapsed>
+            Orphan
+          </ProgressiveCardReveal.CardCollapsed>
+        </ProgressiveCardReveal.Card>,
+      ),
+    ).toThrow(/inside <ProgressiveCardReveal>/);
+    spy.mockRestore();
+  });
+});

--- a/packages/components/src/progressive-card-reveal/progressive-card-reveal.tsx
+++ b/packages/components/src/progressive-card-reveal/progressive-card-reveal.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import * as React from "react";
+
+export type ProgressiveCardRevealProps =
+  React.HTMLAttributes<HTMLDivElement> & {
+    /** Index of the currently expanded card (controlled). */
+    activeIndex: number;
+    /** Fired when a collapsed card is activated. The parent owns the state. */
+    onActiveChange?: (index: number) => void;
+  };
+
+export type ProgressiveCardRevealCardProps = Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "onDrag" | "onDragStart" | "onDragEnd" | "onAnimationStart"
+>;
+
+type RevealContextValue = {
+  activeIndex: number;
+  onActiveChange?: (index: number) => void;
+};
+
+const RevealContext = React.createContext<RevealContextValue | null>(null);
+const CardIndexContext = React.createContext<number | null>(null);
+
+// Size morph (height + position) and corner rounding.
+const LAYOUT_TRANSITION = {
+  type: "spring",
+  stiffness: 260,
+  damping: 30,
+} as const;
+// Crossfade between the collapsed and expanded views.
+const FADE_TRANSITION = { duration: 0.18, ease: "easeOut" } as const;
+const COLLAPSED_RADIUS = 9999;
+const EXPANDED_RADIUS = 20;
+const EXPANDED_WIDTH = "100%";
+// Collapsed cards funnel inward: the farther a card is from the active one,
+// the narrower it gets (distance is `|index - activeIndex|`).
+const COLLAPSED_BASE_WIDTH = 90; // % at distance 1
+const COLLAPSED_WIDTH_STEP = 7; // % narrower per extra step away
+const COLLAPSED_MIN_WIDTH = 60;
+
+function collapsedWidth(distance: number) {
+  const width = COLLAPSED_BASE_WIDTH - (distance - 1) * COLLAPSED_WIDTH_STEP;
+  return `${Math.max(width, COLLAPSED_MIN_WIDTH)}%`;
+}
+
+/**
+ * Slot marker for a card's collapsed (pill) view. Never rendered directly —
+ * `Card` extracts its children and renders them inside the collapsed trigger.
+ */
+function CardCollapsed(_props: { children?: React.ReactNode }) {
+  return null;
+}
+CardCollapsed.displayName = "ProgressiveCardReveal.CardCollapsed";
+
+/**
+ * Slot marker for a card's expanded view. Never rendered directly — `Card`
+ * extracts its children and renders them inside the expanded region.
+ */
+function CardExpanded(_props: { children?: React.ReactNode }) {
+  return null;
+}
+CardExpanded.displayName = "ProgressiveCardReveal.CardExpanded";
+
+function extractSlots(children: React.ReactNode) {
+  let collapsed: React.ReactNode = null;
+  let expanded: React.ReactNode = null;
+  React.Children.forEach(children, (child) => {
+    if (!React.isValidElement(child)) {
+      return;
+    }
+    if (child.type === CardCollapsed) {
+      collapsed = (child.props as { children?: React.ReactNode }).children;
+    } else if (child.type === CardExpanded) {
+      expanded = (child.props as { children?: React.ReactNode }).children;
+    }
+  });
+  return { collapsed, expanded };
+}
+
+const Card = React.forwardRef<HTMLDivElement, ProgressiveCardRevealCardProps>(
+  ({ children, className, ...props }, ref) => {
+    const reveal = React.useContext(RevealContext);
+    const index = React.useContext(CardIndexContext);
+    const reducedMotion = useReducedMotion() ?? false;
+
+    if (reveal === null || index === null) {
+      throw new Error(
+        "ProgressiveCardReveal.Card must be rendered inside <ProgressiveCardReveal>.",
+      );
+    }
+
+    const expanded = index === reveal.activeIndex;
+    const distance = Math.abs(index - reveal.activeIndex);
+    const { collapsed, expanded: expandedView } = extractSlots(children);
+
+    return (
+      <motion.div
+        ref={ref}
+        layout={!reducedMotion}
+        data-expanded={expanded}
+        initial={false}
+        animate={{
+          borderRadius: expanded ? EXPANDED_RADIUS : COLLAPSED_RADIUS,
+        }}
+        transition={reducedMotion ? { duration: 0 } : LAYOUT_TRANSITION}
+        // `layout` animates the width/height delta when these change, so the
+        // active card grows wider at the same time the others shrink.
+        style={{
+          width: expanded ? EXPANDED_WIDTH : collapsedWidth(distance),
+          borderRadius: expanded ? EXPANDED_RADIUS : COLLAPSED_RADIUS,
+        }}
+        className={`relative overflow-hidden border border-border bg-card text-card-foreground shadow-sm transform-gpu ${className ?? ""}`}
+        {...props}
+      >
+        {/* popLayout pulls the exiting view out of flow so the height morph and
+            crossfade run together instead of one-after-the-other. */}
+        <AnimatePresence mode="popLayout" initial={false}>
+          {expanded ? (
+            <motion.div
+              key="expanded"
+              initial={reducedMotion ? false : { opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={reducedMotion ? { duration: 0 } : FADE_TRANSITION}
+              className="px-5 py-4"
+            >
+              {expandedView}
+            </motion.div>
+          ) : (
+            <motion.button
+              key="collapsed"
+              type="button"
+              initial={reducedMotion ? false : { opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={reducedMotion ? { duration: 0 } : FADE_TRANSITION}
+              onClick={() => reveal.onActiveChange?.(index)}
+              aria-expanded={false}
+              className="block w-full cursor-pointer px-5 py-2 text-left text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+            >
+              {collapsed}
+            </motion.button>
+          )}
+        </AnimatePresence>
+      </motion.div>
+    );
+  },
+);
+Card.displayName = "ProgressiveCardReveal.Card";
+
+const Root = React.forwardRef<HTMLDivElement, ProgressiveCardRevealProps>(
+  ({ activeIndex, onActiveChange, children, className, ...props }, ref) => {
+    const contextValue = React.useMemo<RevealContextValue>(
+      () => ({ activeIndex, onActiveChange }),
+      [activeIndex, onActiveChange],
+    );
+
+    // Assign each Card its position so consumers never pass an index manually.
+    let cardIndex = 0;
+    const indexedChildren = React.Children.map(children, (child) => {
+      if (React.isValidElement(child) && child.type === Card) {
+        const index = cardIndex;
+        cardIndex += 1;
+        return (
+          <CardIndexContext.Provider value={index}>
+            {child}
+          </CardIndexContext.Provider>
+        );
+      }
+      return child;
+    });
+
+    return (
+      <RevealContext.Provider value={contextValue}>
+        <div
+          ref={ref}
+          className={`flex flex-col items-center gap-2 ${className ?? ""}`}
+          {...props}
+        >
+          {indexedChildren}
+        </div>
+      </RevealContext.Provider>
+    );
+  },
+);
+Root.displayName = "ProgressiveCardReveal";
+
+const ProgressiveCardReveal = Object.assign(Root, {
+  Card,
+  CardCollapsed,
+  CardExpanded,
+});
+
+export { ProgressiveCardReveal };

--- a/registry.json
+++ b/registry.json
@@ -800,6 +800,21 @@
       }
     },
     {
+      "name": "progressive-card-reveal",
+      "type": "registry:ui",
+      "title": "Progressive Card Reveal",
+      "description": "A vertical stack of cards where one card expands to its full view while the rest collapse to compact pills, animating the morph between them.",
+      "registryDependencies": ["@godui/godui-theme"],
+      "dependencies": ["framer-motion"],
+      "files": [
+        {
+          "path": "packages/components/src/progressive-card-reveal/progressive-card-reveal.tsx",
+          "type": "registry:ui",
+          "target": "components/godui/progressive-card-reveal.tsx"
+        }
+      ]
+    },
+    {
       "name": "elastic-text",
       "type": "registry:ui",
       "title": "Elastic Text",


### PR DESCRIPTION
Adds **ProgressiveCardReveal**, GoDUI's first compound component (`ProgressiveCardReveal` + `.Card` + `.CardCollapsed` + `.CardExpanded`): a vertical card stack where one card expands to full content while the others funnel into compact pills that narrow with distance from the active card. It's controlled via `activeIndex`/`onActiveChange`, and Framer Motion `layout` animates the simultaneous grow/shrink plus content crossfade while respecting reduced motion. Ships with Storybook stories, a docs page (new "Layout" nav category) with an interactive 5-card demo, and a shadcn registry entry. Collapsed pills are real focusable buttons for keyboard access.