### PR TITLE
docs: Storybook-style Examples sections + animation fixes

### DIFF
--- a/apps/docs/content/docs/components/buttons/magic-button.mdx
+++ b/apps/docs/content/docs/components/buttons/magic-button.mdx
@@ -37,6 +37,64 @@ import { MagicButton } from "@/components/godui/magic-button";
 <MagicButton variant="default">Push me</MagicButton>
 ```
 
+## Examples
+
+### Sizes
+
+<ComponentPreview
+  code={`import { MagicButton } from "@/components/godui/magic-button";
+
+export function MagicButtonSizes() {
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-6">
+      <MagicButton size="sm">Small</MagicButton>
+      <MagicButton size="md">Medium</MagicButton>
+      <MagicButton size="lg">Large</MagicButton>
+    </div>
+  );
+}`}
+>
+  <div className="flex flex-wrap items-center justify-center gap-6">
+    <MagicButton size="sm">Small</MagicButton>
+    <MagicButton size="md">Medium</MagicButton>
+    <MagicButton size="lg">Large</MagicButton>
+  </div>
+</ComponentPreview>
+
+### Without rainbow
+
+Set `rainbow={false}` for a static 3D edge that uses the variant color instead of the animated gradient.
+
+<ComponentPreview
+  code={`import { MagicButton } from "@/components/godui/magic-button";
+
+export function MagicButtonPlain() {
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-6">
+      <MagicButton rainbow={false}>Push me</MagicButton>
+      <MagicButton variant="secondary" rainbow={false}>Push me</MagicButton>
+    </div>
+  );
+}`}
+>
+  <div className="flex flex-wrap items-center justify-center gap-6">
+    <MagicButton rainbow={false}>Push me</MagicButton>
+    <MagicButton variant="secondary" rainbow={false}>Push me</MagicButton>
+  </div>
+</ComponentPreview>
+
+### Disabled
+
+<ComponentPreview
+  code={`import { MagicButton } from "@/components/godui/magic-button";
+
+export function MagicButtonDisabled() {
+  return <MagicButton disabled>Push me</MagicButton>;
+}`}
+>
+  <MagicButton disabled>Push me</MagicButton>
+</ComponentPreview>
+
 ## Props
 
 | Prop | Type | Default | Description |

--- a/apps/docs/content/docs/components/buttons/mask-button.mdx
+++ b/apps/docs/content/docs/components/buttons/mask-button.mdx
@@ -45,6 +45,54 @@ import { MaskButton } from "@godui/components";
 <MaskButton mask="nature">Hover me</MaskButton>
 ```
 
+## Examples
+
+### Secondary
+
+<ComponentPreview
+  code={`import { MaskButton } from "@godui/components";
+
+export function MaskButtonSecondary() {
+  return <MaskButton mask="nature" variant="secondary">Hover me</MaskButton>;
+}`}
+>
+  <MaskButton mask="nature" variant="secondary">Hover me</MaskButton>
+</ComponentPreview>
+
+### Sizes
+
+<ComponentPreview
+  code={`import { MaskButton } from "@godui/components";
+
+export function MaskButtonSizes() {
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-6">
+      <MaskButton size="sm">Small</MaskButton>
+      <MaskButton size="md">Medium</MaskButton>
+      <MaskButton size="lg">Large</MaskButton>
+    </div>
+  );
+}`}
+>
+  <div className="flex flex-wrap items-center justify-center gap-6">
+    <MaskButton size="sm">Small</MaskButton>
+    <MaskButton size="md">Medium</MaskButton>
+    <MaskButton size="lg">Large</MaskButton>
+  </div>
+</ComponentPreview>
+
+### Disabled
+
+<ComponentPreview
+  code={`import { MaskButton } from "@godui/components";
+
+export function MaskButtonDisabled() {
+  return <MaskButton disabled>Hover me</MaskButton>;
+}`}
+>
+  <MaskButton disabled>Hover me</MaskButton>
+</ComponentPreview>
+
 ## Props
 
 Accepts all native `<button>` attributes.

