### PR TITLE
fix(docs): point home CTA to /docs/components

### DIFF
--- a/apps/docs/src/app/page.tsx
+++ b/apps/docs/src/app/page.tsx
@@ -57,10 +57,7 @@ export default function Home() {
           . Beautiful motion, built for{" "}
           <span className="font-semibold text-fd-foreground">shadcn/ui</span>.
         </p>
-        <MagicButton
-          size="lg"
-          onClick={() => router.push("/docs/installation")}
-        >
+        <MagicButton size="lg" onClick={() => router.push("/docs/components")}>
           Browse Components
         </MagicButton>
       </section>


### PR DESCRIPTION
Home page "Browse Components" CTA now routes to `/docs/components` instead of `/docs/installation`, landing visitors on the components index.