### PR TITLE
feat(components): add NumberTicker component

### DIFF
--- a/apps/docs/content/docs/components/index.mdx
+++ b/apps/docs/content/docs/components/index.mdx
@@ -60,6 +60,10 @@ import { Cards, Card } from "fumadocs-ui/components/card";
     Draw hand-drawn sketch annotations over inline text — highlight, underline,
     box, circle, and more.
   </Card>
+  <Card href="/docs/components/text/number-ticker" title="Number Ticker">
+    Animates a number to its target value with spring physics when scrolled into
+    view.
+  </Card>
 </Cards>
 
 ## Layout

--- a/apps/docs/content/docs/components/text/number-ticker.mdx
+++ b/apps/docs/content/docs/components/text/number-ticker.mdx
@@ -1,0 +1,75 @@
+---
+title: Number Ticker
+description: Animates a number to its target value with spring physics when scrolled into view.
+---
+
+import { NumberTicker } from "@godui/components";
+
+<ComponentPreview
+  code={`import { NumberTicker } from "@/components/godui/number-ticker";
+
+export function NumberTickerDemo() {
+  return (
+    <NumberTicker value={100} className="text-6xl font-bold tracking-tight" />
+  );
+}`}
+>
+  <NumberTicker value={100} className="text-6xl font-bold tracking-tight" />
+</ComponentPreview>
+
+## Installation
+
+<ComponentInstall componentName="NumberTicker" />
+
+`NumberTicker` animates only once, when it scrolls into view. It renders
+`tabular-nums` so the width stays stable while the digits change.
+
+## Usage
+
+```tsx
+import { NumberTicker } from "@/components/godui/number-ticker";
+```
+
+`NumberTicker` is an inline `<span>` that inherits the surrounding font size,
+weight, and color. Style the element directly:
+
+```tsx
+<NumberTicker value={100} className="text-6xl font-bold tracking-tight" />
+```
+
+### Decimal places
+
+```tsx
+<NumberTicker value={1984.42} decimalPlaces={2} />
+```
+
+### Count down
+
+Set `direction="down"` to count from `value` to `startValue`.
+
+```tsx
+<NumberTicker value={100} direction="down" />
+```
+
+### Delay
+
+`delay` is in seconds and starts once the element is in view.
+
+```tsx
+<NumberTicker value={5000} delay={0.5} />
+```
+
+## Props
+
+| Prop            | Type              | Default | Description                                                        |
+| --------------- | ----------------- | ------- | ------------------------------------------------------------------ |
+| `value`         | `number`          | —       | Target value the ticker animates to (or from, when counting down). |
+| `startValue`    | `number`          | `0`     | Value the counter starts at.                                       |
+| `direction`     | `"up" \| "down"`  | `"up"`  | `"up"` counts toward `value`; `"down"` counts from `value`.        |
+| `delay`         | `number`          | `0`     | Delay in seconds before the animation begins once in view.         |
+| `decimalPlaces` | `number`          | `0`     | Number of decimal places to render.                                |
+| `damping`       | `number`          | `60`    | Spring damping — higher is less bouncy.                            |
+| `stiffness`     | `number`          | `100`   | Spring stiffness — higher is faster.                               |
+
+`NumberTicker` also forwards every standard `<span>` attribute (`className`,
+`style`, `id`, …) to the root element.

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -18,6 +18,7 @@
     "components/text/elastic-text",
     "components/text/text-animate",
     "components/text/highlighter",
+    "components/text/number-ticker",
     "---Layout---",
     "components/layout/progressive-card-reveal",
     "---Effects---",