--- a/apps/docs/content/docs/components/buttons/progress-fold-button.mdx
+++ b/apps/docs/content/docs/components/buttons/progress-fold-button.mdx
@@ -95,6 +95,42 @@ import { ProgressFoldButton } from "@/components/godui/progress-fold-button";
 </ProgressFoldButton>
 ```
 
+## Examples
+
+### Sizes
+
+<ComponentPreview
+  code={`import { ProgressFoldButton } from "@/components/godui/progress-fold-button";
+
+export function ProgressFoldButtonSizes() {
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-6">
+      <ProgressFoldButton size="sm">Small</ProgressFoldButton>
+      <ProgressFoldButton size="md">Medium</ProgressFoldButton>
+      <ProgressFoldButton size="lg">Large</ProgressFoldButton>
+    </div>
+  );
+}`}
+>
+  <div className="flex flex-wrap items-center justify-center gap-6">
+    <ProgressFoldButton size="sm">Small</ProgressFoldButton>
+    <ProgressFoldButton size="md">Medium</ProgressFoldButton>
+    <ProgressFoldButton size="lg">Large</ProgressFoldButton>
+  </div>
+</ComponentPreview>
+
+### Disabled
+
+<ComponentPreview
+  code={`import { ProgressFoldButton } from "@/components/godui/progress-fold-button";
+
+export function ProgressFoldButtonDisabled() {
+  return <ProgressFoldButton disabled>Submit</ProgressFoldButton>;
+}`}
+>
+  <ProgressFoldButton disabled>Submit</ProgressFoldButton>
+</ComponentPreview>
+
 ## Props
 
 Accepts all native `<button>` attributes.

--- a/apps/docs/content/docs/components/buttons/shimmer-button.mdx
+++ b/apps/docs/content/docs/components/buttons/shimmer-button.mdx
@@ -39,6 +39,56 @@ import { ShimmerButton } from "@/components/godui/shimmer-button";
 <ShimmerButton variant="primary">Click me</ShimmerButton>
 ```
 
+## Examples
+
+### Sizes
+
+<ComponentPreview
+  code={`import { ShimmerButton } from "@/components/godui/shimmer-button";
+
+export function ShimmerButtonSizes() {
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-4">
+      <ShimmerButton size="sm">Small</ShimmerButton>
+      <ShimmerButton size="md">Medium</ShimmerButton>
+      <ShimmerButton size="lg">Large</ShimmerButton>
+    </div>
+  );
+}`}
+>
+  <div className="flex flex-wrap items-center justify-center gap-4">
+    <ShimmerButton size="sm">Small</ShimmerButton>
+    <ShimmerButton size="md">Medium</ShimmerButton>
+    <ShimmerButton size="lg">Large</ShimmerButton>
+  </div>
+</ComponentPreview>
+
+### Without shimmer
+
+Set `shimmer={false}` to keep the button styling without the animated border light.
+
+<ComponentPreview
+  code={`import { ShimmerButton } from "@/components/godui/shimmer-button";
+
+export function ShimmerButtonStatic() {
+  return <ShimmerButton shimmer={false}>No shimmer</ShimmerButton>;
+}`}
+>
+  <ShimmerButton shimmer={false}>No shimmer</ShimmerButton>
+</ComponentPreview>
+
+### Disabled
+
+<ComponentPreview
+  code={`import { ShimmerButton } from "@/components/godui/shimmer-button";
+
+export function ShimmerButtonDisabled() {
+  return <ShimmerButton disabled>Disabled</ShimmerButton>;
+}`}
+>
+  <ShimmerButton disabled>Disabled</ShimmerButton>
+</ComponentPreview>
+
 ## Props
 
 | Prop | Type | Default | Description |

--- a/apps/docs/content/docs/components/effects/border-beam.mdx
+++ b/apps/docs/content/docs/components/effects/border-beam.mdx
@@ -3,6 +3,7 @@ title: Border Beam
 description: An animated beam of light that travels around the border of its container.
 ---
 
+import { BorderBeam } from "@godui/components";
 import { BorderBeamDemo } from "@/components/demos/border-beam-demo";
 
 A streak of light rides the border of whatever you put it in. Drop it inside a
