### PR TITLE
docs: add professional README and OSS contributor kit

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,130 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement by opening an
+issue at https://github.com/LucasBassetti/godui/issues or contacting the
+maintainer directly. All complaints will be reviewed and investigated promptly
+and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla coc].
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
+
+[homepage]: https://www.contributor-covenant.org
+[mozilla coc]: https://github.com/mozilla/diversity

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,100 @@
+# Contributing to GodUI
+
+Thanks for your interest in contributing to [GodUI](https://godui.design)! New
+components, bug fixes, documentation improvements, and ideas are all welcome.
+
+By participating, you agree to follow our [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+## Prerequisites
+
+- **Node.js** >= 20.19.0
+- **pnpm** 10.x (`corepack enable` will pin the right version)
+
+## Getting started
+
+```bash
+# 1. Fork the repo on GitHub, then clone your fork
+git clone https://github.com/<your-username>/godui.git
+cd godui
+
+# 2. Install dependencies
+pnpm install
+
+# 3. Start the dev environment (docs + storybook)
+pnpm dev
+```
+
+## Repository layout
+
+GodUI is a [pnpm](https://pnpm.io) + [Turborepo](https://turborepo.com) monorepo:
+
+```
+godui/
+├── apps/
+│   ├── docs/          # Documentation site (Next.js + Fumadocs)
+│   └── storybook/     # Component showcase (Storybook)
+├── packages/
+│   └── components/    # @godui/components — the component library
+└── registry.json      # shadcn registry definition (source of truth)
+```
+
+- **Component source** lives in `packages/components`.
+- **Docs pages** (MDX) live in `apps/docs/content/docs`.
+- **Stories** live in `apps/storybook`.
+
+## Adding a component
+
+1. Create the component in `packages/components` (follow the structure and
+   Tailwind conventions of existing components).
+2. Register it in `registry.json` — add an entry with its name, files, and
+   dependencies. **Do not reformat the rest of the file**; just add your entry.
+3. Build the registry to generate the consumable JSON:
+
+   ```bash
+   pnpm build:registry
+   ```
+
+4. Add a Storybook story in `apps/storybook`.
+5. Add a docs page under `apps/docs/content/docs/components/<category>/` with a
+   `ComponentPreview` and install instructions.
+
+## Code style
+
+GodUI uses [Biome](https://biomejs.dev) for linting and formatting. Run this
+before committing:
+
+```bash
+pnpm check:fix
+```
+
+## Tests
+
+Components are tested with [Vitest](https://vitest.dev):
+
+```bash
+pnpm test
+```
+
+Please add or update tests for any behavior you change.
+
+## Commit messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/). Examples:
+
+```
+feat(components): add Sparkles component
+fix(magic-button): correct hover scale on disabled state
+docs(installation): clarify dark-mode setup
+```
+
+## Pull requests
+
+1. Create a branch off `main`.
+2. Make your changes; ensure `pnpm check` and `pnpm test` pass.
+3. Open a PR against `main` with a clear description and screenshots/GIFs for
+   visual changes.
+
+## Questions
+
+Open a [GitHub issue](https://github.com/LucasBassetti/godui/issues) for bugs,
+feature requests, or questions. Thanks for contributing! 🙌

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Lucas Bassetti
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,180 @@
+<div align="center">
+
+<a href="https://godui.design">
+  <img src="https://raw.githubusercontent.com/LucasBassetti/godui/main/apps/docs/public/og-image.png" alt="GodUI — open-source, animated UI components for Design Engineers" width="100%" />
+</a>
+
+<h1>GodUI</h1>
+
+<p><strong>Open-source, animated UI components for Design Engineers.</strong></p>
+
+<p>
+  Built with React, TypeScript, Tailwind CSS v4, and Motion — distributed as a
+  <a href="https://ui.shadcn.com">shadcn</a> registry, so components are copied
+  straight into your project and you own every line.
+</p>
+
+<p><a href="https://github.com/LucasBassetti/godui/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT" /></a> <a href="https://github.com/LucasBassetti/godui/stargazers"><img src="https://img.shields.io/github/stars/LucasBassetti/godui?style=flat&logo=github&color=yellow" alt="GitHub stars" /></a> <a href="https://github.com/LucasBassetti/godui/commits/main"><img src="https://img.shields.io/github/last-commit/LucasBassetti/godui?logo=git&logoColor=white" alt="Last commit" /></a> <a href="https://github.com/LucasBassetti/godui/pulls"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs welcome" /></a></p>
+
+<p><img src="https://img.shields.io/badge/React-18%20%7C%2019-149ECA?logo=react&logoColor=white" alt="React" /> <img src="https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white" alt="TypeScript" /> <img src="https://img.shields.io/badge/Tailwind_CSS-v4-06B6D4?logo=tailwindcss&logoColor=white" alt="Tailwind CSS v4" /> <img src="https://img.shields.io/badge/Motion-0055FF?logo=framer&logoColor=white" alt="Motion" /> <img src="https://img.shields.io/badge/shadcn-compatible-000000?logo=shadcnui&logoColor=white" alt="shadcn compatible" /></p>
+
+<p>
+  <a href="https://godui.design"><strong>Documentation</strong></a> ·
+  <a href="https://godui.design/docs/components"><strong>Components</strong></a> ·
+  <a href="https://godui.design/docs/installation"><strong>Installation</strong></a> ·
+  <a href="./CONTRIBUTING.md"><strong>Contributing</strong></a>
+</p>
+
+</div>
+
+---
+
+## Overview
+
+**GodUI** is a collection of open-source, animated UI components for Design
+Engineers. Built with **React**, **TypeScript**, **Tailwind CSS v4**, and
+**Motion**, and distributed as a [shadcn](https://ui.shadcn.com) registry — so
+the components are copied straight into your project and you own every line.
+
+If you already use [shadcn/ui](https://ui.shadcn.com), GodUI drops in with the
+exact same workflow: add the `@godui` registry, then pull components by name.
+
+## ✨ What you get
+
+- **You own the code.** Components are installed into your codebase via the
+  shadcn CLI — not hidden behind a versioned dependency.
+- **Motion-first.** Every component ships with polished, performant animation
+  out of the box.
+- **shadcn-native.** Same install flow as shadcn/ui. If you already use shadcn,
+  just add the `@godui` registry.
+- **Tailwind v4 tokens.** Themed with CSS variables — light and dark modes work
+  with zero extra config.
+- **Type-safe.** Full TypeScript types for every component and its props.
+
+## 📦 Installation
+
+GodUI is distributed as a shadcn registry. Components are copied straight into
+your project — you own the source.
+
+**1. Create or set up a project:**
+
+```bash
+pnpm dlx shadcn@latest init
+```
+
+**2. Add the `@godui` registry** to the `registries` field of your
+`components.json` (one-time setup):
+
+```json
+{
+  "registries": {
+    "@godui": "https://godui.design/r/{name}.json"
+  }
+}
+```
+
+**3. Add any component by name:**
+
+```bash
+pnpm dlx shadcn@latest add @godui/magic-button
+```
+
+This copies the component into `components/godui/` and merges the GodUI theme
+tokens and component styles into your global stylesheet automatically.
+
+> Prefer zero configuration? Skip step 2 and install with the full registry URL:
+> `pnpm dlx shadcn@latest add https://godui.design/r/magic-button.json`
+
+See the full [installation guide](https://godui.design/docs/installation) for
+typography and dark-mode setup.
+
+## 🚀 Quick start
+
+Once a component is installed, import and use it:
+
+```tsx
+import { MagicButton } from "@/components/godui/magic-button";
+
+export function Demo() {
+  return <MagicButton size="lg">Get Started</MagicButton>;
+}
+```
+
+## 🧩 Components
+
+36+ animated components, organized by category. Browse them all in the
+[component docs](https://godui.design/docs/components).
+
+| Category | Components |
+| --- | --- |
+| **Buttons** | [Magic Button](https://godui.design/docs/components/buttons/magic-button) · [Shimmer Button](https://godui.design/docs/components/buttons/shimmer-button) · [Magnetic Button](https://godui.design/docs/components/buttons/magnetic-button) · [Mask Button](https://godui.design/docs/components/buttons/mask-button) · [Progress Fold Button](https://godui.design/docs/components/buttons/progress-fold-button) · [Theme Toggle](https://godui.design/docs/components/buttons/theme-toggle) |
+| **Text** | [Aurora Text](https://godui.design/docs/components/text/aurora-text) · [Elastic Text](https://godui.design/docs/components/text/elastic-text) · [Text Animate](https://godui.design/docs/components/text/text-animate) · [Highlighter](https://godui.design/docs/components/text/highlighter) · [Number Ticker](https://godui.design/docs/components/text/number-ticker) |
+| **Overlays** | [Command Palette](https://godui.design/docs/components/overlays/command-palette) · [Toast](https://godui.design/docs/components/overlays/toast) · [Drawer](https://godui.design/docs/components/overlays/drawer) · [Animated Tooltip](https://godui.design/docs/components/overlays/animated-tooltip) · [Dynamic Island](https://godui.design/docs/components/overlays/dynamic-island) |
+| **Navigation** | [Dock](https://godui.design/docs/components/navigation/dock) · [Magic Tab](https://godui.design/docs/components/navigation/magic-tab) |
+| **Layout** | [Bento Grid](https://godui.design/docs/components/layout/bento-grid) · [Tilt Card](https://godui.design/docs/components/layout/tilt-card) · [Progressive Card Reveal](https://godui.design/docs/components/layout/progressive-card-reveal) · [Animated Testimonials](https://godui.design/docs/components/layout/animated-testimonials) |
+| **Effects** | [Border Beam](https://godui.design/docs/components/effects/border-beam) · [Marquee](https://godui.design/docs/components/effects/marquee) · [Sparkles](https://godui.design/docs/components/effects/sparkles) · [Spotlight Card](https://godui.design/docs/components/effects/spotlight-card) · [Scroll Reveal](https://godui.design/docs/components/effects/scroll-reveal) · [Lamp](https://godui.design/docs/components/effects/lamp) · [Confetti](https://godui.design/docs/components/effects/confetti) |
+| **Glass** | [Liquid Glass Card](https://godui.design/docs/components/glass/liquid-glass-card) · [Liquid Glass Lens](https://godui.design/docs/components/glass/liquid-glass-lens) |
+| **Backgrounds** | [Gradient](https://godui.design/docs/components/backgrounds/gradient-background) · [Geometric](https://godui.design/docs/components/backgrounds/geometric-background) · [Decorative](https://godui.design/docs/components/backgrounds/decorative-background) · [Effect](https://godui.design/docs/components/backgrounds/effect-background) · [Pixel Grid](https://godui.design/docs/components/backgrounds/pixel-grid) |
+| **Visualizations** | [Globe](https://godui.design/docs/components/visualizations/globe) · [Animated Beam](https://godui.design/docs/components/visualizations/animated-beam) · [Orbiting Circles](https://godui.design/docs/components/visualizations/orbiting-circles) |
+| **Inputs** | [Magic Input](https://godui.design/docs/components/inputs/magic-input) |
+
+## 🛠️ Local development
+
+GodUI is a [pnpm](https://pnpm.io) + [Turborepo](https://turborepo.com)
+monorepo. Requires **Node >= 20.19.0** and **pnpm 10.x**.
+
+```bash
+# Clone
+git clone https://github.com/LucasBassetti/godui.git
+cd godui
+
+# Install dependencies
+pnpm install
+
+# Start everything (docs + storybook) in dev
+pnpm dev
+
+# Build the shadcn registry from registry.json
+pnpm build:registry
+
+# Run tests
+pnpm test
+
+# Lint & format with Biome
+pnpm check        # check
+pnpm check:fix    # check and auto-fix
+```
+
+## 📁 Project structure
+
+```
+godui/
+├── apps/
+│   ├── docs/          # Documentation site (Next.js + Fumadocs)
+│   └── storybook/     # Component showcase (Storybook)
+├── packages/
+│   └── components/    # @godui/components — the component library
+└── registry.json      # shadcn registry definition (source of truth)
+```
+
+## 🤝 Contributing
+
+Contributions are welcome — new components, bug fixes, docs, and ideas. Read the
+[Contributing Guide](./CONTRIBUTING.md) to get started, and please follow our
+[Code of Conduct](./CODE_OF_CONDUCT.md).
+
+## 📄 License
+
+[MIT](./LICENSE) © Lucas Bassetti
+
+---
+
+<div align="center">
+
+Built by <a href="https://github.com/LucasBassetti">Lucas Bassetti</a> and
+<a href="https://github.com/LucasBassetti/godui/graphs/contributors">contributors</a>.
+
+If GodUI helps you ship, consider <a href="https://github.com/LucasBassetti/godui">starring the repo</a> ⭐ ·
+<a href="https://godui.design">godui.design</a>
+
+</div>


### PR DESCRIPTION
Adds the root README and standard open-source files the repo was missing.

- **README.md** — centered hero (og-image banner, title, badge rows), feature highlights, shadcn install steps, quick start, a categorized table of 36+ components linking to the docs, local-dev guide, and project structure.
- **LICENSE** — MIT, © 2026 Lucas Bassetti.
- **CONTRIBUTING.md** — setup, monorepo layout, add-a-component flow, Biome/Vitest/Conventional Commits, and PR process.
- **CODE_OF_CONDUCT.md** — Contributor Covenant v2.1.

All commands and component links are verified against the existing scripts, install docs, and registry.json. Badges and the banner render once the branch is on GitHub.