### PR TITLE
feat(docs): add design skills, gamut-clamp OKLCH tokens + UI polish

### DIFF
--- a/.agents/skills/make-interfaces-feel-better/SKILL.md
+++ b/.agents/skills/make-interfaces-feel-better/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: make-interfaces-feel-better
+description: Design engineering principles for making interfaces feel polished. Use when building UI components, reviewing frontend code, implementing animations, hover states, shadows, borders, typography, micro-interactions, enter/exit animations, or any visual detail work. Triggers on UI polish, design details, "make it feel better", "feels off", stagger animations, border radius, optical alignment, font smoothing, tabular numbers, image outlines, box shadows.
+---
+
+# Details that make interfaces feel better
+
+Great interfaces rarely come from a single thing. It's usually a collection of small details that compound into a great experience. Apply these principles when building or reviewing UI code.
+
+## Quick Reference
+
+| Category | When to Use |
+| --- | --- |
+| [Typography](typography.md) | Text wrapping, font smoothing, tabular numbers |
+| [Surfaces](surfaces.md) | Border radius, optical alignment, shadows, image outlines, hit areas |
+| [Animations](animations.md) | Interruptible animations, enter/exit transitions, icon animations, scale on press |
+| [Performance](performance.md) | Transition specificity, `will-change` usage |
+
+## Core Principles
+
+### 1. Concentric Border Radius
+
+Outer radius = inner radius + padding. Mismatched radii on nested elements is the most common thing that makes interfaces feel off.
+
+### 2. Optical Over Geometric Alignment
+
+When geometric centering looks off, align optically. Buttons with icons, play triangles, and asymmetric icons all need manual adjustment.
+
+### 3. Shadows Over Borders
+
+Layer multiple transparent `box-shadow` values for natural depth. Shadows adapt to any background; solid borders don't.
+
+### 4. Interruptible Animations
+
+Use CSS transitions for interactive state changes — they can be interrupted mid-animation. Reserve keyframes for staged sequences that run once.
+
+### 5. Split and Stagger Enter Animations
+
+Don't animate a single container. Break content into semantic chunks and stagger each with ~100ms delay.
+
+### 6. Subtle Exit Animations
+
+Use a small fixed `translateY` instead of full height. Exits should be softer than enters.
+
+### 7. Contextual Icon Animations
+
+Animate icons with `opacity`, `scale`, and `blur` instead of toggling visibility. Use exactly these values: scale from `0.25` to `1`, opacity from `0` to `1`, blur from `4px` to `0px`. If the project has `motion` or `framer-motion` in `package.json`, use `transition: { type: "spring", duration: 0.3, bounce: 0 }` — bounce must always be `0`. If no motion library is installed, keep both icons in the DOM (one absolute-positioned) and cross-fade with CSS transitions using `cubic-bezier(0.2, 0, 0, 1)` — this gives both enter and exit animations without any dependency.
+
+### 8. Font Smoothing
+
+Apply `-webkit-font-smoothing: antialiased` to the root layout on macOS for crisper text.
+
+### 9. Tabular Numbers
+
+Use `font-variant-numeric: tabular-nums` for any dynamically updating numbers to prevent layout shift.
+
+### 10. Text Wrapping
+
+Use `text-wrap: balance` on headings. Use `text-wrap: pretty` for body text to avoid orphans.
+
+### 11. Image Outlines
+
+Add a subtle `1px` outline with low opacity to images for consistent depth. The color must be pure black in light mode (`rgba(0, 0, 0, 0.1)`) and pure white in dark mode (`rgba(255, 255, 255, 0.1)`) — never a near-black like slate, zinc, or any tinted neutral. A tinted outline picks up the surface color underneath it and reads as dirt on the image edge.
+
+### 12. Scale on Press
+
+A subtle `scale(0.96)` on click gives buttons tactile feedback. Always use `0.96`. Never use a value smaller than `0.95` — anything below feels exaggerated. Add a `static` prop to disable it when motion would be distracting.
+
+### 13. Skip Animation on Page Load
+
+Use `initial={false}` on `AnimatePresence` to prevent enter animations on first render. Verify it doesn't break intentional entrance animations.
+
+### 14. Never Use `transition: all`
+
+Always specify exact properties: `transition-property: scale, opacity`. Tailwind's `transition-transform` covers `transform, translate, scale, rotate`.
+
+### 15. Use `will-change` Sparingly
+
+Only for `transform`, `opacity`, `filter` — properties the GPU can composite. Never use `will-change: all`. Only add when you notice first-frame stutter.
+
+### 16. Minimum Hit Area
+
+Interactive elements need at least 40×40px hit area. Extend with a pseudo-element if the visible element is smaller. Never let hit areas of two elements overlap.
+
+## Common Mistakes
+
+| Mistake | Fix |
+| --- | --- |
+| Same border radius on parent and child | Calculate `outerRadius = innerRadius + padding` |
+| Icons look off-center | Adjust optically with padding or fix SVG directly |
+| Hard borders between sections | Use layered `box-shadow` with transparency |
+| Jarring enter/exit animations | Split, stagger, and keep exits subtle |
+| Numbers cause layout shift | Apply `tabular-nums` |
+| Heavy text on macOS | Apply `antialiased` to root |
+| Animation plays on page load | Add `initial={false}` to `AnimatePresence` |
+| `transition: all` on elements | Specify exact properties |
+| First-frame animation stutter | Add `will-change: transform` (sparingly) |
+| Tiny hit areas on small controls | Extend with pseudo-element to 40×40px |
+
+## Review Output Format
+
+Always present changes as a markdown table with **Before** and **After** columns. Include every change you made — not just a subset. Never list findings as separate "Before:" / "After:" lines outside of a table. Group changes by principle using a heading above each table, and keep each row focused on a single diff so the reader can scan the whole list quickly.
+
+### Example
+
+#### Concentric border radius
+| Before | After |
+| --- | --- |
+| `rounded-xl` on card + `rounded-xl` on inner button (`p-2`) | `rounded-2xl` on card (`12 + 8`), `rounded-lg` on inner button |
+| `border-radius: 16px` on both nested surfaces | Outer `24px`, inner `16px` with `8px` padding |
+
+#### Tabular numbers
+| Before | After |
+| --- | --- |
+| `<span>{count}</span>` on animated counter | `<span className="tabular-nums">{count}</span>` |
+| Default numerals on timer | Added `font-variant-numeric: tabular-nums` to root |
+
+#### Scale on press
+| Before | After |
+| --- | --- |
+| `<button className="...">` | Added `active:scale-[0.96] transition-transform` |
+| `scale(0.9)` on press | Raised to `scale(0.96)` — anything below `0.95` feels exaggerated |
+
+Rows should cite the specific file and the specific property that changed when it isn't obvious from the snippet. If a principle was reviewed but nothing needed to change, omit that table entirely — empty tables add noise.
+
+## Review Checklist
+
+- [ ] Nested rounded elements use concentric border radius
+- [ ] Icons are optically centered, not just geometrically
+- [ ] Shadows used instead of borders where appropriate
+- [ ] Enter animations are split and staggered
+- [ ] Exit animations are subtle
+- [ ] Dynamic numbers use tabular-nums
+- [ ] Font smoothing is applied
+- [ ] Headings use text-wrap: balance
+- [ ] Images have subtle outlines
+- [ ] Buttons use scale on press where appropriate
+- [ ] AnimatePresence uses `initial={false}` for default-state elements
+- [ ] No `transition: all` — only specific properties
+- [ ] `will-change` only on transform/opacity/filter, never `all`
+- [ ] Interactive elements have at least 40×40px hit area
+
+## Reference Files
+
+- [typography.md](typography.md) — Text wrapping, font smoothing, tabular numbers
+- [surfaces.md](surfaces.md) — Border radius, optical alignment, shadows, image outlines
+- [animations.md](animations.md) — Interruptible animations, enter/exit transitions, icon animations, scale on press
+- [performance.md](performance.md) — Transition specificity, `will-change` usage