@@ -67,6 +68,114 @@ set `glow` for a neon echo.
   <BorderBeam duration={6} delay={3} />
 </Card>
 ```
+
+## Examples
+
+The previews below use a plain `relative overflow-hidden` card so the example is
+self-contained — drop `BorderBeam` into your own `Card` the same way.
+
+### Reverse
+
+Set `reverse` to send the beam counter-clockwise.
+
+<ComponentPreview
+  code={`import { BorderBeam } from "@/components/godui/border-beam";
+
+export function BorderBeamReverse() {
+  return (
+    <div className="relative min-h-[180px] w-[320px] overflow-hidden rounded-xl border border-border bg-card p-6">
+      <p className="text-sm text-muted-foreground">Counter-clockwise beam.</p>
+      <BorderBeam size={70} reverse />
+    </div>
+  );
+}`}
+>
+  <div className="relative min-h-[180px] w-[320px] overflow-hidden rounded-xl border border-border bg-card p-6">
+    <p className="text-sm text-muted-foreground">Counter-clockwise beam.</p>
+    <BorderBeam size={70} reverse />
+  </div>
+</ComponentPreview>
+
+### Glow
+
+`glow` renders a soft blurred echo behind the beam for a neon look.
+
+<ComponentPreview
+  code={`import { BorderBeam } from "@/components/godui/border-beam";
+
+export function BorderBeamGlow() {
+  return (
+    <div className="relative min-h-[180px] w-[320px] overflow-hidden rounded-xl border border-border bg-card p-6">
+      <p className="text-sm text-muted-foreground">Glowing beam.</p>
+      <BorderBeam size={80} glow />
+    </div>
+  );
+}`}
+>
+  <div className="relative min-h-[180px] w-[320px] overflow-hidden rounded-xl border border-border bg-card p-6">
+    <p className="text-sm text-muted-foreground">Glowing beam.</p>
+    <BorderBeam size={80} glow />
+  </div>
+</ComponentPreview>
+
+### Thick colored
+
+Turn `rainbow` off and pass `colorFrom` / `colorTo` to drive your own gradient,
+with a wider `borderWidth`.
+
+<ComponentPreview
+  code={`import { BorderBeam } from "@/components/godui/border-beam";
+
+export function BorderBeamColored() {
+  return (
+    <div className="relative min-h-[180px] w-[320px] overflow-hidden rounded-xl border border-border bg-card p-6">
+      <p className="text-sm text-muted-foreground">Custom gradient, thick border.</p>
+      <BorderBeam
+        size={70}
+        borderWidth={2}
+        rainbow={false}
+        colorFrom="var(--chart-2)"
+        colorTo="var(--chart-4)"
+      />
+    </div>
+  );
+}`}
+>
+  <div className="relative min-h-[180px] w-[320px] overflow-hidden rounded-xl border border-border bg-card p-6">
+    <p className="text-sm text-muted-foreground">Custom gradient, thick border.</p>
+    <BorderBeam
+      size={70}
+      borderWidth={2}
+      rainbow={false}
+      colorFrom="var(--chart-2)"
+      colorTo="var(--chart-4)"
+    />
+  </div>
+</ComponentPreview>
+
+### Dual beams
+
+Render two beams with opposite `delay` values for a continuous double chase.
+
+<ComponentPreview
+  code={`import { BorderBeam } from "@/components/godui/border-beam";
+
+export function BorderBeamDual() {
+  return (
+    <div className="relative min-h-[180px] w-[320px] overflow-hidden rounded-xl border border-border bg-card p-6">
+      <p className="text-sm text-muted-foreground">Two beams chasing each other.</p>
+      <BorderBeam size={70} duration={6} />
+      <BorderBeam size={70} duration={6} delay={3} />
+    </div>
+  );
+}`}
+>
+  <div className="relative min-h-[180px] w-[320px] overflow-hidden rounded-xl border border-border bg-card p-6">
+    <p className="text-sm text-muted-foreground">Two beams chasing each other.</p>
+    <BorderBeam size={70} duration={6} />
+    <BorderBeam size={70} duration={6} delay={3} />
+  </div>
+</ComponentPreview>
 
 ## Props
 

--- a/apps/docs/content/docs/components/navigation/magic-tab.mdx
+++ b/apps/docs/content/docs/components/navigation/magic-tab.mdx
@@ -56,6 +56,139 @@ const [value, setValue] = useState("overview");
 <MagicTab items={items} value={value} onValueChange={setValue} />;
 ```
 
