### PR TITLE
feat(progress-fold-button): controlled loading progress state

### DIFF
--- a/apps/docs/content/docs/components/buttons/progress-fold-button.mdx
+++ b/apps/docs/content/docs/components/buttons/progress-fold-button.mdx
@@ -1,6 +1,6 @@
 ---
 title: Progress Fold Button
-description: A 3D button whose front face folds back on hover and runs a progress bar on click.
+description: A 3D button whose front face folds back to reveal a controlled progress bar while loading.
 ---
 
 import { ProgressFoldButton } from "@godui/components";
@@ -11,21 +11,73 @@ import { ProgressFoldButton } from "@godui/components";
 export function ProgressFoldButtonDemo() {
   return (
     <div className="flex flex-wrap items-center justify-center gap-6">
-      <ProgressFoldButton variant="primary">Hover & click</ProgressFoldButton>
-      <ProgressFoldButton variant="secondary">Hover & click</ProgressFoldButton>
+      <ProgressFoldButton variant="primary">Submit</ProgressFoldButton>
+      <ProgressFoldButton variant="secondary">Submit</ProgressFoldButton>
     </div>
   );
 }`}
 >
   <div className="flex flex-wrap items-center justify-center gap-6">
-    <ProgressFoldButton variant="primary">Hover & click</ProgressFoldButton>
-    <ProgressFoldButton variant="secondary">Hover & click</ProgressFoldButton>
+    <ProgressFoldButton variant="primary">Submit</ProgressFoldButton>
+    <ProgressFoldButton variant="secondary">Submit</ProgressFoldButton>
   </div>
 </ComponentPreview>
 
-The front face folds back on hover, revealing the layers behind it. Clicking
-runs the progress bar animation, which resets when it finishes so it can replay
-on the next click.
+The front face folds back on hover, revealing the layers behind it. Set
+`status="loading"` to hold the fold open and run a progress bar — controlled by
+you, like the Magic Input.
+
+## Loading
+
+`status` and `progress` are fully controlled. While `status="loading"` the front
+face folds open and a progress bar runs behind it — determinate when you pass
+`progress`, otherwise an indeterminate segment sweeps across. Back to `idle` and
+the front folds flat again.
+
+<ComponentPreview
+  code={`import { ProgressFoldButton } from "@/components/godui/progress-fold-button";
+
+export function ProgressFoldButtonLoading() {
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-6">
+      <ProgressFoldButton status="loading">Indeterminate</ProgressFoldButton>
+      <ProgressFoldButton status="loading" progress={60}>
+        Determinate
+      </ProgressFoldButton>
+    </div>
+  );
+}`}
+>
+  <div className="flex flex-wrap items-center justify-center gap-6">
+    <ProgressFoldButton status="loading">Indeterminate</ProgressFoldButton>
+    <ProgressFoldButton status="loading" progress={60}>
+      Determinate
+    </ProgressFoldButton>
+  </div>
+</ComponentPreview>
+
+Wire it up by flipping `status` from your handler:
+
+```tsx
+import * as React from "react";
+import { ProgressFoldButton } from "@/components/godui/progress-fold-button";
+
+export function Example() {
+  const [status, setStatus] = React.useState<"idle" | "loading">("idle");
+
+  const handleClick = async () => {
+    setStatus("loading");
+    await doWork();
+    setStatus("idle");
+  };
+
+  return (
+    <ProgressFoldButton status={status} onClick={handleClick}>
+      Submit
+    </ProgressFoldButton>
+  );
+}
+```
 
 ## Installation
 
@@ -38,8 +90,8 @@ import { ProgressFoldButton } from "@/components/godui/progress-fold-button";
 ```
 
 ```tsx
-<ProgressFoldButton onClick={() => console.log("activated")}>
-  Hover & click
+<ProgressFoldButton status="loading" progress={40}>
+  Submit
 </ProgressFoldButton>
 ```
 
@@ -50,6 +102,9 @@ Accepts all native `<button>` attributes.
 | Prop | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |
 | `variant` | `"primary" \| "secondary"` | `"primary"` | Theme color scheme of the front face |
+| `size` | `"sm" \| "md" \| "lg"` | `"md"` | Button size |
+| `status` | `"idle" \| "loading"` | `"idle"` | Loading lifecycle; `"loading"` folds open and runs the bar |
+| `progress` | `number` | — | 0–100; makes `loading` determinate (omit for indeterminate) |
 | `children` | `ReactNode` | — | Button label |
 | `disabled` | `boolean` | `false` | Disable the button and its animations |
-| `onClick` | `(e) => void` | — | Fires on click; the progress bar runs alongside it |
+| `onClick` | `(e) => void` | — | Fires on click; flip `status` from here to start loading |

--- a/apps/docs/public/r/progress-fold-button.json
+++ b/apps/docs/public/r/progress-fold-button.json
@@ -2,47 +2,25 @@
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "progress-fold-button",
   "title": "Progress Fold Button",