--- a/.agents/skills/make-interfaces-feel-better/animations.md
+++ b/.agents/skills/make-interfaces-feel-better/animations.md
@@ -1,0 +1,379 @@
+# Animations
+
+Interruptible animations, enter/exit transitions, and contextual icon animations.
+
+## Interruptible Animations
+
+Users change intent mid-interaction. If animations aren't interruptible, the interface feels broken.
+
+### CSS Transitions vs. Keyframes
+
+| | CSS Transitions | CSS Keyframe Animations |
+| --- | --- | --- |
+| **Behavior** | Interpolate toward latest state | Run on a fixed timeline |
+| **Interruptible** | Yes — retargets mid-animation | No — restarts from beginning |
+| **Use for** | Interactive state changes (hover, toggle, open/close) | Staged sequences that run once (enter animations, loading) |
+| **Duration** | Adapts to remaining distance | Fixed regardless of state |
+
+```css
+/* Good — interruptible transition for a toggle */
+.drawer {
+  transform: translateX(-100%);
+  transition: transform 200ms ease-out;
+}
+.drawer.open {
+  transform: translateX(0);
+}
+
+/* Clicking again mid-animation smoothly reverses — no jank */
+```
+
+```css
+/* Bad — keyframe animation for interactive element */
+.drawer.open {
+  animation: slideIn 200ms ease-out forwards;
+}
+
+/* Closing mid-animation snaps or restarts — feels broken */
+```
+
+**Rule:** Always prefer CSS transitions for interactive elements. Reserve keyframes for one-shot sequences.
+
+## Enter Animations: Split and Stagger
+
+Don't animate a single large container. Break content into semantic chunks and animate each individually.
+
+### Step by Step
+
+1. **Split** into logical groups (title, description, buttons)
+2. **Stagger** with ~100ms delay between groups
+3. **For titles**, consider splitting into individual words with ~80ms stagger
+4. **Combine** `opacity`, `blur`, and `translateY` for the enter effect
+
+### Code Example
+
+```tsx
+// Motion (Framer Motion) — staggered enter
+function PageHeader() {
+  return (
+    <motion.div
+      initial="hidden"
+      animate="visible"
+      variants={{
+        visible: { transition: { staggerChildren: 0.1 } },
+      }}
+    >
+      <motion.h1
+        variants={{
+          hidden: { opacity: 0, y: 12, filter: "blur(4px)" },
+          visible: { opacity: 1, y: 0, filter: "blur(0px)" },
+        }}
+      >
+        Welcome
+      </motion.h1>
+
+      <motion.p
+        variants={{
+          hidden: { opacity: 0, y: 12, filter: "blur(4px)" },
+          visible: { opacity: 1, y: 0, filter: "blur(0px)" },
+        }}
+      >
+        A description of the page.
+      </motion.p>
+
+      <motion.div
+        variants={{
+          hidden: { opacity: 0, y: 12, filter: "blur(4px)" },
+          visible: { opacity: 1, y: 0, filter: "blur(0px)" },
+        }}
+      >
+        <Button>Get started</Button>
+      </motion.div>
+    </motion.div>
+  );
+}
+```
+
+### CSS-Only Stagger
+
+```css
+.stagger-item {
+  opacity: 0;
+  transform: translateY(12px);
+  filter: blur(4px);
+  animation: fadeInUp 400ms ease-out forwards;
+}
+
+.stagger-item:nth-child(1) { animation-delay: 0ms; }
+.stagger-item:nth-child(2) { animation-delay: 100ms; }
+.stagger-item:nth-child(3) { animation-delay: 200ms; }
+
+@keyframes fadeInUp {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+    filter: blur(0);
+  }
+}
+```
+
+## Exit Animations
+
+Exit animations should be softer and less attention-grabbing than enter animations. The user's focus is moving to the next thing — don't fight for attention.
+
+### Subtle Exit (Recommended)
+
+```tsx
+// Small fixed translateY — indicates direction without drama
+<motion.div
+  exit={{
+    opacity: 0,
+    y: -12,
+    filter: "blur(4px)",
+    transition: { duration: 0.15, ease: "easeIn" },
+  }}
+>
+  {content}
+</motion.div>
+```
+
+### Full Exit (When Context Matters)
+
+```tsx
+// Slide fully out — use when spatial context is important
+// (e.g., a card returning to a list, a drawer closing)
+<motion.div
+  exit={{
+    opacity: 0,
+    x: "-100%",
+    transition: { duration: 0.2, ease: "easeIn" },
+  }}
+>
+  {content}
+</motion.div>
+```
+
+### Good vs. Bad
+
+```css
+/* Good — subtle exit */
+.item-exit {
+  opacity: 0;
+  transform: translateY(-12px);
+  transition: opacity 150ms ease-in, transform 150ms ease-in;
+}
+
+/* Bad — dramatic exit that steals focus */
+.item-exit {
+  opacity: 0;
+  transform: translateY(-100%) scale(0.5);
+  transition: all 400ms ease-in;
+}
+
+/* Bad — no exit animation at all (element just vanishes) */
+.item-exit {
+  display: none;
+}
+```
+
+**Key points:**
+- Use a small fixed `translateY` (e.g., `-12px`) instead of the full container height
+- Keep some directional movement to indicate where the element went
+- Exit duration should be shorter than enter duration (150ms vs 300ms)
+- Don't remove exit animations entirely — subtle motion preserves context
+
+## Contextual Icon Animations
+
+When icons appear or disappear contextually (on hover, on state change), animate them with `opacity`, `scale`, and `blur` rather than just toggling visibility.
+
+### Motion Example
+
+```tsx
+import { AnimatePresence, motion } from "motion/react";
+
+function IconButton({ isActive, icon: Icon }) {
+  return (
+    <button>
+      <AnimatePresence mode="popLayout">
+        <motion.span
+          key={isActive ? "active" : "inactive"}
+          initial={{ opacity: 0, scale: 0.25, filter: "blur(4px)" }}
+          animate={{ opacity: 1, scale: 1, filter: "blur(0px)" }}
+          exit={{ opacity: 0, scale: 0.25, filter: "blur(4px)" }}
+          transition={{ type: "spring", duration: 0.3, bounce: 0 }}
+        >
+          <Icon />
+        </motion.span>
+      </AnimatePresence>
+    </button>
+  );
+}
+```
+
+### CSS Transition Approach (No Motion)
+
+If the project doesn't use Motion (Framer Motion), keep both icons in the DOM and cross-fade them with CSS transitions. Because neither icon unmounts, both enter and exit animate smoothly.
+
+The trick: one icon is absolutely positioned on top of the other. Toggling state cross-fades them — the entering icon scales up from `0.25` while the exiting icon scales down to `0.25`, both with opacity and blur.
+
+```tsx
+function IconButton({ isActive, ActiveIcon, InactiveIcon }) {
+  return (
+    <button>
+      <div className="relative">
+        <div
+          className={cn(
+            "absolute inset-0 flex items-center justify-center",
+            "transition-[opacity,filter,scale] duration-300",
+            "cubic-bezier(0.2, 0, 0, 1)",
+            isActive
+              ? "scale-100 opacity-100 blur-0"
+              : "scale-[0.25] opacity-0 blur-[4px]"
+          )}
+        >
+          <ActiveIcon />
+        </div>
+        <div
+          className={cn(
+            "transition-[opacity,filter,scale] duration-300",
+            "cubic-bezier(0.2, 0, 0, 1)",
+            isActive
+              ? "scale-[0.25] opacity-0 blur-[4px]"
+              : "scale-100 opacity-100 blur-0"
+          )}
+        >
+          <InactiveIcon />
+        </div>
+      </div>
+    </button>
+  );
+}
+```
+
+The non-absolute icon (InactiveIcon) defines the layout size. The absolute icon (ActiveIcon) overlays it without affecting flow.
+
+### Choosing Between Motion and CSS
+
+| | Motion (Framer Motion) | CSS transitions (both icons in DOM) |
+| --- | --- | --- |
+| **Enter animation** | Yes | Yes |
+| **Exit animation** | Yes (via `AnimatePresence`) | Yes (cross-fade — icon never unmounts) |
+| **Spring physics** | Yes | No — use `cubic-bezier(0.2, 0, 0, 1)` as approximation |
+| **When to use** | Project already uses `motion/react` | No motion dependency, or keeping bundle small |
+
+**Rule:** Check the project's `package.json` for `motion` or `framer-motion`. If present, use the Motion approach. If not, use the CSS cross-fade pattern — don't add a dependency just for icon transitions.
+
+### When to Animate Icons
+
+| Animate | Don't animate |
+| --- | --- |
+| Icons that appear on hover (action buttons) | Static navigation icons |
+| State change icons (play → pause, like → liked) | Decorative icons |
+| Icons in contextual toolbars | Icons that are always visible |
+| Loading/success state indicators | Icon labels (text next to icon) |
+
+**Important:** Always use exactly these values for contextual icon animations — do not deviate:
+- `scale`: `0.25` → `1` (never use `0.5` or `0.6`)
+- `opacity`: `0` → `1`
+- `filter`: `"blur(4px)"` → `"blur(0px)"`
+- `transition`: `{ type: "spring", duration: 0.3, bounce: 0 }` — **bounce must always be `0`**, never `0.1` or any other value
+
+## Scale on Press
+
+A subtle scale-down on click gives buttons tactile feedback. Always use `scale(0.96)`. Never use a value smaller than `0.95` — anything below feels exaggerated. Use CSS transitions for interruptibility — if the user releases mid-press, it should smoothly return.
+
+Not every button needs this. Add a `static` prop to your button component that disables the scale effect when the motion would be distracting.
+
+### CSS Example
+
+```css
+.button {
+  transition-property: scale;
+  transition-duration: 150ms;
+  transition-timing-function: ease-out;
+}
+
+.button:active {
+  scale: 0.96;
+}
+```
+
+### Tailwind Example
+
+```tsx
+<button className="transition-transform duration-150 ease-out active:scale-[0.96]">
+  Click me
+</button>
+```
+
+### Motion Example
+
+```tsx
+<motion.button whileTap={{ scale: 0.96 }}>
+  Click me
+</motion.button>
+```
+
+### Static Prop Pattern
+
+Extract the scale class into a variable and conditionally apply it based on a `static` prop:
+
+```tsx
+const tapScale = "active:not-disabled:scale-[0.96]";
+
+function Button({ static: isStatic, className, children, ...props }) {
+  return (
+    <button
+      className={cn(
+        "transition-transform duration-150 ease-out",
+        !isStatic && tapScale,
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+
+// Usage
+<Button>Click me</Button>           {/* scales on press */}
+<Button static>Submit</Button>       {/* no scale */}
+```
+
+## Skip Animation on Page Load
+
+Use `initial={false}` on `AnimatePresence` to prevent enter animations from firing on first render. Elements that are already in their default state shouldn't animate in on page load — only on subsequent state changes.
+
+### When It Works
+
+```tsx
+// Good — icon doesn't animate in on mount, only on state change
+<AnimatePresence initial={false} mode="popLayout">
+  <motion.span
+    key={isActive ? "active" : "inactive"}
+    initial={{ opacity: 0, scale: 0.25, filter: "blur(4px)" }}
+    animate={{ opacity: 1, scale: 1, filter: "blur(0px)" }}
+    exit={{ opacity: 0, scale: 0.25, filter: "blur(4px)" }}
+  >
+    <Icon />
+  </motion.span>
+</AnimatePresence>
+```
+
+Works well for: icon swaps, toggles, tabs, segmented controls — anything that has a default state on page load.
+
+### When It Breaks
+
+Don't use `initial={false}` when the component relies on its `initial` prop to set up a first-time enter animation, like a staggered page hero or a loading state. In those cases, removing the initial animation skips the entire entrance.
+
+```tsx
+// Bad — initial={false} would skip the staggered page enter entirely
+<AnimatePresence initial={false}>
+  <motion.div initial="hidden" animate="visible" variants={...}>
+    ...
+  </motion.div>
+</AnimatePresence>
+```
+
+Verify the component still looks right on a full page refresh before applying this.