+## Examples
+
+### Secondary
+
+<ComponentPreview
+  code={`import { MagicTab } from "@/components/godui/magic-tab";
+
+const items = [
+  { value: "overview", label: "Overview" },
+  { value: "analytics", label: "Analytics" },
+  { value: "reports", label: "Reports" },
+];
+
+export function MagicTabSecondary() {
+  return <MagicTab items={items} defaultValue="overview" variant="secondary" />;
+}`}
+>
+  <MagicTab
+    items={[
+      { value: "overview", label: "Overview" },
+      { value: "analytics", label: "Analytics" },
+      { value: "reports", label: "Reports" },
+    ]}
+    defaultValue="overview"
+    variant="secondary"
+  />
+</ComponentPreview>
+
+### Without rainbow
+
+<ComponentPreview
+  code={`import { MagicTab } from "@/components/godui/magic-tab";
+
+const items = [
+  { value: "overview", label: "Overview" },
+  { value: "analytics", label: "Analytics" },
+  { value: "reports", label: "Reports" },
+];
+
+export function MagicTabPlain() {
+  return <MagicTab items={items} defaultValue="overview" rainbow={false} />;
+}`}
+>
+  <MagicTab
+    items={[
+      { value: "overview", label: "Overview" },
+      { value: "analytics", label: "Analytics" },
+      { value: "reports", label: "Reports" },
+    ]}
+    defaultValue="overview"
+    rainbow={false}
+  />
+</ComponentPreview>
+
+### Disabled tab
+
+Mark any item `disabled` to skip it.
+
+<ComponentPreview
+  code={`import { MagicTab } from "@/components/godui/magic-tab";
+
+const items = [
+  { value: "overview", label: "Overview" },
+  { value: "analytics", label: "Analytics", disabled: true },
+  { value: "reports", label: "Reports" },
+];
+
+export function MagicTabDisabled() {
+  return <MagicTab items={items} defaultValue="overview" />;
+}`}
+>
+  <MagicTab
+    items={[
+      { value: "overview", label: "Overview" },
+      { value: "analytics", label: "Analytics", disabled: true },
+      { value: "reports", label: "Reports" },
+    ]}
+    defaultValue="overview"
+  />
+</ComponentPreview>
+
+### Sizes
+
+<ComponentPreview
+  code={`import { MagicTab } from "@/components/godui/magic-tab";
+
+const items = [
+  { value: "overview", label: "Overview" },
+  { value: "analytics", label: "Analytics" },
+  { value: "reports", label: "Reports" },
+];
+
+export function MagicTabSizes() {
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <MagicTab items={items} defaultValue="overview" size="sm" />
+      <MagicTab items={items} defaultValue="overview" size="md" />
+      <MagicTab items={items} defaultValue="overview" size="lg" />
+    </div>
+  );
+}`}
+>
+  <div className="flex flex-col items-center gap-4">
+    <MagicTab
+      items={[
+        { value: "overview", label: "Overview" },
+        { value: "analytics", label: "Analytics" },
+        { value: "reports", label: "Reports" },
+      ]}
+      defaultValue="overview"
+      size="sm"
+    />
+    <MagicTab
+      items={[
+        { value: "overview", label: "Overview" },
+        { value: "analytics", label: "Analytics" },
+        { value: "reports", label: "Reports" },
+      ]}
+      defaultValue="overview"
+      size="md"
+    />
+    <MagicTab
+      items={[
+        { value: "overview", label: "Overview" },
+        { value: "analytics", label: "Analytics" },
+        { value: "reports", label: "Reports" },
+      ]}
+      defaultValue="overview"
+      size="lg"
+    />
+  </div>
+</ComponentPreview>
+
 ## Props
 
 | Prop | Type | Default | Description |