-  "description": "A button whose front face folds on hover and runs a progress bar on click.",
+  "description": "A button whose front face folds back to reveal a controlled progress bar while loading.",
   "registryDependencies": [
     "@godui/godui-theme"
   ],
   "files": [
     {
       "path": "packages/components/src/progress-fold-button/progress-fold-button.tsx",
-      "content": "\"use client\";\n\nimport * as React from \"react\";\n\nexport type ProgressFoldButtonVariant = \"primary\" | \"secondary\";\nexport type ProgressFoldButtonSize = \"sm\" | \"md\" | \"lg\";\n\nexport type ProgressFoldButtonProps =\n  React.ButtonHTMLAttributes<HTMLButtonElement> & {\n    variant?: ProgressFoldButtonVariant;\n    size?: ProgressFoldButtonSize;\n  };\n\nconst sizeClasses: Record<ProgressFoldButtonSize, string> = {\n  sm: \"progress-fold-button--sm\",\n  md: \"progress-fold-button--md\",\n  lg: \"progress-fold-button--lg\",\n};\n\nconst frontClasses: Record<ProgressFoldButtonVariant, string> = {\n  primary: \"bg-primary text-primary-foreground\",\n  secondary: \"bg-secondary text-secondary-foreground\",\n};\n\n// Fold side: a faint tint at rest (back), a stronger one while the progress\n// bar runs. Alpha utilities blend with the surrounding background so the\n// effect adapts to light and dark themes.\nconst backClasses: Record<ProgressFoldButtonVariant, string> = {\n  primary: \"bg-primary/15\",\n  secondary: \"bg-secondary-foreground/15\",\n};\n\nconst barClasses: Record<ProgressFoldButtonVariant, string> = {\n  primary: \"bg-primary/40\",\n  secondary: \"bg-secondary-foreground/35\",\n};\n\nconst ProgressFoldButton = React.forwardRef<\n  HTMLButtonElement,\n  ProgressFoldButtonProps\n>(\n  (\n    {\n      className,\n      children,\n      onClick,\n      variant = \"primary\",\n      size = \"md\",\n      ...props\n    },\n    ref,\n  ) => {\n    const [active, setActive] = React.useState(false);\n\n    const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {\n      setActive(true);\n      onClick?.(event);\n    };\n\n    return (\n      <button\n        ref={ref}\n        type=\"button\"\n        data-variant={variant}\n        data-size={size}\n        data-active={active ? \"true\" : undefined}\n        onClick={handleClick}\n        className={`progress-fold-button font-medium ${sizeClasses[size]} ${className ?? \"\"}`}\n        {...props}\n      >\n        <span className=\"progress-fold-button-layers\" aria-hidden=\"true\">\n          <span\n            className={`progress-fold-button-back ${backClasses[variant]}`}\n          />\n          <span\n            className={`progress-fold-button-bar ${barClasses[variant]}`}\n            onAnimationEnd={() => setActive(false)}\n          />\n        </span>\n        <span className={`progress-fold-button-front ${frontClasses[variant]}`}>\n          {children}\n        </span>\n      </button>\n    );\n  },\n);\nProgressFoldButton.displayName = \"ProgressFoldButton\";\n\nexport { ProgressFoldButton };\n",
+      "content": "\"use client\";\n\nimport * as React from \"react\";\n\nexport type ProgressFoldButtonVariant = \"primary\" | \"secondary\";\nexport type ProgressFoldButtonSize = \"sm\" | \"md\" | \"lg\";\nexport type ProgressFoldButtonStatus = \"idle\" | \"loading\";\n\nexport type ProgressFoldButtonProps =\n  React.ButtonHTMLAttributes<HTMLButtonElement> & {\n    variant?: ProgressFoldButtonVariant;\n    size?: ProgressFoldButtonSize;\n    /**\n     * Loading lifecycle. `loading` folds the front face open and runs the\n     * progress bar behind it. Fully controlled.\n     */\n    status?: ProgressFoldButtonStatus;\n    /**\n     * 0–100. With `status=\"loading\"` a value makes the bar determinate (fills\n     * to that percentage); omitting it makes the bar indeterminate (a segment\n     * sweeps across).\n     */\n    progress?: number;\n  };\n\nconst sizeClasses: Record<ProgressFoldButtonSize, string> = {\n  sm: \"progress-fold-button--sm\",\n  md: \"progress-fold-button--md\",\n  lg: \"progress-fold-button--lg\",\n};\n\nconst frontClasses: Record<ProgressFoldButtonVariant, string> = {\n  primary: \"bg-primary text-primary-foreground\",\n  secondary: \"bg-secondary text-secondary-foreground\",\n};\n\n// Fold side: a faint tint at rest (back), a stronger one while the progress\n// bar runs. Alpha utilities blend with the surrounding background so the\n// effect adapts to light and dark themes.\nconst backClasses: Record<ProgressFoldButtonVariant, string> = {\n  primary: \"bg-primary/15\",\n  secondary: \"bg-secondary-foreground/15\",\n};\n\nconst barClasses: Record<ProgressFoldButtonVariant, string> = {\n  primary: \"bg-primary/40\",\n  secondary: \"bg-secondary-foreground/35\",\n};\n\nconst clampPercent = (value: number) => Math.max(0, Math.min(100, value));\n\nconst ProgressFoldButton = React.forwardRef<\n  HTMLButtonElement,\n  ProgressFoldButtonProps\n>(\n  (\n    {\n      className,\n      style,\n      children,\n      variant = \"primary\",\n      size = \"md\",\n      status = \"idle\",\n      progress,\n      ...props\n    },\n    ref,\n  ) => {\n    const isLoading = status === \"loading\";\n    const isDeterminate = isLoading && progress != null;\n    const clamped = progress != null ? clampPercent(progress) : undefined;\n\n    // Snap the fill to 0 on entering loading, then arm the smooth transition a\n    // frame later so progress animates without the entry flashing from full.\n    const [armed, setArmed] = React.useState(false);\n    React.useEffect(() => {\n      if (!isLoading) {\n        setArmed(false);\n        return;\n      }\n      setArmed(false);\n      const id = requestAnimationFrame(() => setArmed(true));\n      return () => cancelAnimationFrame(id);\n    }, [isLoading]);\n\n    return (\n      <button\n        ref={ref}\n        type=\"button\"\n        data-variant={variant}\n        data-size={size}\n        data-status={isLoading ? \"loading\" : undefined}\n        data-determinate={isDeterminate ? \"true\" : undefined}\n        data-armed={armed ? \"true\" : undefined}\n        aria-busy={isLoading || undefined}\n        className={`progress-fold-button font-medium ${sizeClasses[size]} ${className ?? \"\"}`}\n        style={\n          clamped != null\n            ? ({\n                ...style,\n                \"--progress-fold-fill\": `${clamped}%`,\n              } as React.CSSProperties)\n            : style\n        }\n        {...props}\n      >\n        <span className=\"progress-fold-button-layers\" aria-hidden=\"true\">\n          <span\n            className={`progress-fold-button-back ${backClasses[variant]}`}\n          />\n          <span className={`progress-fold-button-bar ${barClasses[variant]}`} />\n        </span>\n        <span className={`progress-fold-button-front ${frontClasses[variant]}`}>\n          {children}\n        </span>\n        {isLoading ? (\n          <span\n            className=\"progress-fold-button-sr\"\n            role=\"progressbar\"\n            aria-valuemin={0}\n            aria-valuemax={100}\n            aria-valuenow={isDeterminate ? clamped : undefined}\n            aria-valuetext={isDeterminate ? `${clamped}%` : \"Loading\"}\n          />\n        ) : null}\n      </button>\n    );\n  },\n);\nProgressFoldButton.displayName = \"ProgressFoldButton\";\n\nexport { ProgressFoldButton };\n",
       "type": "registry:ui",
       "target": "components/godui/progress-fold-button.tsx"
     }
   ],
   "css": {
-    "@keyframes progress-fold-bar": {
+    "@keyframes progress-fold-indeterminate": {
       "0%": {
-        "opacity": "1",
-        "width": "0"
+        "transform": "translateX(-100%)"
       },
-      "10%": {
-        "opacity": "1",
-        "width": "15%"
-      },
-      "25%": {
-        "opacity": "1",
-        "width": "25%"
-      },
-      "40%": {
-        "opacity": "1",
-        "width": "35%"
-      },
-      "55%": {
-        "opacity": "1",
-        "width": "75%"
-      },
-      "60%": {
-        "opacity": "1",
-        "width": "100%"
-      },
-      "to": {
-        "opacity": "0",
-        "width": "100%"
+      "100%": {
+        "transform": "translateX(250%)"
       }
     },
     "@layer components": {
@@ -106,6 +84,9 @@
       ".progress-fold-button:hover:not(:disabled) .progress-fold-button-front": {
         "transform": "rotateX(35deg)"
       },
+      ".progress-fold-button[data-status=\"loading\"] .progress-fold-button-front": {
+        "transform": "rotateX(35deg)"
+      },
       ".progress-fold-button-layers": {
         "position": "absolute",
         "inset": "0",
@@ -124,12 +105,32 @@
         "height": "100%",
         "width": "0"
       },
-      ".progress-fold-button[data-active=\"true\"] .progress-fold-button-bar": {
-        "animation": "progress-fold-bar 1.2s"
+      ".progress-fold-button[data-determinate=\"true\"] .progress-fold-button-bar": {
+        "width": "var(--progress-fold-fill, 0%)"
+      },
+      ".progress-fold-button[data-determinate=\"true\"][data-armed=\"true\"] .progress-fold-button-bar": {
+        "transition": "width 0.25s ease"
+      },
+      ".progress-fold-button[data-status=\"loading\"]:not([data-determinate=\"true\"]) .progress-fold-button-bar": {
+        "width": "40%",
+        "animation": "progress-fold-indeterminate 1.2s ease-in-out infinite"
+      },
+      ".progress-fold-button-sr": {
+        "position": "absolute",
+        "width": "1px",
+        "height": "1px",
+        "margin": "-1px",
+        "padding": "0",
+        "overflow": "hidden",
+        "clip": "rect(0, 0, 0, 0)",
+        "white-space": "nowrap",
+        "border": "0"
       },
       "@media (prefers-reduced-motion: reduce)": {
-        ".progress-fold-button-front, .progress-fold-button[data-active=\"true\"] .progress-fold-button-bar": {
-          "transition": "none",
+        ".progress-fold-button-front, .progress-fold-button[data-determinate=\"true\"][data-armed=\"true\"] .progress-fold-button-bar": {
+          "transition": "none"
+        },
+        ".progress-fold-button[data-status=\"loading\"]:not([data-determinate=\"true\"]) .progress-fold-button-bar": {
           "animation": "none"
         }
       }

--- a/apps/docs/public/r/registry.json
+++ b/apps/docs/public/r/registry.json
@@ -689,7 +689,7 @@
       "name": "progress-fold-button",
       "type": "registry:ui",
       "title": "Progress Fold Button",
-      "description": "A button whose front face folds on hover and runs a progress bar on click.",
+      "description": "A button whose front face folds back to reveal a controlled progress bar while loading.",
       "registryDependencies": ["@godui/godui-theme"],
       "files": [
         {
@@ -699,14 +699,9 @@
         }
       ],
       "css": {
-        "@keyframes progress-fold-bar": {
-          "0%": { "opacity": "1", "width": "0" },
-          "10%": { "opacity": "1", "width": "15%" },
-          "25%": { "opacity": "1", "width": "25%" },
-          "40%": { "opacity": "1", "width": "35%" },
-          "55%": { "opacity": "1", "width": "75%" },
-          "60%": { "opacity": "1", "width": "100%" },
-          "to": { "opacity": "0", "width": "100%" }
+        "@keyframes progress-fold-indeterminate": {
+          "0%": { "transform": "translateX(-100%)" },
+          "100%": { "transform": "translateX(250%)" }
         },
         "@layer components": {
           ".progress-fold-button": {
@@ -769,6 +764,9 @@
           ".progress-fold-button:hover:not(:disabled) .progress-fold-button-front": {
             "transform": "rotateX(35deg)"
           },
+          ".progress-fold-button[data-status=\"loading\"] .progress-fold-button-front": {
+            "transform": "rotateX(35deg)"
+          },
           ".progress-fold-button-layers": {
             "position": "absolute",
             "inset": "0",
@@ -787,12 +785,32 @@
             "height": "100%",
             "width": "0"
           },
-          ".progress-fold-button[data-active=\"true\"] .progress-fold-button-bar": {
-            "animation": "progress-fold-bar 1.2s"
+          ".progress-fold-button[data-determinate=\"true\"] .progress-fold-button-bar": {
+            "width": "var(--progress-fold-fill, 0%)"
+          },
+          ".progress-fold-button[data-determinate=\"true\"][data-armed=\"true\"] .progress-fold-button-bar": {
+            "transition": "width 0.25s ease"
+          },
+          ".progress-fold-button[data-status=\"loading\"]:not([data-determinate=\"true\"]) .progress-fold-button-bar": {
+            "width": "40%",
+            "animation": "progress-fold-indeterminate 1.2s ease-in-out infinite"
+          },
+          ".progress-fold-button-sr": {
+            "position": "absolute",
+            "width": "1px",
+            "height": "1px",
+            "margin": "-1px",
+            "padding": "0",
+            "overflow": "hidden",
+            "clip": "rect(0, 0, 0, 0)",
+            "white-space": "nowrap",
+            "border": "0"
           },
           "@media (prefers-reduced-motion: reduce)": {
-            ".progress-fold-button-front, .progress-fold-button[data-active=\"true\"] .progress-fold-button-bar": {
-              "transition": "none",
+            ".progress-fold-button-front, .progress-fold-button[data-determinate=\"true\"][data-armed=\"true\"] .progress-fold-button-bar": {
+              "transition": "none"
+            },
+            ".progress-fold-button[data-status=\"loading\"]:not([data-determinate=\"true\"]) .progress-fold-button-bar": {
               "animation": "none"
             }
           }

--- a/apps/storybook/src/stories/progress-fold-button.stories.tsx
+++ b/apps/storybook/src/stories/progress-fold-button.stories.tsx
@@ -3,6 +3,7 @@ import {
   type ProgressFoldButtonProps,
 } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import * as React from "react";
 
 const meta = {
   title: "Buttons/Progress Fold Button",
@@ -18,21 +19,21 @@ type Story = StoryObj<typeof meta>;
 
 export const Primary: Story = {
   args: {
-    children: "Hover & click",
+    children: "Submit",
     variant: "primary",
   } satisfies ProgressFoldButtonProps,
 };
 
 export const Secondary: Story = {
   args: {
-    children: "Hover & click",
+    children: "Submit",
     variant: "secondary",
   } satisfies ProgressFoldButtonProps,
 };
 
 export const Disabled: Story = {
   args: {
-    children: "Hover & click",
+    children: "Submit",
     variant: "primary",
     disabled: true,
   } satisfies ProgressFoldButtonProps,
@@ -46,4 +47,50 @@ export const Sizes: Story = {
       <ProgressFoldButton size="lg">Large</ProgressFoldButton>
     </div>
   ),
+};
+
+// Indeterminate: click to fold open and loop the bar until clicked again.
+export const Indeterminate: Story = {
+  render: () => {
+    const [loading, setLoading] = React.useState(false);
+    return (
+      <ProgressFoldButton
+        status={loading ? "loading" : "idle"}
+        onClick={() => setLoading((v) => !v)}
+        style={{ minWidth: 160 }}
+      >
+        {loading ? "Working…" : "Start"}
+      </ProgressFoldButton>
+    );
+  },
+};
+
+// Determinate: click to run a progress ramp from 0 to 100, then reset.
+export const Determinate: Story = {
+  render: () => {
+    const [progress, setProgress] = React.useState<number | null>(null);
+
+    React.useEffect(() => {
+      if (progress == null) return;
+      if (progress >= 100) {
+        const id = setTimeout(() => setProgress(null), 600);
+        return () => clearTimeout(id);
+      }
+      const id = setTimeout(() => setProgress((p) => (p ?? 0) + 10), 250);
+      return () => clearTimeout(id);
+    }, [progress]);
+
+    return (
+      <ProgressFoldButton
+        status={progress == null ? "idle" : "loading"}
+        progress={progress ?? undefined}
+        onClick={() => {
+          if (progress == null) setProgress(0);
+        }}
+        style={{ minWidth: 160 }}
+      >
+        {progress == null ? "Upload" : `${progress}%`}
+      </ProgressFoldButton>
+    );
+  },
 };

--- a/docs/superpowers/specs/2026-06-18-progress-fold-button-loading-design.md
+++ b/docs/superpowers/specs/2026-06-18-progress-fold-button-loading-design.md
@@ -1,0 +1,103 @@
+# ProgressFoldButton — Loading Progress State Design
+
+Date: 2026-06-18
+
+## Summary
+
+Give `ProgressFoldButton` a controlled loading progress state modeled on
+`MagicInput`. While `status="loading"` the front face folds back (rotateX tilt)
+and holds, revealing a progress bar behind it. The bar is **determinate** when a
+`progress` value is supplied (fills to that percentage with a smooth transition)
+or **indeterminate** when omitted (a segment loops across). This replaces the
+old uncontrolled click-driven fake animation.
+
+## API
+
+File: `packages/components/src/progress-fold-button/progress-fold-button.tsx`
+
+```tsx
+type ProgressFoldButtonProps =
+  React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    variant?: "primary" | "secondary";   // default "primary"
+    size?: "sm" | "md" | "lg";            // default "md"
+    status?: "idle" | "loading";          // default "idle"
+    progress?: number;                     // 0–100; loading + value = determinate
+  };
+```
+
+- `status="loading"` + `progress` present → **determinate**.
+- `status="loading"` + `progress` omitted → **indeterminate**.
+- `status="idle"` → resting; hover/focus tilt preserved.
+- `progress` is clamped to 0–100.
+- The old internal `active` state and click auto-animation are removed. The
+  component is now fully controlled by `status`/`progress`; `onClick` still
+  fires so the consumer can flip `status` to `loading`.
+
+## Behavior
+
+Driven by data-attributes on the root `<button>`, mirroring `MagicInput`:
+
+- `data-status="loading"` (undefined when idle)
+- `data-determinate="true"` when loading and `progress != null`
+- `data-armed="true"` set one rAF after entering loading (snap-to-0 → arm
+  transition so the determinate fill doesn't flash from full on entry; same
+  pattern as MagicInput's `armed`)
+
+Fold (front rotateX tilt):
+
+- `idle`: flat at rest; tilts on `:hover` / `:focus-visible` (existing rule).
+- `loading`: front holds the tilt (`rotateX(35deg)`) regardless of hover/focus.
+
+Progress bar (`.progress-fold-button-bar`):
+
+- Determinate: `width: var(--progress-fold-fill)` where the root sets
+  `--progress-fold-fill: {clamped}%`. Width transitions smoothly once armed.
+- Indeterminate: a partial-width segment runs a looping keyframe sweeping
+  left→right.
+- The `progress-fold-bar` click keyframe and `onAnimationEnd` reset are removed.
+
+## Accessibility
+
+- `aria-busy="true"` on the button while loading.
+- A visually-hidden `role="progressbar"` element (like MagicInput's
+  `magic-input-sr`) reports state while loading:
+  - determinate: `aria-valuemin=0 aria-valuemax=100 aria-valuenow={clamped}`
+  - indeterminate: `aria-valuetext="Loading"`, no `aria-valuenow`.
+
+## CSS
+
+File: `packages/components/styles.css`
+
+- Keep `.progress-fold-button-bar` base (absolute, full-height, `width: 0`).
+- New: front holds tilt under `.progress-fold-button[data-status="loading"]
+  .progress-fold-button-front { transform: rotateX(35deg); }`.
+- New: determinate width via `--progress-fold-fill` + transition gated by
+  `data-armed`.
+- New indeterminate keyframe (segment sweep) applied when
+  `data-status="loading"` and not `data-determinate`.
+- Remove the `data-active` bar rule and the `progress-fold-bar` keyframe.
+- Extend the existing `prefers-reduced-motion` guard to the new loading
+  animations.
+
+## Tests
+
+File: `packages/components/src/progress-fold-button/progress-fold-button.test.tsx`
+
+- Replace the `data-active`/animationEnd click test (behavior removed).
+- `status="loading"` sets `data-status="loading"` and `aria-busy`.
+- determinate: `progress={40}` sets `data-determinate="true"`, exposes
+  `progressbar` with `aria-valuenow=40`, and `--progress-fold-fill: 40%`.
+- indeterminate: `status="loading"` without `progress` → no `data-determinate`,
+  `progressbar` with `aria-valuetext="Loading"`.
+- `progress` clamps out-of-range values.
+- idle (default) renders no `data-status` / `progressbar`.
+
+## Docs / Story
+
+- Update the Storybook story + docs page with `idle`, indeterminate loading, and
+  determinate loading examples (a stateful demo that flips `status` on click and
+  optionally ramps `progress`).
+
+## Out of Scope
+
+- `success` / `error` states (explicitly dropped for this component).

--- a/packages/components/src/progress-fold-button/progress-fold-button.test.tsx
+++ b/packages/components/src/progress-fold-button/progress-fold-button.test.tsx
@@ -1,7 +1,6 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { render, screen } from "@testing-library/react";
 import { createRef } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { ProgressFoldButton } from "./progress-fold-button";
 
 describe("ProgressFoldButton", () => {
@@ -50,19 +49,59 @@ describe("ProgressFoldButton", () => {
     );
   });
 
-  it("sets data-active on click and clears it on the bar animation end", async () => {
-    const onClick = vi.fn();
-    const { container } = render(
-      <ProgressFoldButton onClick={onClick}>A</ProgressFoldButton>,
+  it("is idle by default: no status / progressbar", () => {
+    render(<ProgressFoldButton>A</ProgressFoldButton>);
+    const button = screen.getByRole("button");
+    expect(button).not.toHaveAttribute("data-status");
+    expect(button).not.toHaveAttribute("aria-busy");
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+  });
+
+  it("marks loading state with data-status and aria-busy", () => {
+    render(<ProgressFoldButton status="loading">A</ProgressFoldButton>);
+    const button = screen.getByRole("button");
+    expect(button).toHaveAttribute("data-status", "loading");
+    expect(button).toHaveAttribute("aria-busy", "true");
+  });
+
+  it("loading without progress is indeterminate", () => {
+    render(<ProgressFoldButton status="loading">A</ProgressFoldButton>);
+    const button = screen.getByRole("button");
+    expect(button).not.toHaveAttribute("data-determinate");
+    const bar = screen.getByRole("progressbar");
+    expect(bar).toHaveAttribute("aria-valuetext", "Loading");
+    expect(bar).not.toHaveAttribute("aria-valuenow");
+  });
+
+  it("loading with progress is determinate and exposes the value", () => {
+    render(
+      <ProgressFoldButton status="loading" progress={40}>
+        A
+      </ProgressFoldButton>,
     );
     const button = screen.getByRole("button");
-    await userEvent.click(button);
-    expect(onClick).toHaveBeenCalledOnce();
-    expect(button).toHaveAttribute("data-active", "true");
+    expect(button).toHaveAttribute("data-determinate", "true");
+    expect(button.style.getPropertyValue("--progress-fold-fill")).toBe("40%");
+    const bar = screen.getByRole("progressbar");
+    expect(bar).toHaveAttribute("aria-valuenow", "40");
+    expect(bar).toHaveAttribute("aria-valuetext", "40%");
+  });
 
-    const bar = container.querySelector(".progress-fold-button-bar");
-    if (!bar) throw new Error("progress bar not found");
-    fireEvent.animationEnd(bar);
-    expect(button).not.toHaveAttribute("data-active");
+  it("clamps out-of-range progress values", () => {
+    const { rerender } = render(
+      <ProgressFoldButton status="loading" progress={150}>
+        A
+      </ProgressFoldButton>,
+    );
+    let button = screen.getByRole("button");
+    expect(button.style.getPropertyValue("--progress-fold-fill")).toBe("100%");
+
+    rerender(
+      <ProgressFoldButton status="loading" progress={-20}>
+        A
+      </ProgressFoldButton>,
+    );
+    button = screen.getByRole("button");
+    expect(button.style.getPropertyValue("--progress-fold-fill")).toBe("0%");
   });
 });

--- a/packages/components/src/progress-fold-button/progress-fold-button.tsx
+++ b/packages/components/src/progress-fold-button/progress-fold-button.tsx
@@ -4,11 +4,23 @@ import * as React from "react";
 
 export type ProgressFoldButtonVariant = "primary" | "secondary";
 export type ProgressFoldButtonSize = "sm" | "md" | "lg";
+export type ProgressFoldButtonStatus = "idle" | "loading";
 
 export type ProgressFoldButtonProps =
   React.ButtonHTMLAttributes<HTMLButtonElement> & {
     variant?: ProgressFoldButtonVariant;
     size?: ProgressFoldButtonSize;
+    /**
+     * Loading lifecycle. `loading` folds the front face open and runs the
+     * progress bar behind it. Fully controlled.
+     */
+    status?: ProgressFoldButtonStatus;
+    /**
+     * 0–100. With `status="loading"` a value makes the bar determinate (fills
+     * to that percentage); omitting it makes the bar indeterminate (a segment
+     * sweeps across).
+     */
+    progress?: number;
   };
 
 const sizeClasses: Record<ProgressFoldButtonSize, string> = {
@@ -35,6 +47,8 @@ const barClasses: Record<ProgressFoldButtonVariant, string> = {
   secondary: "bg-secondary-foreground/35",
 };
 
+const clampPercent = (value: number) => Math.max(0, Math.min(100, value));
+
 const ProgressFoldButton = React.forwardRef<
   HTMLButtonElement,
   ProgressFoldButtonProps
@@ -42,20 +56,32 @@ const ProgressFoldButton = React.forwardRef<
   (
     {
       className,
+      style,
       children,
-      onClick,
       variant = "primary",
       size = "md",
+      status = "idle",
+      progress,
       ...props
     },
     ref,
   ) => {
-    const [active, setActive] = React.useState(false);
+    const isLoading = status === "loading";
+    const isDeterminate = isLoading && progress != null;
+    const clamped = progress != null ? clampPercent(progress) : undefined;
 
-    const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-      setActive(true);
-      onClick?.(event);
-    };
+    // Snap the fill to 0 on entering loading, then arm the smooth transition a
+    // frame later so progress animates without the entry flashing from full.
+    const [armed, setArmed] = React.useState(false);
+    React.useEffect(() => {
+      if (!isLoading) {
+        setArmed(false);
+        return;
+      }
+      setArmed(false);
+      const id = requestAnimationFrame(() => setArmed(true));
+      return () => cancelAnimationFrame(id);
+    }, [isLoading]);
 
     return (
       <button
@@ -63,23 +89,40 @@ const ProgressFoldButton = React.forwardRef<
         type="button"
         data-variant={variant}
         data-size={size}
-        data-active={active ? "true" : undefined}
-        onClick={handleClick}
+        data-status={isLoading ? "loading" : undefined}
+        data-determinate={isDeterminate ? "true" : undefined}
+        data-armed={armed ? "true" : undefined}
+        aria-busy={isLoading || undefined}
         className={`progress-fold-button font-medium ${sizeClasses[size]} ${className ?? ""}`}
+        style={
+          clamped != null
+            ? ({
+                ...style,
+                "--progress-fold-fill": `${clamped}%`,
+              } as React.CSSProperties)
+            : style
+        }
         {...props}
       >
         <span className="progress-fold-button-layers" aria-hidden="true">
           <span
             className={`progress-fold-button-back ${backClasses[variant]}`}
           />
-          <span
-            className={`progress-fold-button-bar ${barClasses[variant]}`}
-            onAnimationEnd={() => setActive(false)}
-          />
+          <span className={`progress-fold-button-bar ${barClasses[variant]}`} />
         </span>
         <span className={`progress-fold-button-front ${frontClasses[variant]}`}>
           {children}
         </span>
+        {isLoading ? (
+          <span
+            className="progress-fold-button-sr"
+            role="progressbar"
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={isDeterminate ? clamped : undefined}
+            aria-valuetext={isDeterminate ? `${clamped}%` : "Loading"}
+          />
+        ) : null}
       </button>
     );
   },

--- a/packages/components/styles.css
+++ b/packages/components/styles.css
@@ -924,6 +924,11 @@
     transform: rotateX(35deg);
   }
 
+  /* While loading the front holds the fold open, revealing the progress bar. */
+  .progress-fold-button[data-status="loading"] .progress-fold-button-front {
+    transform: rotateX(35deg);
+  }
+
   /* Front face colors and the fold-side tints come from Tailwind utility
      classes on the elements (bg-primary / text-primary-foreground and alpha
      tints like bg-primary/15). Those resolve theme tokens reliably and adapt
@@ -944,7 +949,7 @@
     inset: 0;
   }
 
-  /* Progress bar — animates on click via data-active (color via Tailwind) */
+  /* Progress bar — controlled by status / progress (color via Tailwind) */
   .progress-fold-button-bar {
     position: absolute;
     top: 0;
@@ -953,14 +958,46 @@
     width: 0;
   }
 
-  .progress-fold-button[data-active="true"] .progress-fold-button-bar {
-    animation: progress-fold-bar 1.2s;
+  /* Determinate: fill to the supplied percentage. The transition is armed one
+     frame after entering loading so the fill grows from 0 instead of flashing. */
+  .progress-fold-button[data-determinate="true"] .progress-fold-button-bar {
+    width: var(--progress-fold-fill, 0%);
+  }
+
+  .progress-fold-button[data-determinate="true"][data-armed="true"]
+    .progress-fold-button-bar {
+    transition: width 0.25s ease;
+  }
+
+  /* Indeterminate: a fixed segment sweeps left→right on a loop. */
+  .progress-fold-button[data-status="loading"]:not([data-determinate="true"])
+    .progress-fold-button-bar {
+    width: 40%;
+    animation: progress-fold-indeterminate 1.2s ease-in-out infinite;
+  }
+
+  /* Visually-hidden live region reporting progress to assistive tech */
+  .progress-fold-button-sr {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 
   @media (prefers-reduced-motion: reduce) {
     .progress-fold-button-front,
-    .progress-fold-button[data-active="true"] .progress-fold-button-bar {
+    .progress-fold-button[data-determinate="true"][data-armed="true"]
+      .progress-fold-button-bar {
       transition: none;
+    }
+
+    .progress-fold-button[data-status="loading"]:not([data-determinate="true"])
+      .progress-fold-button-bar {
       animation: none;
     }
   }
@@ -1105,33 +1142,12 @@
   }
 }
 
-@keyframes progress-fold-bar {
+/* Progress fold button: indeterminate segment sweeping left→right */
+@keyframes progress-fold-indeterminate {
   0% {
-    opacity: 1;
-    width: 0;
+    transform: translateX(-100%);
   }
-  10% {
-    opacity: 1;
-    width: 15%;
-  }
-  25% {
-    opacity: 1;
-    width: 25%;
-  }
-  40% {
-    opacity: 1;
-    width: 35%;
-  }
-  55% {
-    opacity: 1;
-    width: 75%;
-  }
-  60% {
-    opacity: 1;
-    width: 100%;
-  }
-  to {
-    opacity: 0;
-    width: 100%;
+  100% {
+    transform: translateX(250%);
   }
 }

--- a/registry.json
+++ b/registry.json
@@ -689,7 +689,7 @@
       "name": "progress-fold-button",
       "type": "registry:ui",
       "title": "Progress Fold Button",
-      "description": "A button whose front face folds on hover and runs a progress bar on click.",
+      "description": "A button whose front face folds back to reveal a controlled progress bar while loading.",
       "registryDependencies": ["@godui/godui-theme"],
       "files": [
         {
@@ -699,14 +699,9 @@
         }
       ],
       "css": {
-        "@keyframes progress-fold-bar": {
-          "0%": { "opacity": "1", "width": "0" },
-          "10%": { "opacity": "1", "width": "15%" },
-          "25%": { "opacity": "1", "width": "25%" },
-          "40%": { "opacity": "1", "width": "35%" },
-          "55%": { "opacity": "1", "width": "75%" },
-          "60%": { "opacity": "1", "width": "100%" },
-          "to": { "opacity": "0", "width": "100%" }
+        "@keyframes progress-fold-indeterminate": {
+          "0%": { "transform": "translateX(-100%)" },
+          "100%": { "transform": "translateX(250%)" }
         },
         "@layer components": {
           ".progress-fold-button": {
@@ -769,6 +764,9 @@
           ".progress-fold-button:hover:not(:disabled) .progress-fold-button-front": {
             "transform": "rotateX(35deg)"
           },
+          ".progress-fold-button[data-status=\"loading\"] .progress-fold-button-front": {
+            "transform": "rotateX(35deg)"
+          },
           ".progress-fold-button-layers": {
             "position": "absolute",
             "inset": "0",
@@ -787,12 +785,32 @@
             "height": "100%",
             "width": "0"
           },
-          ".progress-fold-button[data-active=\"true\"] .progress-fold-button-bar": {
-            "animation": "progress-fold-bar 1.2s"
+          ".progress-fold-button[data-determinate=\"true\"] .progress-fold-button-bar": {
+            "width": "var(--progress-fold-fill, 0%)"
+          },
+          ".progress-fold-button[data-determinate=\"true\"][data-armed=\"true\"] .progress-fold-button-bar": {
+            "transition": "width 0.25s ease"
+          },
+          ".progress-fold-button[data-status=\"loading\"]:not([data-determinate=\"true\"]) .progress-fold-button-bar": {
+            "width": "40%",
+            "animation": "progress-fold-indeterminate 1.2s ease-in-out infinite"
+          },
+          ".progress-fold-button-sr": {
+            "position": "absolute",
+            "width": "1px",
+            "height": "1px",
+            "margin": "-1px",
+            "padding": "0",
+            "overflow": "hidden",
+            "clip": "rect(0, 0, 0, 0)",
+            "white-space": "nowrap",
+            "border": "0"
           },
           "@media (prefers-reduced-motion: reduce)": {
-            ".progress-fold-button-front, .progress-fold-button[data-active=\"true\"] .progress-fold-button-bar": {
-              "transition": "none",
+            ".progress-fold-button-front, .progress-fold-button[data-determinate=\"true\"][data-armed=\"true\"] .progress-fold-button-bar": {
+              "transition": "none"
+            },
+            ".progress-fold-button[data-status=\"loading\"]:not([data-determinate=\"true\"]) .progress-fold-button-bar": {
               "animation": "none"
             }
           }


### PR DESCRIPTION
Gives `ProgressFoldButton` a controlled loading progress state modeled on `MagicInput`: setting `status="loading"` holds the front face folded open and runs a progress bar behind it, determinate when a `progress` value (0–100, clamped) is passed and an indeterminate sweeping segment otherwise. Replaces the old click-driven fake animation, adds `aria-busy` plus a visually-hidden `role="progressbar"` for assistive tech, and extends the reduced-motion guard. Updates the CSS, shadcn registry (source + generated `public/r`), Storybook stories (interactive indeterminate + determinate demos with a fixed min-width), docs page, and unit tests. Includes the design spec under `docs/superpowers/specs/`.