--- a/apps/docs/public/r/number-ticker.json
+++ b/apps/docs/public/r/number-ticker.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "number-ticker",
+  "title": "Number Ticker",
+  "description": "Animates a number to its target value with spring physics when scrolled into view.",
+  "dependencies": ["framer-motion"],
+  "registryDependencies": ["@godui/godui-theme"],
+  "files": [
+    {
+      "path": "packages/components/src/number-ticker/number-ticker.tsx",
+      "content": "\"use client\";\n\nimport {\n  useInView,\n  useMotionValue,\n  useSpring,\n} from \"framer-motion\";\nimport * as React from \"react\";\n\nexport type NumberTickerProps = Omit<\n  React.HTMLAttributes<HTMLSpanElement>,\n  \"children\"\n> & {\n  /** Target value the ticker animates to (or from, when `direction` is `\"down\"`). */\n  value: number;\n  /** Value the counter starts at. Defaults to `0`. */\n  startValue?: number;\n  /** `\"up\"` counts toward `value`, `\"down\"` counts from `value` to `startValue`. */\n  direction?: \"up\" | \"down\";\n  /** Delay in seconds before the animation begins once in view. */\n  delay?: number;\n  /** Number of decimal places to render. */\n  decimalPlaces?: number;\n  /** Spring damping — higher is less bouncy. */\n  damping?: number;\n  /** Spring stiffness — higher is faster. */\n  stiffness?: number;\n};\n\nconst NumberTicker = React.forwardRef<HTMLSpanElement, NumberTickerProps>(\n  (\n    {\n      value,\n      startValue = 0,\n      direction = \"up\",\n      delay = 0,\n      decimalPlaces = 0,\n      damping = 60,\n      stiffness = 100,\n      className,\n      ...props\n    },\n    forwardedRef,\n  ) => {\n    const ref = React.useRef<HTMLSpanElement>(null);\n    const motionValue = useMotionValue(direction === \"down\" ? value : startValue);\n    const springValue = useSpring(motionValue, { damping, stiffness });\n    const isInView = useInView(ref, { once: true, margin: \"0px\" });\n\n    React.useImperativeHandle(\n      forwardedRef,\n      () => ref.current as HTMLSpanElement,\n    );\n\n    React.useEffect(() => {\n      if (!isInView) return;\n\n      const timer = setTimeout(() => {\n        motionValue.set(direction === \"down\" ? startValue : value);\n      }, delay * 1000);\n\n      return () => clearTimeout(timer);\n    }, [motionValue, isInView, delay, value, direction, startValue]);\n\n    React.useEffect(\n      () =>\n        springValue.on(\"change\", (latest) => {\n          if (ref.current) {\n            ref.current.textContent = Intl.NumberFormat(\"en-US\", {\n              minimumFractionDigits: decimalPlaces,\n              maximumFractionDigits: decimalPlaces,\n            }).format(Number(latest.toFixed(decimalPlaces)));\n          }\n        }),\n      [springValue, decimalPlaces],\n    );\n\n    return (\n      <span\n        ref={ref}\n        data-slot=\"number-ticker\"\n        className={`inline-block tabular-nums tracking-wider text-foreground ${className ?? \"\"}`}\n        {...props}\n      >\n        {Intl.NumberFormat(\"en-US\", {\n          minimumFractionDigits: decimalPlaces,\n          maximumFractionDigits: decimalPlaces,\n        }).format(direction === \"down\" ? value : startValue)}\n      </span>\n    );\n  },\n);\nNumberTicker.displayName = \"NumberTicker\";\n\nexport { NumberTicker };\n",
+      "type": "registry:ui",
+      "target": "components/godui/number-ticker.tsx"
+    }
+  ],
+  "type": "registry:ui"
+}

--- a/apps/docs/public/r/registry.json
+++ b/apps/docs/public/r/registry.json
@@ -480,6 +480,21 @@
       ]
     },
     {
+      "name": "number-ticker",
+      "type": "registry:ui",
+      "title": "Number Ticker",
+      "description": "Animates a number to its target value with spring physics when scrolled into view.",
+      "registryDependencies": ["@godui/godui-theme"],
+      "dependencies": ["framer-motion"],
+      "files": [
+        {
+          "path": "packages/components/src/number-ticker/number-ticker.tsx",
+          "type": "registry:ui",
+          "target": "components/godui/number-ticker.tsx"
+        }
+      ]
+    },
+    {
       "name": "border-beam",
       "type": "registry:ui",
       "title": "Border Beam",

--- a/apps/docs/src/app/globals.css
+++ b/apps/docs/src/app/globals.css
@@ -96,6 +96,7 @@ body {
 #nd-sidebar a.p-2 {
   padding-top: 0.25rem;
   padding-bottom: 0.25rem;
+  font-size: 0.8125rem;
   /* Subtle 9px corners on the hover/active pill (Fumadocs' rounded-lg resolves
      much larger via the GodUI --radius-lg token). */
   border-radius: 9px;

--- a/apps/storybook/src/stories/number-ticker.stories.tsx
+++ b/apps/storybook/src/stories/number-ticker.stories.tsx
@@ -1,0 +1,49 @@
+import { NumberTicker, type NumberTickerProps } from "@godui/components";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Text/NumberTicker",
+  component: NumberTicker,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+  },
+  args: {
+    value: 100,
+    className: "text-6xl font-bold tracking-tight",
+  } satisfies NumberTickerProps,
+} satisfies Meta<typeof NumberTicker>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    value: 100,
+    className: "text-6xl font-bold tracking-tight",
+  },
+};
+
+export const Decimals: Story = {
+  args: {
+    value: 1984.42,
+    decimalPlaces: 2,
+    className: "text-6xl font-bold tracking-tight",
+  },
+};
+
+export const CountDown: Story = {
+  args: {
+    value: 100,
+    direction: "down",
+    className: "text-6xl font-bold tracking-tight",
+  },
+};
+
+export const Delayed: Story = {
+  args: {
+    value: 5000,
+    delay: 0.5,
+    className: "text-6xl font-bold tracking-tight",
+  },
+};

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -72,6 +72,10 @@ export {
   type MaskButtonSize,
   type MaskButtonVariant,
 } from "./mask-button";