--- a/.agents/skills/make-interfaces-feel-better/performance.md
+++ b/.agents/skills/make-interfaces-feel-better/performance.md
@@ -1,0 +1,88 @@
+# Performance
+
+Transition specificity and GPU compositing hints.
+
+## Transition Only What Changes
+
+Never use `transition: all` or Tailwind's `transition` shorthand (which maps to `transition-property: all`). Always specify the exact properties that change.
+
+### Why
+
+- `transition: all` forces the browser to watch every property for changes
+- Causes unexpected transitions on properties you didn't intend to animate (colors, padding, shadows)
+- Prevents browser optimizations
+
+### CSS Example
+
+```css
+/* Good — only transition what changes */
+.button {
+  transition-property: scale, background-color;
+  transition-duration: 150ms;
+  transition-timing-function: ease-out;
+}
+
+/* Bad — transition everything */
+.button {
+  transition: all 150ms ease-out;
+}
+```
+
+### Tailwind
+
+```tsx
+// Good — explicit properties
+<button className="transition-[scale,background-color] duration-150 ease-out">
+
+// Bad — transition all
+<button className="transition duration-150 ease-out">
+```
+
+### Tailwind `transition-transform` Note
+
+`transition-transform` in Tailwind maps to `transition-property: transform, translate, scale, rotate` — it covers all transform-related properties, not just `transform`. Use this when you're only animating transforms. For multiple non-transform properties, use the bracket syntax: `transition-[scale,opacity,filter]`.
+
+## Use `will-change` Sparingly
+
+`will-change` hints the browser to pre-promote an element to its own GPU compositing layer. Without it, the browser promotes the element only when the animation starts — that one-time layer promotion can cause a micro-stutter on the first frame.
+
+This particularly helps when an element is changing `scale`, `rotation`, or moving around with `transform`. For other properties, it doesn't help much — the browser can't composite them on the GPU anyway.
+
+### Rules
+
+```css
+/* Good — specific property that benefits from GPU compositing */
+.animated-card {
+  will-change: transform;
+}
+
+/* Good — multiple compositor-friendly properties */
+.animated-card {
+  will-change: transform, opacity;
+}
+
+/* Bad — never use will-change: all */
+.animated-card {
+  will-change: all;
+}
+
+/* Bad — properties that can't be GPU-composited anyway */
+.animated-card {
+  will-change: background-color, padding;
+}
+```
+
+### Useful Properties
+
+| Property | GPU-compositable | Worth using `will-change` |
+| --- | --- | --- |
+| `transform` | Yes | Yes |
+| `opacity` | Yes | Yes |
+| `filter` (blur, brightness) | Yes | Yes |
+| `clip-path` | Yes | Yes |
+| `top`, `left`, `width`, `height` | No | No |
+| `background`, `border`, `color` | No | No |
+
+### When to Skip
+
+Modern browsers are already good at optimizing on their own. Only add `will-change` when you notice first-frame stutter — Safari in particular benefits from it. Don't add it preemptively to every animated element; each extra compositing layer costs memory.

--- a/.agents/skills/make-interfaces-feel-better/surfaces.md
+++ b/.agents/skills/make-interfaces-feel-better/surfaces.md
@@ -1,0 +1,256 @@
+# Surfaces
+
+Border radius, optical alignment, shadows, and image outlines.
+
+## Concentric Border Radius
+
+When nesting rounded elements, the outer radius must equal the inner radius plus the padding between them:
+
+```
+outerRadius = innerRadius + padding
+```
+
+This rule is most useful when nested surfaces are close together. If padding is larger than `24px`, treat the layers as separate surfaces and choose each radius independently instead of forcing strict concentric math.
+
+### Example
+
+```css
+/* Good — concentric radii */
+.card {
+  border-radius: 20px; /* 12 + 8 */
+  padding: 8px;
+}
+.card-inner {
+  border-radius: 12px;
+}
+
+/* Bad — same radius on both */
+.card {
+  border-radius: 12px;
+  padding: 8px;
+}
+.card-inner {
+  border-radius: 12px;
+}
+```
+
+### Tailwind Example
+
+```tsx
+// Good — outer radius accounts for padding
+<div className="rounded-2xl p-2">       {/* 16px radius, 8px padding */}
+  <div className="rounded-lg">          {/* 8px radius = 16 - 8 ✓ */}
+    ...
+  </div>
+</div>
+
+// Bad — same radius on both
+<div className="rounded-xl p-2">
+  <div className="rounded-xl">          {/* same radius, looks off */}
+    ...
+  </div>
+</div>
+```
+
+Mismatched border radii on nested elements is one of the most common things that makes interfaces feel off. Always calculate concentrically.
+
+## Optical Alignment
+
+When geometric centering looks off, align optically instead.
+
+### Buttons with Text + Icon
+
+Use slightly less padding on the icon side to make the button feel balanced. A reliable rule of thumb is:
+`icon-side padding = text-side padding - 2px`.
+
+```css
+/* Good — less padding on icon side */
+.button-with-icon {
+  padding-left: 16px;
+  padding-right: 14px; /* icon side = text side - 2px */
+}
+
+/* Bad — equal padding looks like icon is pushed too far right */
+.button-with-icon {
+  padding: 0 16px;
+}
+```
+
+```tsx
+// Tailwind
+<button className="pl-4 pr-3.5 flex items-center gap-2">
+  <span>Continue</span>
+  <ArrowRightIcon />
+</button>
+```
+
+### Play Button Triangles
+
+Play icons are triangular and their geometric center is not their visual center. Shift slightly right:
+
+```css
+/* Good — optically centered */
+.play-button svg {
+  margin-left: 2px; /* shift right to account for triangle shape */
+}
+
+/* Bad — geometrically centered but looks off */
+.play-button svg {
+  /* no adjustment */
+}
+```
+
+### Asymmetric Icons (Stars, Arrows, Carets)
+
+Some icons have uneven visual weight. The best fix is adjusting the SVG directly so no extra margin/padding is needed in the component code.
+
+```tsx
+// Best — fix in the SVG itself
+// Adjust the viewBox or path to visually center the icon
+
+// Fallback — adjust with margin
+<span className="ml-px">
+  <StarIcon />
+</span>
+```
+
+## Shadows Instead of Borders
+
+For **buttons, cards, and containers** that use a border for depth or elevation, prefer replacing it with a subtle `box-shadow`. Shadows adapt to any background since they use transparency; solid borders don't. This also helps when using images or multiple colors as backgrounds — solid border colors don't work well on backgrounds other than the ones they were designed for.
+
+**Do not apply this to dividers** (`border-b`, `border-t`, side borders) or any border whose purpose is layout separation rather than element depth. Those should stay as borders.
+
+### Shadow as Border (Light Mode)
+
+The shadow is comprised of three layers. The first acts as a 1px border ring, the second adds subtle lift, and the third provides ambient depth:
+
+```css
+:root {
+  --shadow-border:
+    0px 0px 0px 1px rgba(0, 0, 0, 0.06),
+    0px 1px 2px -1px rgba(0, 0, 0, 0.06),
+    0px 2px 4px 0px rgba(0, 0, 0, 0.04);
+  --shadow-border-hover:
+    0px 0px 0px 1px rgba(0, 0, 0, 0.08),
+    0px 1px 2px -1px rgba(0, 0, 0, 0.08),
+    0px 2px 4px 0px rgba(0, 0, 0, 0.06);
+}
+```
+
+### Shadow as Border (Dark Mode)
+
+In dark mode, simplify to a single white ring — layered depth shadows aren't visible on dark backgrounds:
+
+```css
+/* Dark mode — adapt to whatever setup the project uses
+   (prefers-color-scheme, class, data attribute, etc.) */
+--shadow-border: 0 0 0 1px rgba(255, 255, 255, 0.08);
+--shadow-border-hover: 0 0 0 1px rgba(255, 255, 255, 0.13);
+```
+
+### Usage with Hover Transition
+
+Apply the variable and add `transition-[box-shadow]` for a smooth hover:
+
+```css
+.card {
+  box-shadow: var(--shadow-border);
+  transition-property: box-shadow;
+  transition-duration: 150ms;
+  transition-timing-function: ease-out;
+}
+
+.card:hover {
+  box-shadow: var(--shadow-border-hover);
+}
+```
+
+### When to Use Shadows vs. Borders
+
+| Use shadows | Use borders |
+| --- | --- |
+| Cards, containers with depth | Dividers between list items |
+| Buttons with bordered styles | Table cell boundaries |
+| Elevated elements (dropdowns, modals) | Form input outlines (for accessibility) |
+| Elements on varied backgrounds | Hairline separators in dense UI |
+| Hover/focus states for lift effect | |
+
+## Image Outlines
+
+Add a subtle `1px` outline with low opacity to images. This creates consistent depth, especially in design systems where other elements use borders or shadows.
+
+### Color rules (non-negotiable)
+
+- **Light mode**: pure black — `rgba(0, 0, 0, 0.1)`. Exact values: R=0, G=0, B=0.
+- **Dark mode**: pure white — `rgba(255, 255, 255, 0.1)`. Exact values: R=255, G=255, B=255.
+- Never use a near-black or near-white from the project palette (e.g. slate-900, zinc-900, `#0a0a0a`, `#111827`, `#f5f5f7`). Tinted outlines pick up the surrounding surface color and read as dirt on the image edge.
+- Never match the outline to the project's accent or ink color. The outline is a neutral separator, not a themed element.
+
+### Light Mode
+
+```css
+img {
+  outline: 1px solid rgba(0, 0, 0, 0.1);
+  outline-offset: -1px; /* inset so it doesn't add to layout */
+}
+```
+
+### Dark Mode
+
+```css
+img {
+  outline: 1px solid rgba(255, 255, 255, 0.1);
+  outline-offset: -1px;
+}
+```
+
+### Tailwind with Dark Mode
+
+```tsx
+<img
+  className="outline outline-1 -outline-offset-1 outline-black/10 dark:outline-white/10"
+  src={src}
+  alt={alt}
+/>
+```
+
+Use `outline-black/10` and `outline-white/10` specifically — not `outline-slate-*`, `outline-zinc-*`, `outline-neutral-*`, or any tinted scale.
+
+**Why outline instead of border?** `outline` doesn't affect layout (no added width/height), and `outline-offset: -1px` keeps it inset so images stay their intended size.
+
+## Minimum Hit Area
+
+Interactive elements should have a minimum hit area of 44×44px (WCAG) or at least 40×40px. If the visible element is smaller (e.g., a 20×20 checkbox), extend the hit area with a pseudo-element.
+
+### CSS Example
+
+```css
+/* Small checkbox with expanded hit area */
+.checkbox {
+  position: relative;
+  width: 20px;
+  height: 20px;
+}
+
+.checkbox::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 40px;
+  height: 40px;
+}
+```
+
+### Tailwind Example
+
+```tsx
+<button className="relative size-5 after:absolute after:top-1/2 after:left-1/2 after:size-10 after:-translate-1/2">
+  <CheckIcon />
+</button>
+```
+
+### Collision Rule
+
+If the extended hit area overlaps another interactive element, shrink the pseudo-element — but make it as large as possible without colliding. Two interactive elements should never have overlapping hit areas.

