### PR TITLE
feat(components): add AuroraText, rename GoDUI to GodUI

### DIFF
--- a/.agents/skills/godui-component-creation/SKILL.md
+++ b/.agents/skills/godui-component-creation/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: godui-component-creation
-description: Create new components for the GoDUI design system in @godui/components. Use when adding a component, fixing missing Tailwind styles on components, wiring Storybook stories, or writing docs pages with ComponentPreview and ComponentInstall.
+description: Create new components for the GodUI design system in @godui/components. Use when adding a component, fixing missing Tailwind styles on components, wiring Storybook stories, or writing docs pages with ComponentPreview and ComponentInstall.
 ---
 
-# GoDUI Component Creation
+# GodUI Component Creation
 
 Follow this workflow when adding a component to `@godui/components`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# GoDUI — Agent Rules
+# GodUI — Agent Rules
 
-GoDUI is a design system monorepo (**pnpm + Turbo**): `@godui/components` (`packages/components`), docs (`apps/docs`, Next.js + Fumadocs), and Storybook (`apps/storybook`).
+GodUI is a design system monorepo (**pnpm + Turbo**): `@godui/components` (`packages/components`), docs (`apps/docs`, Next.js + Fumadocs), and Storybook (`apps/storybook`).
 
 Skills live in `.agents/skills/` (`.claude/skills` and `.cursor/skills` symlink to it). Read the relevant SKILL.md **before** starting the matching task.
 

--- a/apps/docs/content/docs/components/index.mdx
+++ b/apps/docs/content/docs/components/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Components
-description: Browse the full GoDUI component collection.
+description: Browse the full GodUI component collection.
 ---
 
 import { Cards, Card } from "fumadocs-ui/components/card";

--- a/apps/docs/content/docs/components/text/aurora-text.mdx
+++ b/apps/docs/content/docs/components/text/aurora-text.mdx
@@ -1,0 +1,73 @@
+---
+title: Aurora Text
+description: Gradient text with a rainbow aurora that drifts across the letters.
+---
+
+import { AuroraText } from "@godui/components";
+
+<ComponentPreview
+  code={`import { AuroraText } from "@/components/godui/aurora-text";
+
+export function AuroraTextDemo() {
+  return (
+    <h1 className="text-6xl font-bold tracking-tight">
+      Ship <AuroraText>beautiful</AuroraText> UI
+    </h1>
+  );
+}`}
+>
+  <h1 className="text-6xl font-bold tracking-tight">
+    Ship <AuroraText>beautiful</AuroraText> UI
+  </h1>
+</ComponentPreview>
+
+## Installation
+
+<ComponentInstall componentName="AuroraText" />
+
+AuroraText clips an animated gradient to the text via `background-clip: text`.
+The animation is CSS-only and respects `prefers-reduced-motion` — no font or
+JavaScript animation dependency required.
+
+## Usage
+
+```tsx
+import { AuroraText } from "@/components/godui/aurora-text";
+```
+
+`AuroraText` is an inline `<span>`, so it inherits the surrounding font size and
+weight. Wrap it inside a heading and style that parent:
+
+```tsx
+<h1 className="text-6xl font-bold tracking-tight">
+  Ship <AuroraText>beautiful</AuroraText> UI
+</h1>
+```
+
+### Custom colors
+
+Pass any list of CSS colors. The aurora loops back to the first stop for a
+seamless cycle, so two or three colors are enough.
+
+```tsx
+<AuroraText colors={["#ff512f", "#dd2476", "#ff512f"]}>Sunset</AuroraText>
+```
+
+### Speed
+
+`speed` is a multiplier — `1` is roughly a 10s cycle, higher is faster.
+
+```tsx
+<AuroraText speed={3}>Lightspeed</AuroraText>
+```
+
+## Props
+
+| Prop       | Type       | Default            | Description                                              |
+| ---------- | ---------- | ------------------ | -------------------------------------------------------- |
+| `children` | `ReactNode`| —                  | Text to render with the aurora gradient.                 |
+| `colors`   | `string[]` | Rainbow spectrum   | Gradient stops the aurora cycles through.                |
+| `speed`    | `number`   | `1`                | Speed multiplier; `1` ≈ 10s per cycle, higher is faster. |
+
+`AuroraText` also forwards every standard `<span>` attribute (`className`,
+`style`, `id`, …) to the root element.

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -6,7 +6,7 @@ description: A UI collection of open-source animated components for Design Engin
 import { Cards, Card } from "fumadocs-ui/components/card";
 import { MagicButton } from "@godui/components";
 