+export {
+  NumberTicker,
+  type NumberTickerProps,
+} from "./number-ticker";
 export { PixelGrid, type PixelGridProps } from "./pixel-grid";
 export {
   ProgressFoldButton,

--- a/packages/components/src/number-ticker/index.ts
+++ b/packages/components/src/number-ticker/index.ts
@@ -1,0 +1,1 @@
+export { NumberTicker, type NumberTickerProps } from "./number-ticker";

--- a/packages/components/src/number-ticker/number-ticker.tsx
+++ b/packages/components/src/number-ticker/number-ticker.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useInView, useMotionValue, useSpring } from "framer-motion";
+import * as React from "react";
+
+export type NumberTickerProps = Omit<
+  React.HTMLAttributes<HTMLSpanElement>,
+  "children"
+> & {
+  /** Target value the ticker animates to (or from, when `direction` is `"down"`). */
+  value: number;
+  /** Value the counter starts at. Defaults to `0`. */
+  startValue?: number;
+  /** `"up"` counts toward `value`, `"down"` counts from `value` to `startValue`. */
+  direction?: "up" | "down";
+  /** Delay in seconds before the animation begins once in view. */
+  delay?: number;
+  /** Number of decimal places to render. */
+  decimalPlaces?: number;
+  /** Spring damping — higher is less bouncy. */
+  damping?: number;
+  /** Spring stiffness — higher is faster. */
+  stiffness?: number;
+};
+
+const NumberTicker = React.forwardRef<HTMLSpanElement, NumberTickerProps>(
+  (
+    {
+      value,
+      startValue = 0,
+      direction = "up",
+      delay = 0,
+      decimalPlaces = 0,
+      damping = 60,
+      stiffness = 100,
+      className,
+      ...props
+    },
+    forwardedRef,
+  ) => {
+    const ref = React.useRef<HTMLSpanElement>(null);
+    const motionValue = useMotionValue(
+      direction === "down" ? value : startValue,
+    );
+    const springValue = useSpring(motionValue, { damping, stiffness });
+    const isInView = useInView(ref, { once: true, margin: "0px" });
+
+    React.useImperativeHandle(
+      forwardedRef,
+      () => ref.current as HTMLSpanElement,
+    );
+
+    React.useEffect(() => {
+      if (!isInView) return;
+
+      const timer = setTimeout(() => {
+        motionValue.set(direction === "down" ? startValue : value);
+      }, delay * 1000);
+
+      return () => clearTimeout(timer);
+    }, [motionValue, isInView, delay, value, direction, startValue]);
+
+    React.useEffect(
+      () =>
+        springValue.on("change", (latest) => {
+          if (ref.current) {
+            ref.current.textContent = Intl.NumberFormat("en-US", {
+              minimumFractionDigits: decimalPlaces,
+              maximumFractionDigits: decimalPlaces,
+            }).format(Number(latest.toFixed(decimalPlaces)));
+          }
+        }),
+      [springValue, decimalPlaces],
+    );
+
+    return (
+      <span
+        ref={ref}
+        data-slot="number-ticker"
+        className={`inline-block tabular-nums tracking-wider text-foreground ${className ?? ""}`}
+        {...props}
+      >
+        {Intl.NumberFormat("en-US", {
+          minimumFractionDigits: decimalPlaces,
+          maximumFractionDigits: decimalPlaces,
+        }).format(direction === "down" ? value : startValue)}
+      </span>
+    );
+  },
+);
+NumberTicker.displayName = "NumberTicker";
+
+export { NumberTicker };

--- a/registry.json
+++ b/registry.json
@@ -480,6 +480,21 @@
       ]
     },
     {
+      "name": "number-ticker",
+      "type": "registry:ui",
+      "title": "Number Ticker",
+      "description": "Animates a number to its target value with spring physics when scrolled into view.",
+      "registryDependencies": ["@godui/godui-theme"],
+      "dependencies": ["framer-motion"],
+      "files": [
+        {
+          "path": "packages/components/src/number-ticker/number-ticker.tsx",
+          "type": "registry:ui",
+          "target": "components/godui/number-ticker.tsx"
+        }
+      ]
+    },
+    {
       "name": "border-beam",
       "type": "registry:ui",
       "title": "Border Beam",


### PR DESCRIPTION
Adds a `NumberTicker` component to `@godui/components` that animates a number to its target value using framer-motion spring physics when it scrolls into view, rendered with `tabular-nums` for a stable width. It supports counting up or down, decimal places, an entrance `delay`, and configurable spring `damping`/`stiffness`. Wired into the registry (`registry.json` + built `public/r` output), Storybook (Default/Decimals/CountDown/Delayed stories), and the docs (new `text/number-ticker` page, nav, and landing card). Also reduces the docs sidebar nav-link font size from `0.875rem` to `0.8125rem`.