--- a/.agents/skills/make-interfaces-feel-better/typography.md
+++ b/.agents/skills/make-interfaces-feel-better/typography.md
@@ -1,0 +1,135 @@
+# Typography
+
+Typography rendering details that make interfaces feel better.
+
+## Text Wrapping
+
+### text-wrap: balance
+
+Distributes text evenly across lines, preventing orphaned words on headings and short text blocks. **Only works on blocks of 6 lines or fewer** (Chromium) or 10 lines or fewer (Firefox) — the balancing algorithm is computationally expensive, so browsers limit it to short text.
+
+```css
+/* Good — even line lengths on short text */
+h1, h2, h3 {
+  text-wrap: balance;
+}
+```
+
+```css
+/* Bad — default wrapping leaves orphans */
+h1 {
+  /* no text-wrap rule → "Read our
+     blog" instead of balanced lines */
+}
+```
+
+```css
+/* Bad — balance on long paragraphs (silently ignored, wastes intent) */
+.article-body p {
+  text-wrap: balance;
+}
+```
+
+**Tailwind:** `text-balance`
+
+### text-wrap: pretty
+
+Prevents orphaned words (a single word dangling on the last line) by adjusting line breaks throughout the paragraph. Unlike `balance`, it doesn't try to equalize line lengths — it just ensures the last line isn't embarrassingly short. Works on text of any length with no line-count limit.
+
+This should be your **default for short-to-medium text** — paragraphs, descriptions, captions, list items, card text. For very long text (10+ lines), skip both `pretty` and `balance` — the browser's default wrapping is fine and you avoid unnecessary layout cost.
+
+```css
+/* Good — descriptions, captions, short paragraphs */
+p, li, figcaption, blockquote {
+  text-wrap: pretty;
+}
+```
+
+```tsx
+// Tailwind
+<p className="text-pretty">
+  A short paragraph that won't leave an orphan on the last line.
+</p>
+```
+
+**Tailwind:** `text-pretty`
+
+### When to Use Which
+
+| Scenario | Use |
+| --- | --- |
+| Headings, titles where even distribution matters | `text-wrap: balance` |
+| Short-to-medium text — paragraphs, descriptions, captions, UI text | `text-wrap: pretty` |
+| Long text (10+ lines), code blocks, pre-formatted text | Neither — leave default |
+
+## Font Smoothing (macOS)
+
+On macOS, text renders heavier than intended by default. Apply antialiased smoothing to the root layout so all text renders crisper and thinner.
+
+```css
+/* CSS */
+html {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+```
+
+```tsx
+// Tailwind — apply to root layout
+<html className="antialiased">
+```
+
+### Good vs. Bad
+
+```css
+/* Good — applied once at the root */
+html {
+  -webkit-font-smoothing: antialiased;
+}
+
+/* Bad — applied per-element, inconsistent */
+.heading {
+  -webkit-font-smoothing: antialiased;
+}
+.body {
+  /* no smoothing → heavier than heading */
+}
+```
+
+**Note:** This only affects macOS rendering. Other platforms ignore these properties, so it's safe to apply universally.
+
+## Tabular Numbers
+
+When numbers update dynamically (counters, prices, timers, table columns), use tabular-nums to make all digits equal width. This prevents layout shift as values change.
+
+```css
+/* CSS */
+.counter {
+  font-variant-numeric: tabular-nums;
+}
+```
+
+```tsx
+// Tailwind
+<span className="tabular-nums">{count}</span>
+```
+
+### When to Use
+
+| Use tabular-nums | Don't use tabular-nums |
+| --- | --- |
+| Counters and timers | Static display numbers |
+| Prices that update | Decorative large numbers |
+| Table columns with numbers | Phone numbers, zip codes |
+| Animated number transitions | Version numbers (v2.1.0) |
+| Scoreboards, dashboards | |
+
+### Caveat
+
+Some fonts (like Inter) change the visual appearance of numerals with this property — specifically, the digit `1` becomes wider and centered. This is expected behavior and usually desirable for alignment, but verify it looks right in your specific font.
+
+```css
+/* With Inter font:
+   Default:  1234  → proportional, "1" is narrow
+   Tabular:  1234  → all digits equal width, "1" centered */
+```

