### PR TITLE
feat(docs): add landing page with hero and MagicButton CTA

### DIFF
--- a/apps/docs/src/app/page.tsx
+++ b/apps/docs/src/app/page.tsx
@@ -1,5 +1,26 @@
-import { redirect } from "next/navigation";
+"use client";
+
+import { MagicButton } from "@godui/components";
+import { useRouter } from "next/navigation";
+import { DocsHeader } from "./docs/_components/docs-header";
 
 export default function Home() {
-  redirect("/docs/installation");
+  const router = useRouter();
+
+  return (
+    <main className="flex min-h-svh flex-col">
+      <DocsHeader />
+      <section className="flex flex-1 flex-col items-center justify-center gap-8 px-4 text-center">
+        <h1 className="max-w-3xl text-balance font-semibold text-4xl text-fd-foreground tracking-tight sm:text-5xl md:text-6xl">
+          UI library for Design Engineers
+        </h1>
+        <MagicButton
+          size="lg"
+          onClick={() => router.push("/docs/installation")}
+        >
+          Browse Components
+        </MagicButton>
+      </section>
+    </main>
+  );
 }


### PR DESCRIPTION
Replaces the home page redirect with a real docs landing page. Reuses the existing `DocsHeader`, adds a centered "UI library for Design Engineers" hero, and a `MagicButton` CTA that navigates to `/docs/installation`.