### PR TITLE
feat(docs): add aeo.js Answer Engine Optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,16 @@ build
 apps/docs/public/design-system
 storybook-static
 
+# aeo.js generated AEO files
+apps/docs/public/robots.txt
+apps/docs/public/sitemap.xml
+apps/docs/public/llms.txt
+apps/docs/public/llms-full.txt
+apps/docs/public/docs.json
+apps/docs/public/ai-index.json
+apps/docs/public/schema.json
+apps/docs/public/**/*.md
+
 # Debug / env
 .env*.local
 npm-debug.log*

--- a/apps/docs/aeo.config.mjs
+++ b/apps/docs/aeo.config.mjs
@@ -1,0 +1,5 @@
+export const aeoConfig = {
+  title: "GodUI",
+  description: "A design system and component library",
+  url: "https://godui.design",
+};

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -4,13 +4,14 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build --turbopack",
+    "build": "next build --turbopack && node scripts/aeo-postbuild.mjs",
     "start": "next start",
     "lint": "eslint",
     "postinstall": "fumadocs-mdx"
   },
   "dependencies": {
     "@godui/components": "workspace:*",
+    "aeo.js": "^0.0.14",
     "framer-motion": "^12.40.0",
     "fumadocs-core": "16.10.2",
     "fumadocs-mdx": "15.0.12",

--- a/apps/docs/scripts/aeo-postbuild.mjs
+++ b/apps/docs/scripts/aeo-postbuild.mjs
@@ -1,0 +1,4 @@
+import { postBuild } from "aeo.js/next";
+import { aeoConfig } from "../aeo.config.mjs";
+
+await postBuild(aeoConfig);

--- a/apps/docs/src/app/aeo-widget.tsx
+++ b/apps/docs/src/app/aeo-widget.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { useEffect } from "react";
+import { aeoConfig } from "../../aeo.config.mjs";
+
+export function AeoWidget() {
+  useEffect(() => {
+    import("aeo.js/widget").then(({ AeoWidget }) => {
+      new AeoWidget({
+        config: {
+          ...aeoConfig,
+          widget: { enabled: true, position: "bottom-right" },
+        },
+      });
+    });
+  }, []);
+
+  return null;
+}

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -2,10 +2,23 @@ import { GeistMono, GeistSans } from "@godui/components/fonts/next";
 import { RootProvider } from "fumadocs-ui/provider/next";
 import type { Metadata } from "next";
 import "./globals.css";
+import { AeoWidget } from "./aeo-widget";
 
 export const metadata: Metadata = {
   title: "GodUI",
   description: "A design system and component library",
+  metadataBase: new URL("https://godui.design"),
+  alternates: {
+    types: {
+      "text/plain": [
+        { url: "/llms.txt", title: "LLM Summary" },
+        { url: "/llms-full.txt", title: "Full Content for LLMs" },
+      ],
+      "application/json": [
+        { url: "/ai-index.json", title: "AI-Optimized Index" },
+      ],
+    },
+  },
 };
 
 export default function RootLayout({
@@ -29,6 +42,7 @@ export default function RootLayout({
         >
           {children}
         </RootProvider>
+        <AeoWidget />
       </body>
     </html>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@godui/components':
         specifier: workspace:*
         version: link:../../packages/components
+      aeo.js:
+        specifier: ^0.0.14
+        version: 0.0.14(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0))
       framer-motion:
         specifier: ^12.40.0
         version: 12.40.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -2323,6 +2326,9 @@ packages:
   '@types/mdx@2.0.14':
     resolution: {integrity: sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==}
 
+  '@types/minimatch@5.1.2':
+    resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
+
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
@@ -2606,6 +2612,33 @@ packages:
     resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  aeo.js@0.0.14:
+    resolution: {integrity: sha512-QTx2unWGLhirRUGOO/OjBS5LbK1oH3EWDFjG9LftcB28xRBSRlN5c3Sb5LoSwDIWl2ZRTJes9AvK8lgDD+iLqw==}
+    hasBin: true
+    peerDependencies:
+      '@astrojs/astro': '>=3.0.0'
+      '@nuxt/kit': '>=3.0.0'
+      next: '>=13.0.0'
+      react: '>=17.0.0'
+      vite: '>=4.0.0'
+      vue: '>=3.0.0'
+      webpack: '>=5.0.0'
+    peerDependenciesMeta:
+      '@astrojs/astro':
+        optional: true
+      '@nuxt/kit':
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+      vite:
+        optional: true
+      vue:
+        optional: true
+      webpack:
+        optional: true
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -7841,6 +7874,8 @@ snapshots:
 
   '@types/mdx@2.0.14': {}
 
+  '@types/minimatch@5.1.2': {}
+
   '@types/ms@2.1.0': {}
 
   '@types/node@25.9.3':
@@ -8133,6 +8168,15 @@ snapshots:
       acorn: 8.17.0
 
   acorn@8.17.0: {}
+
+  aeo.js@0.0.14(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)):
+    dependencies:
+      '@types/minimatch': 5.1.2
+      minimatch: 10.2.5
+    optionalDependencies:
+      next: 16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      vite: 7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)
 
   agent-base@7.1.4: {}
 
@@ -8854,8 +8898,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.6
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
@@ -8877,7 +8921,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -8888,22 +8932,22 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -8914,7 +8958,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3


### PR DESCRIPTION
Adds [aeo.js](https://aeojs.org) to the docs site so it's discoverable and citable by AI answer engines (ChatGPT, Claude, Perplexity), generating `robots.txt`, `sitemap.xml`, `llms.txt`/`llms-full.txt`, `docs.json`, `ai-index.json`, and `schema.json` into `public/` (gitignored as build artifacts), plus a floating Human/AI toggle widget. Config lives in `apps/docs/aeo.config.mjs` (url `https://godui.design`), shared by the generator and the widget.

Generation runs via aeo.js's `postBuild()` chained into the `build` script rather than its `withAeo()` wrapper, because the docs app builds with Turbopack — which ignores the webpack hook `withAeo()` depends on. Verified locally: a clean build emits all 8 files and every route serves 200 with correct content-types.

Known limitation: Fumadocs serves docs through a dynamic catch-all route, so per-doc body content in `llms-full.txt` is partial (sitemap/llms.txt page listings still cover all docs).