--- a/.agents/skills/oklch-skill/SKILL.md
+++ b/.agents/skills/oklch-skill/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: oklch-skill
+description: OKLCH color space for web projects. Convert hex/rgb/hsl to oklch, generate palettes, check contrast, handle gamut boundaries, and theme with Tailwind v4. Triggers on oklch, color conversion, palette generation, contrast ratio, gamut, display p3, design tokens, hue drift, chroma, dark mode colors.
+---
+
+# OKLCH Colors
+
+OKLCH is a perceptually uniform color space where the numbers actually mean what you think they mean. Most color problems in CSS — broken palettes, failing contrast, hue drift — come from using color spaces that don't match how we see. OKLCH fixes the model so the tools work. To explore interactively, visit [oklch.fyi](https://oklch.fyi).
+
+## Quick Reference
+
+| Category | When to use | Reference |
+| --- | --- | --- |
+| Conversion | Hex/rgb/hsl to oklch | [color-conversion.md](color-conversion.md) |
+| Palettes | Generate scales, multi-hue, dark mode | [palette-generation.md](palette-generation.md) |
+| Contrast | APCA/WCAG checks, fixing failing contrast | [accessibility-contrast.md](accessibility-contrast.md) |
+| Gamut & Tailwind | P3 fallbacks, `@theme` scales, gamut clamping | [gamut-and-tailwind.md](gamut-and-tailwind.md) |
+
+## Why OKLCH
+
+- **Perceptual uniformity.** Equal L steps = equal brightness. `oklch(0.5 ...)` is visually mid. HSL's `lightness: 50%` varies wildly by hue.
+- **Stable hue.** HSL blue shifts toward purple as lightness changes. OKLCH hue stays constant across the full lightness range.
+- **Independent chroma.** Chroma is an absolute measure of colorfulness that doesn't depend on lightness. HSL saturation does.
+- **Finite gamut.** Not every oklch value maps to a displayable sRGB color. High-chroma values at certain hues will clip — gamut awareness is required.
+
+## OKLCH Syntax
+
+```
+oklch(L C H)
+oklch(L C H / alpha)
+```
+
+| Channel | Range | Description |
+| --- | --- | --- |
+| L (Lightness) | 0–1 | 0 = black, 1 = white. Perceptually uniform. |
+| C (Chroma) | 0–~0.4 | Colorfulness. 0 = gray. Max depends on L and H. |
+| H (Hue) | 0–360 | Hue angle in degrees. |
+| alpha | 0–1 | Optional transparency. Slash syntax. |
+
+```css
+oklch(0.637 0.237 25.331)
+oklch(0.8 0.05 200 / 0.5)
+```
+
+**Formatting:** L and C use 3 decimal places, H uses up to 3. Drop trailing zeros. Format `-0` as `0`. Browser support: Baseline 2023, 96%+ global coverage.
+
+## Key Thresholds
+
+| Rule | Value |
+| --- | --- |
+| Light/dark boundary | L > 0.6 = light background → use dark text |
+| Lightness gap (light bg) | Foreground L < 0.45 when background L > 0.85 |
+| Lightness gap (dark bg) | Foreground L > 0.75 when background L < 0.25 |
+| Hue drift threshold | > 10° spread across palette steps = visible drift |
+| APCA normal text | \|Lc\| >= 60 to pass, >= 75 for pass+ |
+| WCAG 2 normal text | 4.5:1 AA, 7:1 AAA |
+| Contrast fix | Adjust L only — chroma has negligible effect |
+
+## Review Output Format
+
+Always present color changes as a markdown table with **Before** and **After** columns. Include **every color that was changed** — not just a subset. Never list findings as separate "Before:" / "After:" lines outside of a table.
+
+| Before | After |
+| --- | --- |
+| `color: #3b82f6` | `color: oklch(0.623 0.188 259.815)` |
+| Same absolute C across hues | Same C% of each hue's max chroma |
+| No sRGB fallback for P3 color | `@media (color-gamut: p3)` wrapper |
+
+This keeps feedback scannable and diff-friendly. Each row is a self-contained change the developer can act on independently.
+
+## Common Mistakes
+
+| Issue | Fix |
+| --- | --- |
+| Hex/rgb/hsl color in new code | Convert to `oklch()` |
+| HSL palette ramp with hue drift | Rebuild with constant oklch hue |
+| Failing contrast (check foreground vs its background using APCA) | Adjust oklch L channel, keep C and H |
+| High chroma without gamut check | Clamp to max chroma for the L/H in sRGB |
+| Same absolute C across different hues | Use same C% (percentage of max) for consistent vividness |
+| P3 color without sRGB fallback | Add `@media (color-gamut: p3)` pattern |
+| Dark mode with hand-picked colors | Derive from light palette by reversing L mapping |
+| Hex in Tailwind v4 `@theme` | Convert to oklch values |
+| Alpha with comma syntax | Use slash: `oklch(L C H / alpha)` |
+
+## Reference Files
+
+- [color-conversion.md](color-conversion.md) — Supported formats, conversion examples, bulk conversion rules, what to leave alone
+- [palette-generation.md](palette-generation.md) — Scale convention, generation algorithm, multi-hue palettes, dark mode, why not HSL
+- [accessibility-contrast.md](accessibility-contrast.md) — APCA and WCAG 2 thresholds, fixing contrast with L, lightness gap guide, hue drift detection
+- [gamut-and-tailwind.md](gamut-and-tailwind.md) — sRGB vs P3, gamut clamping, CSS fallback patterns, Tailwind v4 @theme and migration

--- a/.agents/skills/oklch-skill/accessibility-contrast.md
+++ b/.agents/skills/oklch-skill/accessibility-contrast.md
@@ -1,0 +1,74 @@
+# Accessibility & Contrast
+
+Contrast is always measured between a **foreground color** (text, icon, or UI element) and the **background color** it sits on. When checking contrast, identify the background the element will be rendered against — typically the nearest parent's background color.
+
+## APCA thresholds (recommended)
+
+APCA (Accessible Perceptual Contrast Algorithm) is more perceptually accurate than WCAG 2 and pairs naturally with oklch since both are grounded in perceptual lightness. Use APCA as the default.
+
+Lc (Lightness Contrast) measures the perceived contrast between foreground and background. These are conservative approximations:
+
+| Content Type | Pass | Pass+ |
+| --- | --- | --- |
+| Normal text | Lc 60 | Lc 75 |
+| Large text | Lc 45 | Lc 60 |
+| UI components | Lc 30 | — |
+
+APCA's Lc value is signed — positive means light text on dark background, negative means dark text on light. Use the absolute value for threshold comparison.
+
+## WCAG 2 thresholds (for legal compliance)
+
+WCAG 2 is still required when making formal WCAG 2.x conformance claims. It uses a luminance ratio that can be both too strict and too lenient depending on the color pair.
+
+| Content Type | AA | AAA |
+| --- | --- | --- |
+| Normal text (<18px / <14px bold) | 4.5:1 | 7:1 |
+| Large text (>=18px / >=14px bold) | 3:1 | 4.5:1 |
+| UI components & graphical objects | 3:1 | — |
+
+## Fixing contrast with oklch
+
+In hex/rgb, fixing contrast means trial and error across three channels. In oklch, contrast is controlled by **lightness (L) alone** — adjust the L distance between the foreground and its background:
+
+```css
+/* Failing: text too close in lightness to its background */
+color: oklch(0.65 0.2 250);       /* foreground */
+background: oklch(0.75 0.05 250); /* background */
+
+/* Fix: darken the text, keep C and H unchanged */
+color: oklch(0.35 0.2 250);       /* foreground — more L distance */
+background: oklch(0.75 0.05 250); /* background — unchanged */
+```
+
+Chroma has negligible effect on contrast — always adjust L, never C.
+
+## Quick lightness gap guide
+
+- **Light background (L > 0.85):** foreground L should be below 0.45
+- **Dark background (L < 0.25):** foreground L should be above 0.75
+
+These are approximations — always verify with an actual contrast calculation.
+
+## Light vs dark color detection
+
+A color is considered light when its oklch lightness exceeds 0.6:
+
+```
+if L > 0.6 → use dark text on this background
+if L <= 0.6 → use light text on this background
+```
+
+## Hue drift detection
+
+To detect hue drift in an existing HSL palette:
+
+1. Convert each step to oklch
+2. Compare the H values across steps
+3. If the hue spread is greater than 10°, the palette has visible drift
+
+```css
+/* HSL blue ramp — hue shifts toward purple */
+hsl(240, 80%, 20%)  →  oklch H ≈ 269
+hsl(240, 80%, 50%)  →  oklch H ≈ 267
+hsl(240, 80%, 90%)  →  oklch H ≈ 285  /* shifted 18° */
+```

--- a/.agents/skills/oklch-skill/color-conversion.md
+++ b/.agents/skills/oklch-skill/color-conversion.md
@@ -1,0 +1,53 @@
+# Color Conversion
+
+When converting existing colors to oklch, convert the color values but leave everything else unchanged — don't change gradient interpolation, don't restructure the CSS.
+
+## Supported input formats
+
+| Format | Examples |
+| --- | --- |
+| Hex (3/6/8-digit) | `#f00`, `#ff0000`, `#ff000080` |
+| `rgb()` / `rgba()` | `rgb(255, 0, 0)`, `rgba(255, 0, 0, 0.5)` |
+| `hsl()` / `hsla()` | `hsl(0, 100%, 50%)`, `hsla(0, 100%, 50%, 0.5)` |
+
+## Conversion examples
+
+```css
+/* Before */
+color: #3b82f6;
+background: #1e293b;
+border-color: #e2e8f0;
+
+/* After */
+color: oklch(0.623 0.188 259.815);
+background: oklch(0.279 0.037 260.031);
+border-color: oklch(0.929 0.013 255.508);
+```
+
+```css
+/* Before */
+color: rgb(59, 130, 246);
+border: 1px solid rgba(0, 0, 0, 0.1);
+
+/* After */
+color: oklch(0.623 0.188 259.815);
+border: 1px solid oklch(0 0 0 / 0.1);
+```
+
+Alpha uses the forward-slash syntax. Omit alpha when it's 1.
+
+## What to leave alone
+
+- CSS keywords: `currentColor`, `inherit`, `initial`, `unset`, `transparent`
+- Gradient interpolation methods — only convert the color stops, not the function itself
+- Colors in third-party library configs that expect hex input
+
+## Bulk conversion
+
+When converting an entire file:
+
+1. Replace all hex colors with their oklch equivalents
+2. Replace all `rgb()`, `rgba()`, `hsl()`, `hsla()` function calls
+3. Leave gradient functions unchanged — only convert the color stops within them
+4. Leave `currentColor`, `inherit`, `transparent`, and CSS keywords as-is
+5. Preserve comments and formatting