--- a/apps/docs/content/docs/components/text/elastic-text.mdx
+++ b/apps/docs/content/docs/components/text/elastic-text.mdx
@@ -67,6 +67,48 @@ The weight emphasis follows the pointer while it's over the text.
 </ElasticText>
 ```
 
+## Examples
+
+### Hover
+
+`mode="hover"` ties the weight emphasis to the pointer instead of an automatic spotlight.
+
+<ComponentPreview
+  code={`import { ElasticText } from "@/components/godui/elastic-text";
+
+export function ElasticTextHover() {
+  return (
+    <ElasticText mode="hover" className="text-4xl tracking-tight">
+      Move Your Mouse
+    </ElasticText>
+  );
+}`}
+>
+  <ElasticText mode="hover" className="text-4xl tracking-tight">
+    Move Your Mouse
+  </ElasticText>
+</ComponentPreview>
+
+### Plays once
+
+`loop={false}` runs a single spotlight sweep across the text, then settles back to normal weight. Use the replay button to run it again.
+
+<ComponentPreview
+  code={`import { ElasticText } from "@/components/godui/elastic-text";
+
+export function ElasticTextOnce() {
+  return (
+    <ElasticText loop={false} className="text-4xl tracking-tight">
+      Plays once
+    </ElasticText>
+  );
+}`}
+>
+  <ElasticText loop={false} className="text-4xl tracking-tight">
+    Plays once
+  </ElasticText>
+</ComponentPreview>
+
 ## Props
 
 | Prop | Type | Default | Description |
@@ -77,6 +119,7 @@ The weight emphasis follows the pointer while it's over the text.
 | `maxWeight` | `number` | `900` | Peak (heaviest) weight under the spotlight / pointer |
 | `duration` | `number` | `2` | Seconds for one full `auto` sweep |
 | `loop` | `boolean` | `true` | Repeat the `auto` sweep |
+| `startOnView` | `boolean` | `true` | Start the `auto` sweep only once the text scrolls into view |
 | `radius` | `number` | `120` | Pointer influence radius in px (`hover` mode) |
 
 ## Accessibility

--- a/apps/docs/content/docs/components/text/highlighter.mdx
+++ b/apps/docs/content/docs/components/text/highlighter.mdx
@@ -102,6 +102,65 @@ Set `isView` to defer the draw-in animation until the element scrolls into view.
 </Highlighter>
 ```
 
+## Examples
+
+### In a sentence
+
+Drop it around any inline word — the sketch draws over the text in place.
+
+<ComponentPreview
+  code={`import { Highlighter } from "@/components/godui/highlighter";
+
+export function HighlighterSentence() {
+  return (
+    <p className="max-w-md text-xl leading-relaxed">
+      The quick brown <Highlighter action="underline" color="#60a5fa">fox</Highlighter>{" "}
+      jumps over the <Highlighter action="highlight">lazy dog</Highlighter>.
+    </p>
+  );
+}`}
+>
+  <p className="max-w-md text-xl leading-relaxed">The quick brown <Highlighter action="underline" color="#60a5fa">fox</Highlighter> jumps over the <Highlighter action="highlight">lazy dog</Highlighter>.</p>
+</ComponentPreview>
+
+### Tuning the sketch
+
+Push `strokeWidth`, `iterations`, `padding`, and `animationDuration` for a bolder, looser, slower draw.
+
+<ComponentPreview
+  code={`import { Highlighter } from "@/components/godui/highlighter";
+
+export function HighlighterTuned() {
+  return (
+    <p className="text-3xl font-sans">
+      <Highlighter
+        action="box"
+        color="#22d3ee"
+        strokeWidth={2.5}
+        iterations={3}
+        padding={6}
+        animationDuration={900}
+      >
+        Bolder, looser, slower
+      </Highlighter>
+    </p>
+  );
+}`}
+>
+  <p className="text-3xl font-sans">
+    <Highlighter
+      action="box"
+      color="#22d3ee"
+      strokeWidth={2.5}
+      iterations={3}
+      padding={6}
+      animationDuration={900}
+    >
+      Bolder, looser, slower
+    </Highlighter>
+  </p>
+</ComponentPreview>
+
 ## Props
 
 | Prop | Type | Default | Description |

