### PR TITLE
feat(docs): breadcrumbs, Introduction root, and Components index pages

### DIFF
--- a/apps/docs/content/docs/components/index.mdx
+++ b/apps/docs/content/docs/components/index.mdx
@@ -1,0 +1,83 @@
+---
+title: Components
+description: Browse the full GoDUI component collection.
+---
+
+import { Cards, Card } from "fumadocs-ui/components/card";
+
+## Buttons
+
+<Cards>
+  <Card href="/docs/components/buttons/magic-button" title="Magic Button">
+    A pushable 3D button with rainbow edge animation and solid front face.
+  </Card>
+  <Card href="/docs/components/buttons/shimmer-button" title="Shimmer Button">
+    A button with an animated shimmering border light effect.
+  </Card>
+  <Card
+    href="/docs/components/buttons/progress-fold-button"
+    title="Progress Fold Button"
+  >
+    A 3D button whose front face folds back to reveal a controlled progress bar
+    while loading.
+  </Card>
+  <Card href="/docs/components/buttons/mask-button" title="Mask Button">
+    A button whose face wipes away on hover via an animated CSS sprite-sheet
+    mask, revealing the label behind it.
+  </Card>
+</Cards>
+
+## Navigation
+
+<Cards>
+  <Card href="/docs/components/navigation/magic-tab" title="Magic Tab">
+    A segmented tab bar where the selected option lifts into a 3D button with an
+    optional rainbow edge.
+  </Card>
+</Cards>
+
+## Inputs
+
+<Cards>
+  <Card href="/docs/components/inputs/magic-input" title="Magic Input">
+    A 3D layered text input that lifts on focus with an optional rainbow edge
+    animation.
+  </Card>
+</Cards>
+
+## Text
+
+<Cards>
+  <Card href="/docs/components/text/elastic-text" title="Elastic Text">
+    Variable-font text whose weight springs up under an automatic spotlight or
+    the pointer.
+  </Card>
+  <Card href="/docs/components/text/text-animate" title="Text Animate">
+    Staggered entrance animations for headlines and copy, split by word,
+    character, or line.
+  </Card>
+  <Card href="/docs/components/text/highlighter" title="Highlighter">
+    Draw hand-drawn sketch annotations over inline text — highlight, underline,
+    box, circle, and more.
+  </Card>
+</Cards>
+
+## Layout
+
+<Cards>
+  <Card
+    href="/docs/components/layout/progressive-card-reveal"
+    title="Progressive Card Reveal"
+  >
+    A vertical stack of cards where one expands to its full view while the rest
+    collapse to compact pills.
+  </Card>
+</Cards>
+
+## Effects
+
+<Cards>
+  <Card href="/docs/components/effects/border-beam" title="Border Beam">
+    An animated beam of light that travels around the border of its container.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/components/meta.json
+++ b/apps/docs/content/docs/components/meta.json
@@ -2,6 +2,7 @@
   "title": "Components",
   "defaultOpen": true,
   "pages": [
+    "index",
     "---Buttons---",
     "buttons/magic-button",
     "buttons/shimmer-button",

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -1,0 +1,43 @@
+---
+title: Introduction
+description: A UI collection of open-source animated components for Design Engineers.
+---
+
+import { Cards, Card } from "fumadocs-ui/components/card";
+import { MagicButton } from "@godui/components";
+
+**GoDUI** is a collection of open-source, animated UI components for Design
+Engineers. Built with **React**, **TypeScript**, **Tailwind CSS v4**, and
+**Motion**, and distributed as a [shadcn](https://ui.shadcn.com) registry — so
+the components are copied straight into your project and you own every line.
+
+<ComponentPreview code={`import { MagicButton } from "@godui/components";
+
+export function Demo() {
+  return <MagicButton size="lg">Get Started</MagicButton>;
+}`}>
+  <MagicButton size="lg">Get Started</MagicButton>
+</ComponentPreview>
+
+## What you get
+
+- **You own the code.** Components are installed into your codebase via the
+  shadcn CLI — not hidden behind a versioned dependency.
+- **Motion-first.** Every component ships with polished, performant animation
+  out of the box.
+- **shadcn-native.** Same install flow as shadcn/ui. If you already use shadcn,
+  just add the `@godui` registry.
+- **Tailwind v4 tokens.** Themed with CSS variables — light and dark modes work
+  with zero extra config.
+- **Type-safe.** Full TypeScript types for every component and its props.
+
+## Next steps
+
+<Cards>
+  <Card href="/docs/installation" title="Installation">
+    Add the `@godui` registry and pull your first component in minutes.
+  </Card>
+  <Card href="/docs/components" title="Components">
+    Browse the full collection of animated components.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "GoDUI",
-  "pages": ["installation", "components"]
+  "pages": ["index", "installation", "components"]
 }

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -7,15 +7,6 @@ const storybookDevOrigin = "http://127.0.0.1:6006";
 
 const nextConfig: NextConfig = {
   transpilePackages: ["@godui/components"],
-  async redirects() {
-    return [
-      {
-        source: "/docs",
-        destination: "/docs/installation",
-        permanent: false,
-      },
-    ];
-  },
   async rewrites() {
     if (process.env.NODE_ENV === "development") {
       return [

--- a/apps/docs/src/app/docs/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/docs/[[...slug]]/page.tsx
@@ -8,6 +8,7 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getMDXComponents } from "@/components/mdx";
 import { source } from "@/lib/source";
+import { type Crumb, Breadcrumbs } from "../_components/breadcrumbs";
 
 export default async function Page(props: PageProps<"/docs/[[...slug]]">) {
   const params = await props.params;
@@ -16,8 +17,26 @@ export default async function Page(props: PageProps<"/docs/[[...slug]]">) {
 
   const MDX = page.data.body;
 
+  const slug = params.slug ?? [];
+  const crumbs: Crumb[] = [{ name: "Docs", url: slug.length ? "/docs" : undefined }];
+  if (slug[0] === "components") {
+    const atComponentsRoot = slug.length === 1;
+    crumbs.push({
+      name: "Components",
+      url: atComponentsRoot ? undefined : "/docs/components",
+    });
+    if (!atComponentsRoot) crumbs.push({ name: page.data.title });
+  } else if (slug.length) {
+    crumbs.push({ name: page.data.title });
+  }
+
   return (
-    <DocsPage toc={page.data.toc} full={page.data.full}>
+    <DocsPage
+      toc={page.data.toc}
+      full={page.data.full}
+      breadcrumb={{ enabled: false }}
+    >
+      <Breadcrumbs crumbs={crumbs} />
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription>{page.data.description}</DocsDescription>
       <DocsBody>

--- a/apps/docs/src/app/docs/_components/breadcrumbs.tsx
+++ b/apps/docs/src/app/docs/_components/breadcrumbs.tsx
@@ -1,0 +1,39 @@
+import Link from "fumadocs-core/link";
+import { ChevronRight } from "lucide-react";
+import { Fragment } from "react";
+import { cn } from "@/lib/cn";
+
+export type Crumb = { name: string; url?: string };
+
+export function Breadcrumbs({ crumbs }: { crumbs: Crumb[] }) {
+  if (crumbs.length <= 1) return null;
+
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className="-mb-2 flex items-center gap-1.5 text-fd-muted-foreground text-sm"
+    >
+      {crumbs.map((crumb, i) => {
+        const isLast = i === crumbs.length - 1;
+
+        return (
+          <Fragment key={crumb.name}>
+            {i > 0 && <ChevronRight className="size-3.5 shrink-0" aria-hidden />}
+            {crumb.url && !isLast ? (
+              <Link
+                href={crumb.url}
+                className="transition-colors hover:text-fd-foreground"
+              >
+                {crumb.name}
+              </Link>
+            ) : (
+              <span className={cn(isLast && "text-fd-foreground")}>
+                {crumb.name}
+              </span>
+            )}
+          </Fragment>
+        );
+      })}
+    </nav>
+  );
+}

--- a/apps/docs/src/app/docs/_components/docs-header.tsx
+++ b/apps/docs/src/app/docs/_components/docs-header.tsx
@@ -31,6 +31,14 @@ export function DocsHeader({ className, ...props }: ComponentProps<"header">) {
       >
         <GoduiLogo className="h-10 w-10" width={40} height={40} />
       </Link>
+      <nav className="flex items-center">
+        <Link
+          href="/docs/components"
+          className="font-medium text-fd-muted-foreground text-sm transition-colors hover:text-fd-foreground"
+        >
+          Components
+        </Link>
+      </nav>
       <div className="flex-1" />
       <div className="flex items-center gap-1 sm:gap-2">
         {/* Desktop: full search bar */}

--- a/apps/docs/src/app/globals.css
+++ b/apps/docs/src/app/globals.css
@@ -224,6 +224,28 @@ body {
   color: var(--search-fg);
 }
 
+/* Search results — readable inline code pills (match docs prose tokens) */
+.bg-fd-popover code[class~="bg-fd-secondary"] {
+  background: var(--inline-code-bg) !important;
+  color: var(--inline-code-fg) !important;
+  border-color: var(--inline-code-border) !important;
+}
+
+/* Search results — matched-term highlight as a real highlighter mark.
+   Fumadocs renders matches as `text-fd-primary underline`, which is low
+   contrast on the muted code pills. Override with a tinted background +
+   high-contrast text so it reads on plain text and inside code pills. */
+.bg-fd-popover [class~="text-fd-primary"][class~="underline"] {
+  background: var(--search-highlight-bg);
+  color: var(--search-highlight-fg) !important;
+  text-decoration: none;
+  border-radius: 4px;
+  padding: 0 0.1875rem;
+  font-weight: 600;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+}
+
 /* Sidebar — no border, blend with page background, stick below header */
 #nd-sidebar {
   border-right: none !important;

--- a/packages/components/theme/dark.css
+++ b/packages/components/theme/dark.css
@@ -81,6 +81,8 @@
     --search-kbd-bg: oklch(0.28 0.024 266);
     --search-kbd-fg: oklch(0.86 0.08 266);
     --search-placeholder: oklch(0.62 0.02 266);
+    --search-highlight-bg: oklch(0.38 0.1 266);
+    --search-highlight-fg: oklch(0.97 0.025 266);
 
     /* Theme panel */
     --theme-panel-bg: oklch(0.195 0.026 266);
@@ -218,6 +220,8 @@
   --search-kbd-bg: oklch(0.28 0.024 266);
   --search-kbd-fg: oklch(0.86 0.08 266);
   --search-placeholder: oklch(0.62 0.02 266);
+  --search-highlight-bg: oklch(0.38 0.1 266);
+  --search-highlight-fg: oklch(0.97 0.025 266);
 
   --theme-panel-bg: oklch(0.195 0.026 266);
   --theme-panel-border: oklch(0.28 0.02 266);

--- a/packages/components/theme/light.css
+++ b/packages/components/theme/light.css
@@ -141,6 +141,8 @@
   --search-kbd-bg: oklch(0.965 0.006 266);
   --search-kbd-fg: oklch(0.2 0.036 266);
   --search-placeholder: oklch(0.54 0.022 266);
+  --search-highlight-bg: oklch(0.89 0.085 266);
+  --search-highlight-fg: oklch(0.34 0.13 266);
 
   /* Theme panel */
   --theme-panel-bg: oklch(1 0 0);


### PR DESCRIPTION
Adds custom breadcrumbs (`Docs / Components / {component}`) to every docs page and disables the default fumadocs breadcrumb that duplicated the page title. Adds an Introduction page as the `/docs` root — with intro copy, a live component preview, a feature list, and next-step cards — and removes the stale `/docs → /docs/installation` redirect so the root renders. Adds a Components index page listing every component grouped by category, plus a Components link in the header next to the logo.