--- a/.agents/skills/oklch-skill/gamut-and-tailwind.md
+++ b/.agents/skills/oklch-skill/gamut-and-tailwind.md
@@ -1,0 +1,103 @@
+# Gamut Awareness & Tailwind v4
+
+## sRGB vs Display P3
+
+Every sRGB color exists within Display P3, but not every P3 color exists within sRGB. Display P3 covers ~50% more colors.
+
+## Max chroma varies by lightness and hue
+
+The gamut boundary is irregular. At L=0.5 in sRGB:
+
+- Highest chroma: purple (H ≈ 285) at C ≈ 0.29
+- Red-orange (H ≈ 0-30): C ≈ 0.20
+- Lowest chroma: cyan (H ≈ 195) at C ≈ 0.09
+
+The peak hue shifts with lightness. At L=0.7 magenta peaks, at L=0.9 green peaks. Cyan consistently has the lowest max chroma.
+
+## Gamut checking
+
+If a color's chroma exceeds the maximum for its L/H/space, it clips. The fix: reduce chroma while keeping L and H constant.
+
+```css
+/* Out of sRGB gamut */
+oklch(0.7 0.35 150)
+
+/* Clamped to max chroma */
+oklch(0.7 0.22 150)
+```
+
+## CSS fallback patterns
+
+```css
+/* sRGB fallback for all browsers */
+.accent {
+  color: oklch(0.7 0.2 150);
+}
+
+/* P3 enhancement for wider gamut displays */
+@media (color-gamut: p3) {
+  .accent {
+    color: oklch(0.7 0.3 150);
+  }
+}
+```
+
+For browsers without oklch support:
+
+```css
+.accent {
+  color: #4ade80;
+}
+
+@supports (color: oklch(0 0 0)) {
+  .accent {
+    color: oklch(0.7 0.2 150);
+  }
+
+  @media (color-gamut: p3) {
+    .accent {
+      color: oklch(0.7 0.3 150);
+    }
+  }
+}
+```
+
+## Tailwind v4
+
+Tailwind CSS v4 defines its default palette in oklch. Custom themes should follow the same convention.
+
+### Custom color scale with @theme
+
+```css
+@theme {
+  --color-brand-50: oklch(0.971 0.012 250);
+  --color-brand-100: oklch(0.932 0.028 250);
+  --color-brand-200: oklch(0.882 0.048 250);
+  --color-brand-300: oklch(0.812 0.078 250);
+  --color-brand-400: oklch(0.722 0.148 250);
+  --color-brand-500: oklch(0.623 0.188 250);
+  --color-brand-600: oklch(0.535 0.168 250);
+  --color-brand-700: oklch(0.445 0.138 250);
+  --color-brand-800: oklch(0.362 0.108 250);
+  --color-brand-900: oklch(0.289 0.078 250);
+  --color-brand-950: oklch(0.215 0.048 250);
+}
+```
+
+This gives you `bg-brand-500`, `text-brand-200`, etc. automatically.
+
+### Opacity modifiers
+
+Tailwind's opacity modifier syntax works with oklch:
+
+```html
+<div class="bg-brand-500/50"></div>
+<!-- Compiles to: oklch(0.623 0.188 250 / 0.5) -->
+```
+
+### Migrating existing themes
+
+1. Convert all hex values in `@theme` to oklch
+2. Replace any `theme()` references that used hex
+3. Test dark mode — oklch values may look slightly different due to perceptual accuracy
+4. Check for hardcoded hex in component code and convert those too

--- a/.agents/skills/oklch-skill/palette-generation.md
+++ b/.agents/skills/oklch-skill/palette-generation.md
@@ -1,0 +1,93 @@
+# Palette Generation
+
+## The scale convention
+
+Design system palettes use a numeric scale from 50 (lightest) to 950 (darkest). The standard labels by palette size:
+
+| Size | Labels |
+| --- | --- |
+| 5 | 100, 300, 500, 700, 900 |
+| 9 | 50, 100, 200, 300, 500, 700, 800, 900, 950 |
+| 11 | 50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950 |
+
+9 steps is the standard default (matches Tailwind).
+
+## Algorithm
+
+Given a base color with lightness (L), chroma percentage, and hue (H):
+
+**Step 1 — Lightness bounds:**
+
+```
+delta = 0.4
+minL = max(0.05, baseL - delta)
+maxL = min(0.95, baseL + delta)
+```
+
+Lightness is clamped to [0.05, 0.95] to avoid pure black/white which have zero chroma.
+
+**Step 2 — Distribute lightness** evenly from maxL (lightest, label 50) to minL (darkest, label 950).
+
+**Step 3 — Clamp chroma per step.** Each lightness level has a different maximum chroma for a given hue and color space:
+
+```
+maxChroma = findMaxChroma(step[i].L, hue, colorSpace)
+step[i].C = (chromaPercentage / 100) * maxChroma
+```
+
+This ensures every step is within gamut. High-chroma base colors will have lower chroma at the lightest and darkest ends — this is correct and expected.
+
+## CSS variable output
+
+```css
+:root {
+  --color-50: oklch(0.971 0.012 250);
+  --color-100: oklch(0.932 0.028 250);
+  --color-200: oklch(0.882 0.048 250);
+  --color-300: oklch(0.812 0.078 250);
+  --color-500: oklch(0.623 0.188 250);
+  --color-700: oklch(0.445 0.138 250);
+  --color-800: oklch(0.362 0.108 250);
+  --color-900: oklch(0.289 0.078 250);
+  --color-950: oklch(0.215 0.048 250);
+}
+```
+
+## Multi-hue palettes
+
+When generating palettes for multiple hues, use the same **lightness** and **chroma percentage** for all. Same L guarantees equal perceived brightness. Same chroma percentage (not absolute chroma) guarantees equal vividness relative to each hue's maximum.
+
+```css
+:root {
+  /* Same L, same C% (80% of max) — different absolute C per hue */
+  --blue-500: oklch(0.623 0.141 250);   /* 80% of max 0.176 */
+  --green-500: oklch(0.623 0.157 145);  /* 80% of max 0.196 */
+  --red-500: oklch(0.623 0.202 25);     /* 80% of max 0.253 */
+}
+```
+
+Different hues have different max chroma at the same lightness. Using the same absolute C value across hues would make some appear more vivid than others.
+
+## Dark mode
+
+Reverse the palette mapping so that the lightest step becomes the darkest and vice versa:
+
+```css
+:root {
+  --color-bg: var(--color-50);
+  --color-text: var(--color-950);
+}
+
+.dark {
+  --color-bg: var(--color-950);
+  --color-text: var(--color-50);
+}
+```
+
+This works because oklch's perceptual uniformity means equal L steps in both directions produce equally readable results.
+
+## Why not HSL palettes?
+
+**Hue drift:** `hsl(240, 80%, 20%)` and `hsl(240, 80%, 90%)` are not the same perceptual hue. The light variant shifts ~18° toward purple. OKLCH hue is stable.
+
+**Brightness inconsistency:** `hsl(60, 100%, 50%)` (yellow) and `hsl(240, 100%, 50%)` (blue) have the same HSL lightness but wildly different perceived brightness.

--- a/.claude/skills/make-interfaces-feel-better
+++ b/.claude/skills/make-interfaces-feel-better
@@ -1,0 +1,1 @@
+../../.agents/skills/make-interfaces-feel-better

--- a/.claude/skills/oklch-skill
+++ b/.claude/skills/oklch-skill
@@ -1,0 +1,1 @@
+../../.agents/skills/oklch-skill

--- a/apps/docs/src/app/docs/_components/docs-header.tsx
+++ b/apps/docs/src/app/docs/_components/docs-header.tsx
@@ -15,7 +15,11 @@ import { ThemeToggle } from "./theme-toggle";
 const iconButton =
   "inline-flex size-9 items-center justify-center rounded-full text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground";
 