-**GoDUI** is a collection of open-source, animated UI components for Design
+**GodUI** is a collection of open-source, animated UI components for Design
 Engineers. Built with **React**, **TypeScript**, **Tailwind CSS v4**, and
 **Motion**, and distributed as a [shadcn](https://ui.shadcn.com) registry — so
 the components are copied straight into your project and you own every line.

--- a/apps/docs/content/docs/installation.mdx
+++ b/apps/docs/content/docs/installation.mdx
@@ -1,9 +1,9 @@
 ---
 title: Installation
-description: Install GoDUI components with the shadcn CLI.
+description: Install GodUI components with the shadcn CLI.
 ---
 
-GoDUI is a design system built with Tailwind CSS v4 and React, distributed as a
+GodUI is a design system built with Tailwind CSS v4 and React, distributed as a
 [shadcn](https://ui.shadcn.com) registry. Components are copied straight into
 your project — you own the source.
 
@@ -19,7 +19,7 @@ Run the `init` command to create a new project or to set up an existing one:
 pnpm dlx shadcn@latest init
 ```
 
-## 2. Add the GoDUI registry
+## 2. Add the GodUI registry
 
 Add the `@godui` namespace to the `registries` field of your
 `components.json` (one-time setup):
@@ -34,13 +34,13 @@ Add the `@godui` namespace to the `registries` field of your
 
 ## 3. Add components
 
-You can now add any GoDUI component by name:
+You can now add any GodUI component by name:
 
 ```bash
 pnpm dlx shadcn@latest add @godui/magic-button
 ```
 
-This copies the component into `components/godui/` and merges the GoDUI theme
+This copies the component into `components/godui/` and merges the GodUI theme
 tokens and component styles into your global stylesheet automatically.
 
 > Prefer zero configuration? Skip step 2 and install with the full registry URL:
@@ -48,7 +48,7 @@ tokens and component styles into your global stylesheet automatically.
 
 ## Typography (bring your own font)
 
-GoDUI is font-agnostic. The theme ships a neutral system font stack as the
+GodUI is font-agnostic. The theme ships a neutral system font stack as the
 default, so components look right with zero setup. To use any font, override
 `--font-sans` (and optionally `--font-mono` / `--font-serif`) in your global
 stylesheet — everything inherits it.
@@ -59,7 +59,7 @@ stylesheet — everything inherits it.
 }
 ```
 
-### Optional: Geist (the GoDUI brand font)
+### Optional: Geist (the GodUI brand font)
 
 The docs site uses [Geist](https://vercel.com/font). To match it in a Next.js
 app, install `geist` and point `--font-sans` / `--font-mono` at its variables:

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -1,5 +1,5 @@
 {
-  "title": "GoDUI",
+  "title": "GodUI",
   "pages": [
     "---Getting Started---",
     "index",
@@ -14,6 +14,7 @@
     "---Inputs---",
     "components/inputs/magic-input",
     "---Text---",
+    "components/text/aurora-text",
     "components/text/elastic-text",
     "components/text/text-animate",
     "components/text/highlighter",

--- a/apps/docs/public/r/aurora-text.json
+++ b/apps/docs/public/r/aurora-text.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "aurora-text",
+  "title": "Aurora Text",
+  "description": "Gradient text with a rainbow aurora that drifts across the letters.",
+  "registryDependencies": ["@godui/godui-theme"],
+  "files": [
+    {
+      "path": "packages/components/src/aurora-text/aurora-text.tsx",
+      "content": "\"use client\";\n\nimport * as React from \"react\";\n\nexport type AuroraTextProps = React.HTMLAttributes<HTMLSpanElement> & {\n  children: React.ReactNode;\n  /** Gradient stops the aurora cycles through. Defaults to a rainbow spectrum. */\n  colors?: string[];\n  /** Speed multiplier — `1` ≈ 10s per cycle, higher is faster. */\n  speed?: number;\n};\n\n// Full-spectrum rainbow, looped back to the first stop for a seamless cycle.\nconst RAINBOW_COLORS = [\n  \"#ff2d55\",\n  \"#ff9500\",\n  \"#ffd60a\",\n  \"#34c759\",\n  \"#00c7be\",\n  \"#0a84ff\",\n  \"#5e5ce6\",\n  \"#bf5af2\",\n];\n\nconst AuroraText = React.forwardRef<HTMLSpanElement, AuroraTextProps>(\n  (\n    {\n      children,\n      className,\n      colors = RAINBOW_COLORS,\n      speed = 1,\n      style,\n      ...props\n    },\n    ref,\n  ) => {\n    const stops = [...colors, colors[0]].join(\", \");\n\n    return (\n      <span\n        ref={ref}\n        data-slot=\"aurora-text\"\n        className={`relative inline-block ${className ?? \"\"}`}\n        {...props}\n      >\n        <span className=\"sr-only\">{children}</span>\n        <span\n          aria-hidden=\"true\"\n          className=\"animate-aurora-text bg-[length:200%_auto] bg-clip-text text-transparent motion-reduce:animate-none\"\n          style={\n            {\n              backgroundImage: `linear-gradient(135deg, ${stops})`,\n              \"--aurora-text-speed\": `${10 / speed}s`,\n              ...style,\n            } as React.CSSProperties\n          }\n        >\n          {children}\n        </span>\n      </span>\n    );\n  },\n);\nAuroraText.displayName = \"AuroraText\";\n\nexport { AuroraText };\n",
+      "type": "registry:ui",
+      "target": "components/godui/aurora-text.tsx"
+    }
+  ],
+  "cssVars": {
+    "theme": {
+      "animate-aurora-text": "aurora-text var(--aurora-text-speed, 10s) infinite linear"
+    }
+  },
+  "css": {
+    "@keyframes aurora-text": {
+      "0%": {
+        "background-position": "0% 50%"
+      },
+      "50%": {
+        "background-position": "100% 50%"
+      },
+      "100%": {
+        "background-position": "0% 50%"
+      }
+    }
+  },
+  "type": "registry:ui"
+}

--- a/apps/docs/public/r/godui-theme.json
+++ b/apps/docs/public/r/godui-theme.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "godui-theme",
-  "title": "GoDUI Theme",
-  "description": "Celestial Sapphire design tokens (OKLCH) — colors, radius, fonts, shadows, button scale, and rainbow tokens shared by all GoDUI components.",
+  "title": "GodUI Theme",
+  "description": "Celestial Sapphire design tokens (OKLCH) — colors, radius, fonts, shadows, button scale, and rainbow tokens shared by all GodUI components.",
   "cssVars": {
     "theme": {
       "font-sans": "ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, \"Noto Sans\", sans-serif",

--- a/apps/docs/public/r/registry.json
+++ b/apps/docs/public/r/registry.json
@@ -6,8 +6,8 @@
     {
       "name": "godui-theme",
       "type": "registry:theme",
-      "title": "GoDUI Theme",
-      "description": "Celestial Sapphire design tokens (OKLCH) — colors, radius, fonts, shadows, button scale, and rainbow tokens shared by all GoDUI components.",
+      "title": "GodUI Theme",
+      "description": "Celestial Sapphire design tokens (OKLCH) — colors, radius, fonts, shadows, button scale, and rainbow tokens shared by all GodUI components.",
       "cssVars": {
         "theme": {
           "font-sans": "ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, \"Noto Sans\", sans-serif",
@@ -386,6 +386,38 @@
           "target": "components/godui/progressive-card-reveal.tsx"
         }
       ]
+    },
+    {
+      "name": "aurora-text",
+      "type": "registry:ui",
+      "title": "Aurora Text",
+      "description": "Gradient text with a rainbow aurora that drifts across the letters.",
+      "registryDependencies": ["@godui/godui-theme"],
+      "files": [
+        {
+          "path": "packages/components/src/aurora-text/aurora-text.tsx",
+          "type": "registry:ui",
+          "target": "components/godui/aurora-text.tsx"
+        }
+      ],
+      "cssVars": {
+        "theme": {
+          "animate-aurora-text": "aurora-text var(--aurora-text-speed, 10s) infinite linear"
+        }
+      },
+      "css": {
+        "@keyframes aurora-text": {
+          "0%": {
+            "background-position": "0% 50%"
+          },
+          "50%": {
+            "background-position": "100% 50%"
+          },
+          "100%": {
+            "background-position": "0% 50%"
+          }
+        }
+      }
     },
     {
       "name": "elastic-text",

--- a/apps/docs/src/app/docs/_components/godui-logo.tsx
+++ b/apps/docs/src/app/docs/_components/godui-logo.tsx
@@ -4,7 +4,7 @@ type GoduiLogoProps = Omit<ComponentProps<"svg">, "viewBox"> & {
   alt?: string;
 };
 
-export function GoduiLogo({ alt = "GoDUI", ...props }: GoduiLogoProps) {
+export function GoduiLogo({ alt = "GodUI", ...props }: GoduiLogoProps) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/apps/docs/src/app/icon.svg
+++ b/apps/docs/src/app/icon.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-  <title>GoDUI</title>
+  <title>GodUI</title>
   <style>
     path { fill: #000; }
     @media (prefers-color-scheme: dark) { path { fill: #fff; } }

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -4,7 +4,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "GoDUI",
+  title: "GodUI",
   description: "A design system and component library",
 };
 

--- a/apps/docs/src/components/component-install.tsx
+++ b/apps/docs/src/components/component-install.tsx
@@ -315,7 +315,7 @@ export function ComponentInstall({
 
               <p className="text-sm text-fd-muted-foreground">
                 Update the import paths to match your project, and make sure the
-                GoDUI theme tokens are present (install any component via the
+                GodUI theme tokens are present (install any component via the
                 CLI once, or add <code>@godui/godui-theme</code>).
               </p>
             </>

--- a/apps/docs/src/lib/layout.shared.tsx
+++ b/apps/docs/src/lib/layout.shared.tsx
@@ -3,7 +3,7 @@ import type { BaseLayoutProps } from "fumadocs-ui/layouts/shared";
 export function baseOptions(): BaseLayoutProps {
   return {
     nav: {
-      title: "GoDUI",
+      title: "GodUI",
     },
     themeSwitch: {
       enabled: false,

--- a/apps/storybook/src/stories/aurora-text.stories.tsx
+++ b/apps/storybook/src/stories/aurora-text.stories.tsx
@@ -1,0 +1,41 @@
+import { AuroraText, type AuroraTextProps } from "@godui/components";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Text/AuroraText",
+  component: AuroraText,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+  },
+  args: {
+    children: "Aurora",
+    className: "text-6xl font-bold tracking-tight",
+  } satisfies AuroraTextProps,
+} satisfies Meta<typeof AuroraText>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Rainbow: Story = {
+  args: {
+    children: "Aurora",
+    className: "text-6xl font-bold tracking-tight",
+  },
+};
+
+export const Fast: Story = {
+  args: {
+    children: "Lightspeed",
+    speed: 3,
+    className: "text-6xl font-bold tracking-tight",
+  },
+};
+
+export const CustomColors: Story = {
+  args: {
+    children: "Sunset",
+    colors: ["#ff512f", "#dd2476", "#ff512f"],
+    className: "text-6xl font-bold tracking-tight",
+  },
+};

--- a/docs/superpowers/specs/2026-06-17-magic-input-design.md
+++ b/docs/superpowers/specs/2026-06-17-magic-input-design.md
@@ -58,7 +58,7 @@ mirroring the `.magic-button*` rules. Sizes reuse the shared `--button-py-*`,
 `--button-px-*`, `--button-text-*`, `--button-leading-*` tokens. Radius via
 `--radius-xl`. All theme colors via Tailwind tokens / CSS vars already defined.
 
-## Surrounding work (GoDUI conventions)
+## Surrounding work (GodUI conventions)
 
 - Export from `packages/components/src/index.ts`.
 - Storybook story: `apps/storybook/src/stories/magic-input.stories.tsx`

--- a/packages/components/src/aurora-text/aurora-text.test.tsx
+++ b/packages/components/src/aurora-text/aurora-text.test.tsx
@@ -1,0 +1,47 @@
+import { render } from "@testing-library/react";
+import { createRef } from "react";
+import { describe, expect, it } from "vitest";
+import { AuroraText } from "./aurora-text";
+
+describe("AuroraText", () => {
+  it("renders the text content", () => {
+    const { container } = render(<AuroraText>Aurora</AuroraText>);
+    const root = container.querySelector("[data-slot='aurora-text']");
+    expect(root?.textContent).toBe("AuroraAurora");
+  });
+
+  it("exposes the text once to assistive tech and hides the animated copy", () => {
+    const { container } = render(<AuroraText>Aurora</AuroraText>);
+    expect(container.querySelector(".sr-only")?.textContent).toBe("Aurora");
+    expect(container.querySelector("[aria-hidden='true']")?.textContent).toBe(
+      "Aurora",
+    );
+  });
+
+  it("builds a gradient from custom colors, looping back to the first stop", () => {
+    const { container } = render(
+      <AuroraText colors={["#ff0000", "#00ff00"]}>Hi</AuroraText>,
+    );
+    const animated = container.querySelector<HTMLSpanElement>(
+      "[aria-hidden='true']",
+    );
+    expect(animated?.style.backgroundImage).toContain("#ff0000");
+    expect(animated?.style.backgroundImage).toContain("#00ff00");
+    // first stop repeated at the end for a seamless cycle
+    expect(animated?.style.backgroundImage.match(/#ff0000/g)).toHaveLength(2);
+  });
+
+  it("maps the speed prop to the animation duration var", () => {
+    const { container } = render(<AuroraText speed={2}>Hi</AuroraText>);
+    const animated = container.querySelector<HTMLSpanElement>(
+      "[aria-hidden='true']",
+    );
+    expect(animated?.style.getPropertyValue("--aurora-text-speed")).toBe("5s");
+  });
+
+  it("forwards the ref to the root span", () => {
+    const ref = createRef<HTMLSpanElement>();
+    render(<AuroraText ref={ref}>Hi</AuroraText>);
+    expect(ref.current).toBeInstanceOf(HTMLSpanElement);
+  });
+});

--- a/packages/components/src/aurora-text/aurora-text.tsx
+++ b/packages/components/src/aurora-text/aurora-text.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import * as React from "react";
+
+export type AuroraTextProps = React.HTMLAttributes<HTMLSpanElement> & {
+  children: React.ReactNode;
+  /** Gradient stops the aurora cycles through. Defaults to a rainbow spectrum. */
+  colors?: string[];
+  /** Speed multiplier — `1` ≈ 10s per cycle, higher is faster. */
+  speed?: number;
+};
+
+// Full-spectrum rainbow, looped back to the first stop for a seamless cycle.
+const RAINBOW_COLORS = [
+  "#ff2d55",
+  "#ff9500",
+  "#ffd60a",
+  "#34c759",
+  "#00c7be",
+  "#0a84ff",
+  "#5e5ce6",
+  "#bf5af2",
+];
+
+const AuroraText = React.forwardRef<HTMLSpanElement, AuroraTextProps>(
+  (
+    {
+      children,
+      className,
+      colors = RAINBOW_COLORS,
+      speed = 1,
+      style,
+      ...props
+    },
+    ref,
+  ) => {
+    const stops = [...colors, colors[0]].join(", ");
+
+    return (
+      <span
+        ref={ref}
+        data-slot="aurora-text"
+        className={`relative inline-block ${className ?? ""}`}
+        {...props}
+      >
+        <span className="sr-only">{children}</span>
+        <span
+          aria-hidden="true"
+          className="animate-aurora-text bg-[length:200%_auto] bg-clip-text text-transparent motion-reduce:animate-none"
+          style={
+            {
+              backgroundImage: `linear-gradient(135deg, ${stops})`,
+              "--aurora-text-speed": `${10 / speed}s`,
+              ...style,
+            } as React.CSSProperties
+          }
+        >
+          {children}
+        </span>
+      </span>
+    );
+  },
+);
+AuroraText.displayName = "AuroraText";
+
+export { AuroraText };

--- a/packages/components/src/aurora-text/index.ts
+++ b/packages/components/src/aurora-text/index.ts
@@ -1,0 +1,1 @@
+export { AuroraText, type AuroraTextProps } from "./aurora-text";

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,3 +1,4 @@
+export { AuroraText, type AuroraTextProps } from "./aurora-text";
 export { BorderBeam, type BorderBeamProps } from "./border-beam";
 export {
   ElasticText,

--- a/packages/components/styles.css
+++ b/packages/components/styles.css
@@ -94,6 +94,9 @@
     alternate;
   --animate-spin-around: spin-around calc(var(--speed) * 2) infinite linear;
 
+  --animate-aurora-text: aurora-text var(--aurora-text-speed, 10s) infinite
+    linear;
+
   --animate-magic-rainbow: magic-rainbow var(--rainbow-speed, 2s) infinite
     linear;
   --animate-magic-input-indeterminate: magic-input-indeterminate 1.2s
@@ -132,6 +135,19 @@
   }
   100% {
     transform: translateZ(0) rotate(360deg);
+  }
+}
+
+/* Aurora text: gradient drifts back and forth across the clipped text */
+@keyframes aurora-text {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
   }
 }
 

--- a/registry.json
+++ b/registry.json
@@ -6,8 +6,8 @@
     {
       "name": "godui-theme",
       "type": "registry:theme",
-      "title": "GoDUI Theme",
-      "description": "Celestial Sapphire design tokens (OKLCH) — colors, radius, fonts, shadows, button scale, and rainbow tokens shared by all GoDUI components.",
+      "title": "GodUI Theme",
+      "description": "Celestial Sapphire design tokens (OKLCH) — colors, radius, fonts, shadows, button scale, and rainbow tokens shared by all GodUI components.",
       "cssVars": {
         "theme": {
           "font-sans": "ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, \"Noto Sans\", sans-serif",
@@ -386,6 +386,38 @@
           "target": "components/godui/progressive-card-reveal.tsx"
         }
       ]
+    },
+    {
+      "name": "aurora-text",
+      "type": "registry:ui",
+      "title": "Aurora Text",
+      "description": "Gradient text with a rainbow aurora that drifts across the letters.",
+      "registryDependencies": ["@godui/godui-theme"],
+      "files": [
+        {
+          "path": "packages/components/src/aurora-text/aurora-text.tsx",
+          "type": "registry:ui",
+          "target": "components/godui/aurora-text.tsx"
+        }
+      ],
+      "cssVars": {
+        "theme": {
+          "animate-aurora-text": "aurora-text var(--aurora-text-speed, 10s) infinite linear"
+        }
+      },
+      "css": {
+        "@keyframes aurora-text": {
+          "0%": {
+            "background-position": "0% 50%"
+          },
+          "50%": {
+            "background-position": "100% 50%"
+          },
+          "100%": {
+            "background-position": "0% 50%"
+          }
+        }
+      }
     },
     {
       "name": "elastic-text",


### PR DESCRIPTION
Adds a rainbow **AuroraText** component: a gradient clipped to the text with a CSS-only aurora drift, configurable `colors` and `speed` props, and `prefers-reduced-motion` support. Wires the export, Tailwind keyframe/token, registry entry, Storybook stories, and a docs page with nav. Also renames the **"GoDUI" display text to "GodUI"** across docs, app chrome, registry titles/descriptions, AGENTS.md, and skill/spec docs. Lowercase identifiers (`@godui` package scope, the `godui` slug, `components/godui/` paths, `--god-*` CSS vars) are intentionally unchanged. Verified: `pnpm check` and `pnpm test` pass.