--- a/apps/docs/content/docs/components/text/text-animate.mdx
+++ b/apps/docs/content/docs/components/text/text-animate.mdx
@@ -77,6 +77,102 @@ import { TextAnimate } from "@/components/godui/text-animate";
 </TextAnimate>
 ```
 
+## Examples
+
+Hit the replay button on any preview to play the animation again.
+
+### Word fade in
+
+<ComponentPreview
+  code={`import { TextAnimate } from "@/components/godui/text-animate";
+
+export function TextAnimateFade() {
+  return (
+    <TextAnimate animation="fadeIn" by="word" className="text-4xl font-semibold tracking-tight">
+      Animate your ideas into reality
+    </TextAnimate>
+  );
+}`}
+>
+  <TextAnimate animation="fadeIn" by="word" className="text-4xl font-semibold tracking-tight">
+    Animate your ideas into reality
+  </TextAnimate>
+</ComponentPreview>
+
+### Character stagger
+
+<ComponentPreview
+  code={`import { TextAnimate } from "@/components/godui/text-animate";
+
+export function TextAnimateChars() {
+  return (
+    <TextAnimate animation="slideUp" by="character" stagger={0.03} className="text-3xl font-medium">
+      Character by character
+    </TextAnimate>
+  );
+}`}
+>
+  <TextAnimate animation="slideUp" by="character" stagger={0.03} className="text-3xl font-medium">
+    Character by character
+  </TextAnimate>
+</ComponentPreview>
+
+### Scale up
+
+<ComponentPreview
+  code={`import { TextAnimate } from "@/components/godui/text-animate";
+
+export function TextAnimateScale() {
+  return (
+    <TextAnimate animation="scaleUp" by="word" className="text-4xl font-semibold tracking-tight">
+      Scale up with spring
+    </TextAnimate>
+  );
+}`}
+>
+  <TextAnimate animation="scaleUp" by="word" className="text-4xl font-semibold tracking-tight">
+    Scale up with spring
+  </TextAnimate>
+</ComponentPreview>
+
+### Slide from the right
+
+<ComponentPreview
+  code={`import { TextAnimate } from "@/components/godui/text-animate";
+
+export function TextAnimateSlide() {
+  return (
+    <TextAnimate animation="slideLeft" by="word" className="text-4xl font-semibold tracking-tight">
+      Slide from the right
+    </TextAnimate>
+  );
+}`}
+>
+  <TextAnimate animation="slideLeft" by="word" className="text-4xl font-semibold tracking-tight">
+    Slide from the right
+  </TextAnimate>
+</ComponentPreview>
+
+### Semantic heading
+
+Render a real `h1` with `as` while keeping the staggered entrance.
+
+<ComponentPreview
+  code={`import { TextAnimate } from "@/components/godui/text-animate";
+
+export function TextAnimateHeading() {
+  return (
+    <TextAnimate as="h1" animation="blurInUp" by="word" className="text-5xl font-bold tracking-tight">
+      Hero headline
+    </TextAnimate>
+  );
+}`}
+>
+  <TextAnimate as="h1" animation="blurInUp" by="word" className="text-5xl font-bold tracking-tight">
+    Hero headline
+  </TextAnimate>
+</ComponentPreview>
+
 ## Props
 
 | Prop | Type | Default | Description |

--- a/apps/docs/src/app/page.tsx
+++ b/apps/docs/src/app/page.tsx
@@ -12,7 +12,7 @@ export default function Home() {
       <DocsHeader />
       <section className="flex flex-1 flex-col items-center justify-center gap-8 px-4 text-center">
         <h1 className="max-w-3xl text-balance font-semibold text-4xl text-fd-foreground tracking-tight sm:text-5xl md:text-6xl">
-          UI library for Design Engineers
+          UI collection for Design Engineers
         </h1>
         <MagicButton
           size="lg"

--- a/packages/components/src/elastic-text/elastic-text.tsx
+++ b/packages/components/src/elastic-text/elastic-text.tsx
@@ -29,12 +29,15 @@ export type ElasticTextProps = React.HTMLAttributes<HTMLSpanElement> & {
   duration?: number;
   /** Repeat the `auto` sweep. */
   loop?: boolean;
+  /** Start the `auto` sweep only once the text scrolls into view. */
+  startOnView?: boolean;
   /** Pointer influence radius in px (`hover` mode). */
   radius?: number;
 };
 
 const SPRING = { stiffness: 150, damping: 18, mass: 1 } as const;
 const AUTO_SPREAD = 2.5;
+const VIEW_THRESHOLD = 0.3;
 
 type SegmentProps = {
   segment: string;
@@ -114,6 +117,7 @@ const ElasticText = React.forwardRef<HTMLSpanElement, ElasticTextProps>(
       maxWeight = 900,
       duration = 2,
       loop = true,
+      startOnView = true,
       radius = 120,
       ...props
     },
@@ -139,7 +143,10 @@ const ElasticText = React.forwardRef<HTMLSpanElement, ElasticTextProps>(
       [textContent],
     );
 
-    const spotlight = useMotionValue(0);
+    // Start off the left edge so the first paint is uniform normal weight — at
+    // position 0 the leading character would render at max weight (a "big P"
+    // flash) before the sweep effect runs.
+    const spotlight = useMotionValue(-AUTO_SPREAD);
     const pointerX = useMotionValue(0);
     const pointerActive = useMotionValue(0);
     const centersRef = React.useRef<number[]>([]);
@@ -148,24 +155,63 @@ const ElasticText = React.forwardRef<HTMLSpanElement, ElasticTextProps>(
       [],
     );
 
-    // Auto mode: sweep the spotlight back and forth across the characters.
+    // Auto mode: sweep the spotlight across the characters. When `startOnView`
+    // is set, hold off until the text scrolls into view via IntersectionObserver.
     React.useEffect(() => {
       if (reducedMotion || mode !== "auto" || !segments) {
         return;
       }
-      const controls = animate(
-        spotlight,
-        [0, Math.max(segments.length - 1, 1)],
-        {
-          duration,
-          // Infinite: sweep forever. Finite: one sweep out and back to rest.
-          repeat: loop ? Number.POSITIVE_INFINITY : 1,
-          repeatType: "mirror",
-          ease: "easeInOut",
+      const last = Math.max(segments.length - 1, 1);
+      // Rest off the left edge so every character sits at normal weight until
+      // the sweep actually starts (no leading-character flash while waiting).
+      spotlight.set(-AUTO_SPREAD);
+
+      const start = () =>
+        loop
+          ? // Loop: sweep back and forth forever.
+            animate(spotlight, [0, last], {
+              duration,
+              repeat: Number.POSITIVE_INFINITY,
+              repeatType: "mirror",
+              ease: "easeInOut",
+            })
+          : // Once: a single pass that starts and ends off the text (padded by
+            // AUTO_SPREAD on both sides) so the weight settles back to normal
+            // everywhere instead of leaving the leading characters emphasized.
+            animate(spotlight, [-AUTO_SPREAD, last + AUTO_SPREAD], {
+              duration,
+              ease: "easeInOut",
+            });
+
+      const node = containerRef.current;
+      if (
+        !startOnView ||
+        !node ||
+        typeof IntersectionObserver === "undefined"
+      ) {
+        const controls = start();
+        return () => controls.stop();
+      }
+
+      let controls: ReturnType<typeof animate> | undefined;
+      const observer = new IntersectionObserver(
+        (entries) => {
+          for (const entry of entries) {
+            if (entry.isIntersecting) {
+              controls = start();
+              observer.disconnect();
+              break;
+            }
+          }
         },
+        { threshold: VIEW_THRESHOLD },
       );
-      return () => controls.stop();
-    }, [duration, loop, mode, reducedMotion, segments, spotlight]);
+      observer.observe(node);
+      return () => {
+        observer.disconnect();
+        controls?.stop();
+      };
+    }, [duration, loop, mode, reducedMotion, segments, spotlight, startOnView]);
 
     const updateCenters = React.useCallback(() => {
       const container = containerRef.current;

--- a/packages/components/src/progressive-card-reveal/progressive-card-reveal.tsx
+++ b/packages/components/src/progressive-card-reveal/progressive-card-reveal.tsx
@@ -50,12 +50,14 @@ const EXPANDED_WIDTH = "100%";
 const COLLAPSED_BASE_WIDTH = 90; // % at distance 1
 const COLLAPSED_WIDTH_STEP = 7; // % narrower per extra step away
 const COLLAPSED_MIN_WIDTH = 60;
-// Hovering a collapsed card nudges it wider to signal it's interactive.
-const HOVER_WIDTH_BOOST = 5;
+// Hovering a collapsed card nudges it up via a transform scale (not a width
+// change) so the content never reflows — a width change would re-lay-out the
+// right-aligned values every spring frame, which reads as a flicker.
+const HOVER_SCALE = 1.03;
 
-function collapsedWidth(distance: number, hovered = false) {
+function collapsedWidth(distance: number) {
   const base = COLLAPSED_BASE_WIDTH - (distance - 1) * COLLAPSED_WIDTH_STEP;
-  const width = Math.max(base, COLLAPSED_MIN_WIDTH) + (hovered ? HOVER_WIDTH_BOOST : 0);
+  const width = Math.max(base, COLLAPSED_MIN_WIDTH);
   return `${width}%`;
 }
 
@@ -98,7 +100,6 @@ const Card = React.forwardRef<HTMLDivElement, ProgressiveCardRevealCardProps>(
     const reveal = React.useContext(RevealContext);
     const index = React.useContext(CardIndexContext);
     const reducedMotion = useReducedMotion() ?? false;
-    const [hovered, setHovered] = React.useState(false);
 
     if (reveal === null || index === null) {
       throw new Error(
@@ -121,23 +122,22 @@ const Card = React.forwardRef<HTMLDivElement, ProgressiveCardRevealCardProps>(
         data-expanded={expanded}
         initial={false}
         transition={reducedMotion ? { duration: 0 } : LAYOUT_TRANSITION}
-        // Hover is React state, not `whileHover`. A gesture animation would
-        // take ownership of the `width` motion value and stop syncing from
-        // `style` — so a later activeIndex change (new depth) wouldn't update
-        // the width until you hovered again. Keeping width as a single
-        // state-driven `style` value avoids that stale-width bug; the `layout`
-        // spring animates every change (depth, hover, expand) consistently.
-        onHoverStart={() => setHovered(true)}
-        onHoverEnd={() => setHovered(false)}
+        // Hover lift is a `whileHover` scale — a transform, so it never reflows
+        // the card's content (a width change would re-lay-out the right-aligned
+        // values every spring frame, which reads as a flicker). Only collapsed
+        // cards lift; the expanded one stays put. Width remains a state-driven
+        // `style` value, so a later activeIndex change (new depth) still updates
+        // it — scale and width are independent, so there's no stale-width bug.
+        whileHover={
+          reducedMotion || expanded ? undefined : { scale: HOVER_SCALE }
+        }
         // borderRadius is set via `style` (not `animate`) on purpose: framer
         // only applies inverse-scale correction to radius when it's a style
         // value, so the corners stay crisp instead of warping as the box is
         // scaled during the layout morph. The value change tweens along with
         // the layout animation.
         style={{
-          width: expanded
-            ? EXPANDED_WIDTH
-            : collapsedWidth(depth, hovered && !reducedMotion),
+          width: expanded ? EXPANDED_WIDTH : collapsedWidth(depth),
           borderRadius: expanded ? EXPANDED_RADIUS : COLLAPSED_RADIUS,
         }}
         className={`relative overflow-hidden border border-border bg-card text-card-foreground shadow-sm transform-gpu ${className ?? ""}`}


### PR DESCRIPTION
Adds a `## Examples` section (after Usage, before Props) to nine component docs pages, each a live `<ComponentPreview>` with its source, sourced from the component stories — plus updates the home hero to "UI collection for Design Engineers". While writing the examples, fixes two animation bugs: **ElasticText** now starts its auto sweep only on viewport entry (new `startOnView` prop, default true, via IntersectionObserver), rests at normal weight until then, settles `loop={false}` to uniform normal weight, and no longer flashes a heavy leading character on mount. **ProgressiveCardReveal** hover now lifts via a `whileHover` scale transform instead of an animated width, so the right-aligned content no longer reflows/flickers each spring frame. Verified: `@godui/components` 114 tests pass, `tsc --noEmit` clean, docs build green.