-export function DocsHeader({ className, ...props }: ComponentProps<"header">) {
+export function DocsHeader({
+  className,
+  showSidebarTrigger = true,
+  ...props
+}: ComponentProps<"header"> & { showSidebarTrigger?: boolean }) {
   return (
     <header
       id="nd-nav"
@@ -52,13 +56,16 @@ export function DocsHeader({ className, ...props }: ComponentProps<"header">) {
           className={cn(iconButton, "md:hidden")}
         />
         <ThemeToggle />
-        {/* Mobile: open the sidenav drawer */}
-        <SidebarTrigger
-          aria-label="Open menu"
-          className={cn(iconButton, "md:hidden")}
-        >
-          <Menu className="size-5" />
-        </SidebarTrigger>
+        {/* Mobile: open the sidenav drawer (only when inside DocsLayout, which
+            provides SidebarContext — the home page has no sidebar) */}
+        {showSidebarTrigger ? (
+          <SidebarTrigger
+            aria-label="Open menu"
+            className={cn(iconButton, "md:hidden")}
+          >
+            <Menu className="size-5" />
+          </SidebarTrigger>
+        ) : null}
       </div>
     </header>
   );

--- a/apps/docs/src/app/globals.css
+++ b/apps/docs/src/app/globals.css
@@ -24,11 +24,11 @@
   --color-fd-accent-foreground: var(--color-accent-foreground);
   --color-fd-ring: var(--color-ring);
   --color-fd-overlay: hsla(0, 0%, 0%, 0.2);
-  --color-fd-info: oklch(62.3% 0.214 259.815);
-  --color-fd-warning: oklch(76.9% 0.188 70.08);
+  --color-fd-info: oklch(62.3% 0.204 259.815);
+  --color-fd-warning: oklch(76.9% 0.167 70.08);
   --color-fd-error: oklch(63.7% 0.237 25.331);
-  --color-fd-success: oklch(72.3% 0.219 149.579);
-  --color-fd-idea: oklch(70.5% 0.209 60.849);
+  --color-fd-success: oklch(72.3% 0.201 149.579);
+  --color-fd-idea: oklch(70.5% 0.164 60.849);
   --color-fd-diff-remove: rgba(200, 10, 100, 0.12);
   --color-fd-diff-remove-symbol: rgb(230, 10, 100);
   --color-fd-diff-add: rgba(14, 180, 100, 0.1);
@@ -46,10 +46,27 @@ body {
   font-family: var(--font-sans);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  text-wrap: pretty;
 }
 
 * {
   box-sizing: border-box;
+}
+
+/* Wide-gamut (P3) displays — restore the richer fd-* status hues; the
+   sRGB-clamped values in @theme above remain the fallback. */
+@media (color-gamut: p3) {
+  :root {
+    --color-fd-info: oklch(62.3% 0.214 259.815);
+    --color-fd-warning: oklch(76.9% 0.188 70.08);
+    --color-fd-success: oklch(72.3% 0.219 149.579);
+    --color-fd-idea: oklch(70.5% 0.188 60.849);
+  }
+}
+
+/* Balance docs prose headings */
+.prose :is(h1, h2, h3) {
+  text-wrap: balance;
 }
 
 @layer base {

--- a/apps/docs/src/app/page.tsx
+++ b/apps/docs/src/app/page.tsx
@@ -43,7 +43,7 @@ export default function Home() {
           WebkitMaskComposite: "source-in",
         }}
       />
-      <DocsHeader className="border-transparent" />
+      <DocsHeader className="border-transparent" showSidebarTrigger={false} />
       <section className="relative z-10 flex flex-1 flex-col items-center justify-center gap-8 px-4 text-center">
         <h1 className="max-w-3xl text-balance font-semibold text-4xl text-fd-foreground tracking-tight sm:text-5xl md:text-6xl">
           UI collection for Design Engineers

--- a/packages/components/styles.css
+++ b/packages/components/styles.css
@@ -1257,7 +1257,7 @@
   /* Pointer press + keyboard activation (Enter/Space) share a press cue */
   .mask-button:active:not(:disabled),
   .mask-button[data-pressed="true"]:not(:disabled) {
-    transform: scale(0.97);
+    transform: scale(0.96);
   }
 
   .mask-button:disabled {

--- a/packages/components/theme/dark.css
+++ b/packages/components/theme/dark.css
@@ -12,7 +12,7 @@
     --popover-foreground: oklch(0.96 0.008 266);
 
     /* Brand — luminous Celestial Sapphire */
-    --primary: oklch(0.72 0.15 266);
+    --primary: oklch(0.72 0.145 266);
     --primary-foreground: oklch(0.18 0.04 266);
 
     /* Heavenly Gold on dusk violet */
@@ -33,32 +33,32 @@
     /* Inputs */
     --border: oklch(0.28 0.02 266);
     --input: oklch(0.265 0.02 266);
-    --ring: oklch(0.72 0.15 266);
+    --ring: oklch(0.72 0.145 266);
 
     /* Charts — angelic spectrum */
-    --chart-1: oklch(0.71 0.16 266);
+    --chart-1: oklch(0.71 0.15 266);
     --chart-2: oklch(0.84 0.13 90);
     --chart-3: oklch(0.84 0.1 185);
     --chart-4: oklch(0.74 0.16 305);
-    --chart-5: oklch(0.8 0.12 14);
+    --chart-5: oklch(0.8 0.116 14);
 
     /* Sidebar */
     --sidebar: oklch(0.18 0.026 266);
     --sidebar-foreground: oklch(0.96 0.008 266);
 
-    --sidebar-primary: oklch(0.72 0.15 266);
+    --sidebar-primary: oklch(0.72 0.145 266);
     --sidebar-primary-foreground: oklch(0.18 0.04 266);
 
     --sidebar-accent: oklch(0.3 0.045 266);
     --sidebar-accent-foreground: oklch(0.85 0.055 266);
 
     --sidebar-border: oklch(0.265 0.02 266);
-    --sidebar-ring: oklch(0.72 0.15 266);
+    --sidebar-ring: oklch(0.72 0.145 266);
 
     /* Syntax Highlighting */
     --syntax-plain: oklch(0.935 0.01 266);
     --syntax-punctuation: oklch(0.65 0.02 266);
-    --syntax-keyword: oklch(0.78 0.14 302);
+    --syntax-keyword: oklch(0.78 0.135 302);
     --syntax-property: oklch(0.83 0.12 90);
     --syntax-string: oklch(0.8 0.13 168);
     --syntax-comment: oklch(0.58 0.02 266);
@@ -71,7 +71,7 @@
 
     /* Inline code */
     --inline-code-bg: oklch(0.28 0.038 266);
-    --inline-code-fg: oklch(0.86 0.08 266);
+    --inline-code-fg: oklch(0.86 0.068 266);
     --inline-code-border: oklch(0.36 0.04 266);
 
     /* Search */
@@ -79,17 +79,17 @@
     --search-fg: oklch(0.885 0.01 266);
     --search-border: oklch(0.28 0.02 266);
     --search-kbd-bg: oklch(0.28 0.024 266);
-    --search-kbd-fg: oklch(0.86 0.08 266);
+    --search-kbd-fg: oklch(0.86 0.068 266);
     --search-placeholder: oklch(0.62 0.02 266);
     --search-highlight-bg: oklch(0.38 0.1 266);
-    --search-highlight-fg: oklch(0.97 0.025 266);
+    --search-highlight-fg: oklch(0.97 0.014 266);
 
     /* Theme panel */
     --theme-panel-bg: oklch(0.195 0.026 266);
     --theme-panel-border: oklch(0.28 0.02 266);
     --theme-panel-fg: oklch(0.65 0.02 266);
     --theme-panel-active-bg: oklch(0.28 0.038 266);
-    --theme-panel-active-fg: oklch(0.72 0.15 266);
+    --theme-panel-active-fg: oklch(0.72 0.145 266);
 
     /* Shadows */
     --shadow-2xs: 0 1px 2px rgb(0 0 0 / 0.12);
@@ -133,19 +133,19 @@
     /* GOD UI Brand — sapphire → light → divine gold */
     --god-gradient: linear-gradient(
       135deg,
-      oklch(0.72 0.15 266) 0%,
+      oklch(0.72 0.145 266) 0%,
       oklch(1 0 0) 50%,
       oklch(0.86 0.12 90) 100%
     );
 
     --god-glow:
-      0 0 24px oklch(0.72 0.15 266 / 0.28),
+      0 0 24px oklch(0.72 0.145 266 / 0.28),
       0 0 80px oklch(0.86 0.12 90 / 0.12);
 
-    --rainbow-1: oklch(0.72 0.15 266);
+    --rainbow-1: oklch(0.72 0.145 266);
     --rainbow-2: oklch(0.74 0.16 305);
     --rainbow-3: oklch(0.84 0.1 185);
-    --rainbow-4: oklch(0.8 0.12 14);
+    --rainbow-4: oklch(0.8 0.116 14);
     --rainbow-5: oklch(0.84 0.13 90);
 
     --rainbow-speed: 2s;
@@ -162,7 +162,7 @@
   --popover: oklch(0.235 0.028 266);
   --popover-foreground: oklch(0.96 0.008 266);
 
-  --primary: oklch(0.72 0.15 266);
+  --primary: oklch(0.72 0.145 266);
   --primary-foreground: oklch(0.18 0.04 266);
 
   --secondary: oklch(0.275 0.038 290);
@@ -178,29 +178,29 @@
 
   --border: oklch(0.28 0.02 266);
   --input: oklch(0.265 0.02 266);
-  --ring: oklch(0.72 0.15 266);
+  --ring: oklch(0.72 0.145 266);
 
-  --chart-1: oklch(0.71 0.16 266);
+  --chart-1: oklch(0.71 0.15 266);
   --chart-2: oklch(0.84 0.13 90);
   --chart-3: oklch(0.84 0.1 185);
   --chart-4: oklch(0.74 0.16 305);
-  --chart-5: oklch(0.8 0.12 14);
+  --chart-5: oklch(0.8 0.116 14);
 
   --sidebar: oklch(0.18 0.026 266);
   --sidebar-foreground: oklch(0.96 0.008 266);
 
-  --sidebar-primary: oklch(0.72 0.15 266);
+  --sidebar-primary: oklch(0.72 0.145 266);
   --sidebar-primary-foreground: oklch(0.18 0.04 266);
 
   --sidebar-accent: oklch(0.3 0.045 266);
   --sidebar-accent-foreground: oklch(0.85 0.055 266);
 
   --sidebar-border: oklch(0.265 0.02 266);
-  --sidebar-ring: oklch(0.72 0.15 266);
+  --sidebar-ring: oklch(0.72 0.145 266);
 
   --syntax-plain: oklch(0.935 0.01 266);
   --syntax-punctuation: oklch(0.65 0.02 266);
-  --syntax-keyword: oklch(0.78 0.14 302);
+  --syntax-keyword: oklch(0.78 0.135 302);
   --syntax-property: oklch(0.83 0.12 90);
   --syntax-string: oklch(0.8 0.13 168);
   --syntax-comment: oklch(0.58 0.02 266);
@@ -211,23 +211,23 @@
   --code-block-border: oklch(0.26 0.02 266);
 
   --inline-code-bg: oklch(0.28 0.038 266);
-  --inline-code-fg: oklch(0.86 0.08 266);
+  --inline-code-fg: oklch(0.86 0.068 266);
   --inline-code-border: oklch(0.36 0.04 266);
 
   --search-bg: oklch(0.195 0.026 266);
   --search-fg: oklch(0.885 0.01 266);
   --search-border: oklch(0.28 0.02 266);
   --search-kbd-bg: oklch(0.28 0.024 266);
-  --search-kbd-fg: oklch(0.86 0.08 266);
+  --search-kbd-fg: oklch(0.86 0.068 266);
   --search-placeholder: oklch(0.62 0.02 266);
   --search-highlight-bg: oklch(0.38 0.1 266);
-  --search-highlight-fg: oklch(0.97 0.025 266);
+  --search-highlight-fg: oklch(0.97 0.014 266);
 
   --theme-panel-bg: oklch(0.195 0.026 266);
   --theme-panel-border: oklch(0.28 0.02 266);
   --theme-panel-fg: oklch(0.65 0.02 266);
   --theme-panel-active-bg: oklch(0.28 0.038 266);
-  --theme-panel-active-fg: oklch(0.72 0.15 266);
+  --theme-panel-active-fg: oklch(0.72 0.145 266);
 
   --shadow-2xs: 0 1px 2px rgb(0 0 0 / 0.12);
   --shadow-xs: 0 1px 3px rgb(0 0 0 / 0.15);
@@ -260,19 +260,57 @@
 
   --god-gradient: linear-gradient(
     135deg,
-    oklch(0.72 0.15 266) 0%,
+    oklch(0.72 0.145 266) 0%,
     oklch(1 0 0) 50%,
     oklch(0.86 0.12 90) 100%
   );
 
   --god-glow:
-    0 0 24px oklch(0.72 0.15 266 / 0.28),
+    0 0 24px oklch(0.72 0.145 266 / 0.28),
     0 0 80px oklch(0.86 0.12 90 / 0.12);
 
-  --rainbow-1: oklch(0.72 0.15 266);
+  --rainbow-1: oklch(0.72 0.145 266);
   --rainbow-2: oklch(0.74 0.16 305);
   --rainbow-3: oklch(0.84 0.1 185);
-  --rainbow-4: oklch(0.8 0.12 14);
+  --rainbow-4: oklch(0.8 0.116 14);
   --rainbow-5: oklch(0.84 0.13 90);
   --rainbow-speed: 2s;
+}
+
+/* Wide-gamut (P3) displays — restore the fuller chroma these tokens were
+   authored with; the sRGB-clamped values above remain the fallback. */
+@media (color-gamut: p3) {
+  @media (prefers-color-scheme: dark) {
+    :root:not(.light) {
+      --primary: oklch(0.72 0.15 266);
+      --ring: oklch(0.72 0.15 266);
+      --chart-1: oklch(0.71 0.16 266);
+      --chart-5: oklch(0.8 0.12 14);
+      --sidebar-primary: oklch(0.72 0.15 266);
+      --sidebar-ring: oklch(0.72 0.15 266);
+      --syntax-keyword: oklch(0.78 0.14 302);
+      --inline-code-fg: oklch(0.86 0.075 266);
+      --search-kbd-fg: oklch(0.86 0.075 266);
+      --search-highlight-fg: oklch(0.97 0.016 266);
+      --theme-panel-active-fg: oklch(0.72 0.15 266);
+      --rainbow-1: oklch(0.72 0.15 266);
+      --rainbow-4: oklch(0.8 0.12 14);
+    }
+  }
+
+  .dark {
+    --primary: oklch(0.72 0.15 266);
+    --ring: oklch(0.72 0.15 266);
+    --chart-1: oklch(0.71 0.16 266);
+    --chart-5: oklch(0.8 0.12 14);
+    --sidebar-primary: oklch(0.72 0.15 266);
+    --sidebar-ring: oklch(0.72 0.15 266);
+    --syntax-keyword: oklch(0.78 0.14 302);
+    --inline-code-fg: oklch(0.86 0.075 266);
+    --search-kbd-fg: oklch(0.86 0.075 266);
+    --search-highlight-fg: oklch(0.97 0.016 266);
+    --theme-panel-active-fg: oklch(0.72 0.15 266);
+    --rainbow-1: oklch(0.72 0.15 266);
+    --rainbow-4: oklch(0.8 0.12 14);
+  }
 }

--- a/packages/components/theme/light.css
+++ b/packages/components/theme/light.css
@@ -16,11 +16,11 @@
   --primary-foreground: oklch(1 0 0);
 
   /* Heavenly Gold */
-  --secondary: oklch(0.97 0.04 90);
+  --secondary: oklch(0.97 0.038 90);
   --secondary-foreground: oklch(0.42 0.09 80);
 
   /* Celestial Accent */
-  --accent: oklch(0.965 0.025 266);
+  --accent: oklch(0.965 0.016 266);
   --accent-foreground: oklch(0.46 0.155 266);
 
   /* Neutral */
@@ -49,7 +49,7 @@
   --sidebar-primary: oklch(0.55 0.19 266);
   --sidebar-primary-foreground: oklch(1 0 0);
 
-  --sidebar-accent: oklch(0.97 0.018 266);
+  --sidebar-accent: oklch(0.97 0.014 266);
   --sidebar-accent-foreground: oklch(0.46 0.155 266);
 
   --sidebar-border: oklch(0.925 0.01 266);
@@ -120,12 +120,12 @@
   --syntax-punctuation: oklch(0.54 0.022 266);
   --syntax-keyword: oklch(0.52 0.19 302);
   --syntax-property: oklch(0.56 0.11 90);
-  --syntax-string: oklch(0.52 0.13 168);
+  --syntax-string: oklch(0.52 0.106 168);
   --syntax-comment: oklch(0.63 0.016 266);
-  --syntax-number: oklch(0.54 0.13 235);
+  --syntax-number: oklch(0.54 0.115 235);
 
   /* Inline code */
-  --inline-code-bg: oklch(0.955 0.028 266);
+  --inline-code-bg: oklch(0.955 0.021 266);
   --inline-code-fg: oklch(0.46 0.165 266);
   --inline-code-border: oklch(0.82 0.07 266);
 
@@ -141,14 +141,14 @@
   --search-kbd-bg: oklch(0.965 0.006 266);
   --search-kbd-fg: oklch(0.2 0.036 266);
   --search-placeholder: oklch(0.54 0.022 266);
-  --search-highlight-bg: oklch(0.89 0.085 266);
+  --search-highlight-bg: oklch(0.89 0.053 266);
   --search-highlight-fg: oklch(0.34 0.13 266);
 
   /* Theme panel */
   --theme-panel-bg: oklch(1 0 0);
   --theme-panel-border: oklch(0.89 0.011 266);
   --theme-panel-fg: oklch(0.4 0.022 266);
-  --theme-panel-active-bg: oklch(0.955 0.028 266);
+  --theme-panel-active-bg: oklch(0.955 0.021 266);
   --theme-panel-active-fg: oklch(0.46 0.165 266);
 
   /* Z-index */
@@ -202,4 +202,20 @@
   --rainbow-5: oklch(0.8 0.13 90);
 
   --rainbow-speed: 2s;
+}
+
+/* Wide-gamut (P3) displays — restore the fuller chroma these tokens were
+   authored with; the sRGB-clamped values above remain the fallback. */
+@media (color-gamut: p3) {
+  :root,
+  .light {
+    --secondary: oklch(0.97 0.04 90);
+    --accent: oklch(0.965 0.018 266);
+    --sidebar-accent: oklch(0.97 0.016 266);
+    --inline-code-bg: oklch(0.955 0.023 266);
+    --theme-panel-active-bg: oklch(0.955 0.023 266);
+    --search-highlight-bg: oklch(0.89 0.058 266);
+    --syntax-string: oklch(0.52 0.13 168);
+    --syntax-number: oklch(0.54 0.13 235);
+  }
 }

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "skills": {
+    "make-interfaces-feel-better": {
+      "source": "jakubkrehel/make-interfaces-feel-better",
+      "sourceType": "github",
+      "skillPath": "skills/make-interfaces-feel-better/SKILL.md",
+      "computedHash": "54b6e221bbe4e2d1a8461c3f9ecabe69daf891f964e9ee5e699c323daa018f2e"
+    },
+    "oklch-skill": {
+      "source": "jakubkrehel/oklch-skill",
+      "sourceType": "github",
+      "skillPath": "skills/oklch-skill/SKILL.md",
+      "computedHash": "3825dcd7ea094655e9f07280185ba9da1d10d08f44cf06a8c316eb42334d7cd3"
+    }
+  }
+}


### PR DESCRIPTION
Adds the `make-interfaces-feel-better` and `oklch-skill` skill packages (`.agents/skills`, `.claude` symlinks, `skills-lock.json`) and applies a review pass against both. Theme color tokens that fell outside sRGB are clamped to their in-gamut max chroma (L/H preserved), with a `@media (color-gamut: p3)` block restoring the richer chroma on wide-gamut displays (`light.css`, `dark.css`, and `fd-*` tokens in `globals.css`). Smaller polish: mask-button press scale `0.97`→`0.96`, `text-wrap: pretty` on body and `balance` on docs prose headings. Also fixes a pre-existing crash where the home page rendered `DocsHeader` whose mobile `SidebarTrigger` requires `SidebarContext` (only provided by `DocsLayout`) — gated behind a `showSidebarTrigger` prop so `/` prerenders again. Verified with a full `pnpm --filter docs build` (19/19 static pages, 0 sRGB gamut clips in base tokens).