### PR TITLE
feat(docs): animate preview/code tabs and copy button

### DIFF
--- a/apps/docs/src/app/globals.css
+++ b/apps/docs/src/app/globals.css
@@ -628,6 +628,22 @@ hr.docs-lead-divider {
   }
 }
 
+/* Copy button: pop the icon in when it swaps to the success check mark. */
+@keyframes godui-tool-pop {
+  0% {
+    transform: scale(0.3) rotate(-18deg);
+    opacity: 0;
+  }
+  55% {
+    transform: scale(1.22) rotate(4deg);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1) rotate(0deg);
+    opacity: 1;
+  }
+}
+
 /* "Built with GodUI" TOC card — subtle primary-tinted gradient surface. */
 .toc-cta {
   background: linear-gradient(

--- a/apps/docs/src/components/component-preview.tsx
+++ b/apps/docs/src/components/component-preview.tsx
@@ -21,7 +21,7 @@ function PlayIcon() {
   return (
     <svg
       aria-hidden="true"
-      viewBox="2 0 24 24"
+      viewBox="6.5 5 14 14"
       className="size-3"
       fill="currentColor"
     >

--- a/apps/docs/src/components/component-preview.tsx
+++ b/apps/docs/src/components/component-preview.tsx
@@ -21,7 +21,7 @@ function PlayIcon() {
   return (
     <svg
       aria-hidden="true"
-      viewBox="0 0 24 24"
+      viewBox="2 0 24 24"
       className="size-3"
       fill="currentColor"
     >

--- a/apps/docs/src/components/copy-button.tsx
+++ b/apps/docs/src/components/copy-button.tsx
@@ -23,34 +23,45 @@ export function CopyButton({ value, className }: CopyButtonProps) {
       aria-label={copied ? "Copied" : "Copy to clipboard"}
       onClick={onCopy}
       className={cn(
-        "inline-flex size-8 items-center justify-center rounded-md text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground",
+        "inline-flex size-8 items-center justify-center rounded-md text-fd-muted-foreground transition-[color,border-color,transform] duration-150 hover:bg-fd-accent hover:text-fd-accent-foreground active:scale-90",
         className,
+        copied && "border-fd-success/45 text-fd-success hover:text-fd-success",
       )}
     >
-      {copied ? (
-        <svg
-          aria-hidden="true"
-          viewBox="0 0 24 24"
-          className="size-4"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-        >
-          <path d="M20 6 9 17l-5-5" />
-        </svg>
-      ) : (
-        <svg
-          aria-hidden="true"
-          viewBox="0 0 24 24"
-          className="size-4"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-        >
-          <rect x="9" y="9" width="13" height="13" rx="2" />
-          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-        </svg>
-      )}
+      {/* Remount on toggle (via key) so the pop animation replays each copy. */}
+      <span
+        key={copied ? "check" : "copy"}
+        className={cn(
+          "inline-flex",
+          copied &&
+            "animate-[godui-tool-pop_380ms_cubic-bezier(0.16,1,0.3,1)] motion-reduce:animate-none",
+        )}
+      >
+        {copied ? (
+          <svg
+            aria-hidden="true"
+            viewBox="0 0 24 24"
+            className="size-4"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            <path d="M20 6 9 17l-5-5" />
+          </svg>
+        ) : (
+          <svg
+            aria-hidden="true"
+            viewBox="0 0 24 24"
+            className="size-4"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            <rect x="9" y="9" width="13" height="13" rx="2" />
+            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+          </svg>
+        )}
+      </span>
     </button>
   );
 }

--- a/apps/docs/src/components/docs-tabs.tsx
+++ b/apps/docs/src/components/docs-tabs.tsx
@@ -66,25 +66,48 @@ export function PillTabs({ tabs, value, onChange, className }: PillTabsProps) {
  * tabs) this renders an enclosed track with a raised active segment.
  */
 export function Segmented({ tabs, value, onChange, className }: DocsTabsProps) {
+  const activeIndex = Math.max(
+    0,
+    tabs.findIndex((tab) => tab.value === value),
+  );
+
   return (
     <div
       className={cn(
         // NB: --color-fd-muted is aliased to muted-foreground in the GodUI
         // theme, so bg-fd-muted renders light in dark mode. Use the real
         // --muted/--card tokens directly for a correct, contrasting track.
-        "inline-flex gap-0.5 rounded-[10px] border border-fd-border bg-[var(--muted)] p-[3px]",
+        // Grid (not inline-flex) so every segment is an equal-width column —
+        // a shrink-to-fit flex track sizes buttons to their content, which
+        // makes the half-width thumb misalign with the wider tab.
+        "relative inline-grid rounded-[10px] border border-fd-border bg-[var(--muted)] p-[3px]",
         className,
       )}
+      style={{
+        gridTemplateColumns: `repeat(${tabs.length}, minmax(0, 1fr))`,
+      }}
     >
+      {/* Floating thumb that slides under the active segment. */}
+      <span
+        aria-hidden="true"
+        className="absolute inset-y-[3px] left-[3px] rounded-[7px] bg-[var(--card)] shadow-sm transition-transform duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none"
+        style={{
+          // Match the flex-1 button width exactly: track inner width is
+          // (100% - 2*3px padding), split n ways. translateX(100%) then steps
+          // by one button so the thumb stays centered under each segment.
+          width: `calc((100% - 6px) / ${tabs.length})`,
+          transform: `translateX(${activeIndex * 100}%)`,
+        }}
+      />
       {tabs.map((tab) => (
         <button
           key={tab.value}
           type="button"
           onClick={() => onChange(tab.value)}
           className={cn(
-            "inline-flex items-center gap-1.5 rounded-[7px] px-3 py-1 text-[13px] font-medium transition-colors",
+            "relative z-[1] inline-flex items-center justify-center gap-1.5 rounded-[7px] px-3 py-1 text-[13px] font-medium transition-colors",
             value === tab.value
-              ? "bg-[var(--card)] text-[var(--foreground)] shadow-sm"
+              ? "text-[var(--foreground)]"
               : "text-[var(--muted-foreground)] hover:text-[var(--foreground)]",
           )}
         >


### PR DESCRIPTION
Ports two micro-interactions from the design system mockup into the docs example blocks. The Preview/Code segmented control now has a floating thumb that slides under the active tab (300ms cubic-bezier), and the copy button's icon remounts and pops in with a success color and active press scale. The segmented track uses an equal-column grid so the half-width thumb stays centered under each tab regardless of label width. Both animations respect `prefers-reduced-motion`.