### PR TITLE
feat(mcp): add GodUI MCP server and CLI installer

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,0 +1,41 @@
+name: Release CLI
+
+# Publishes @godui/cli to npm when a tag like `cli-v0.1.0` is pushed.
+# Requires an NPM_TOKEN repo secret (npm automation token with publish access).
+on:
+  push:
+    tags:
+      - "cli-v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # for npm provenance
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm --filter @godui/cli build
+
+      - name: Test
+        run: pnpm --filter @godui/cli test
+
+      - name: Publish
+        run: pnpm --filter @godui/cli publish --no-git-checks --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -1,0 +1,41 @@
+name: Release MCP
+
+# Publishes @godui/mcp to npm when a tag like `mcp-v0.1.0` is pushed.
+# Requires an NPM_TOKEN repo secret (npm automation token with publish access).
+on:
+  push:
+    tags:
+      - "mcp-v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # for npm provenance
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm --filter @godui/mcp build
+
+      - name: Test
+        run: pnpm --filter @godui/mcp test
+
+      - name: Publish
+        run: pnpm --filter @godui/mcp publish --no-git-checks --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/apps/docs/content/docs/mcp.mdx
+++ b/apps/docs/content/docs/mcp.mdx
@@ -1,0 +1,52 @@
+---
+title: MCP Server
+description: Use GodUI from your AI IDE — discover and install components by description.
+---
+
+GodUI ships an [MCP](https://modelcontextprotocol.io) server so AI coding agents
+(Cursor, Windsurf, Claude, Cline, Roo-Cline, …) can browse the GodUI catalog and
+install components straight into your project. Add it once, then just ask for the
+component you want in plain language.
+
+## Installation
+
+Use the **CLI** to write the config automatically, or add it **Manually**.
+
+<MCPInstall />
+
+The server runs locally over `stdio` via `npx` — no API key, no account. The CLI
+installs into your editor's MCP config; with Manual you paste the block into it
+yourself.
+
+## Usage
+
+Ask your IDE to use any GodUI component:
+
+- "Add a GodUI magic button"
+- "Add a marquee of logos"
+- "Add an animated gradient background"
+- "Add a number ticker that counts to 1000"
+
+The agent finds the right component, then installs it with the
+[shadcn CLI](/docs/installation) — copying the source into your project so you
+own it.
+
+## Tools
+
+The server exposes three tools:
+
+| Tool | What it does |
+| --- | --- |
+| `list_components` | List the full catalog, optionally filtered by category. |
+| `search_components` | Find components by what they do (natural language). |
+| `get_component` | Fetch one component's install command and full source. |
+
+## How it works
+
+The server fetches the live registry at `https://godui.design/r`, so it always
+serves the latest components — no upgrade needed when GodUI ships something new.
+Point it at a local registry for development by setting `GODUI_REGISTRY_URL`:
+
+```bash
+GODUI_REGISTRY_URL=http://localhost:3000/r npx @godui/mcp@latest
+```

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -4,6 +4,7 @@
     "---Getting Started---",
     "index",
     "installation",
+    "mcp",
     "---Buttons---",
     "components/buttons/magic-button",
     "components/buttons/shimmer-button",

--- a/apps/docs/public/r/index.json
+++ b/apps/docs/public/r/index.json
@@ -1,0 +1,331 @@
+{
+  "name": "godui",
+  "homepage": "https://godui.design",
+  "generatedAt": "2026-06-25T20:24:19.294Z",
+  "components": [
+    {
+      "name": "animated-beam",
+      "title": "Animated Beam",
+      "description": "An animated gradient beam that travels along a path connecting two separate nodes.",
+      "category": "Visualizations",
+      "dependencies": ["framer-motion"],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add @godui/animated-beam"
+    },
+    {
+      "name": "animated-testimonials",
+      "title": "Animated Testimonials",
+      "description": "A testimonial carousel with a shuffling image stack, word-by-word quote reveal, and autoplay.",
+      "category": "Layout",
+      "dependencies": ["framer-motion"],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add @godui/animated-testimonials"
+    },
+    {
+      "name": "animated-tooltip",
+      "title": "Animated Tooltip",
+      "description": "A tooltip that springs in and tilts in 3D as the pointer moves across its trigger.",
+      "category": "Overlays",
+      "dependencies": ["framer-motion"],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add @godui/animated-tooltip"
+    },
+    {
+      "name": "aurora-text",
+      "title": "Aurora Text",
+      "description": "Gradient text with a rainbow aurora that drifts across the letters.",
+      "category": "Text",
+      "dependencies": [],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add @godui/aurora-text"
+    },
+    {
+      "name": "bento-grid",
+      "title": "Bento Grid",
+      "description": "A modular bento layout of mixed-size cards that stagger in on scroll and lift with a spotlight on hover.",
+      "category": "Layout",
+      "dependencies": ["framer-motion"],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add @godui/bento-grid"
+    },
+    {
+      "name": "border-beam",
+      "title": "Border Beam",
+      "description": "An animated beam of light that travels around the border of its container.",
+      "category": "Effects",
+      "dependencies": ["framer-motion"],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add @godui/border-beam"
+    },
+    {
+      "name": "command-palette",
+      "title": "Command Palette",
+      "description": "A ⌘K command menu with fuzzy filtering, keyboard navigation, and a spring-tracked active highlight.",
+      "category": "Overlays",
+      "dependencies": ["framer-motion"],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add @godui/command-palette"
+    },
+    {
+      "name": "confetti",
+      "title": "Confetti",
+      "description": "A physics-based confetti burst with an imperative fire API for celebratory moments.",
+      "category": "Effects",
+      "dependencies": ["canvas-confetti"],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add @godui/confetti"
+    },
+    {
+      "name": "dock",
+      "title": "Dock",
+      "description": "A macOS-style dock whose items magnify with spring physics as the pointer moves across them.",
+      "category": "Navigation",
+      "dependencies": ["framer-motion"],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add @godui/dock"
+    },
+    {
+      "name": "drawer",
+      "title": "Drawer",
+      "description": "A draggable bottom or side sheet with rubber-band physics, flick-to-dismiss, scrim, and scroll lock.",
+      "category": "Overlays",
+      "dependencies": ["framer-motion"],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add @godui/drawer"
+    },
+    {
+      "name": "dynamic-island",
+      "title": "Dynamic Island",
+      "description": "An Apple-inspired pill that springs between size presets while its content cross-fades.",
+      "category": "Overlays",
+      "dependencies": ["framer-motion"],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add @godui/dynamic-island"
+    },
+    {
+      "name": "elastic-text",
+      "title": "Elastic Text",
+      "description": "Variable-font text whose weight springs up under an automatic spotlight or the pointer.",
+      "category": "Text",
+      "dependencies": ["framer-motion"],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add @godui/elastic-text"
+    },
+    {
+      "name": "globe",
+      "title": "Globe",
+      "description": "A draggable, auto-rotating WebGL globe with glowing location markers.",
+      "category": "Visualizations",
+      "dependencies": ["cobe"],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add @godui/globe"
+    },
+    {
+      "name": "highlighter",
+      "title": "Highlighter",
+      "description": "Hand-drawn rough-notation annotations (highlight, underline, box, circle) over text.",
+      "category": "Text",
+      "dependencies": ["framer-motion", "rough-notation"],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add @godui/highlighter"
+    },
+    {
+      "name": "lamp",
+      "title": "Lamp",
+      "description": "A conic-gradient lamp that ignites and reveals a headline as it scrolls into view.",
+      "category": "Effects",
+      "dependencies": ["framer-motion"],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add @godui/lamp"
+    },
+    {
+      "name": "liquid-glass-card",
+      "title": "Liquid Glass Card",
+      "description": "A glass panel that refracts the content behind it with a mouse-tracked specular highlight.",
+      "category": "Glass",
+      "dependencies": [],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add @godui/liquid-glass-card"
+    },
+    {
+      "name": "liquid-glass-lens",
+      "title": "Liquid Glass Lens",
+      "description": "A circular glass lens that floats over your content and follows the cursor, refracting everything beneath it.",
+      "category": "Glass",
+      "dependencies": [],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add @godui/liquid-glass-lens"
+    },
+    {
+      "name": "magic-button",
+      "title": "Magic Button",
+      "description": "A tactile 3D push button with an animated rainbow edge and shadow.",
+      "category": "Buttons",
+      "dependencies": [],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add @godui/magic-button"
+    },
+    {
+      "name": "magic-input",
+      "title": "Magic Input",
+      "description": "A 3D layered text input that lifts on focus with an optional rainbow edge animation.",
+      "category": "Inputs",
+      "dependencies": [],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add @godui/magic-input"
+    },
+    {
+      "name": "magic-tab",
+      "title": "Magic Tab",
+      "description": "A segmented tab bar where the selected option lifts into a 3D button with an optional rainbow edge.",
+      "category": "Navigation",
+      "dependencies": [],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add @godui/magic-tab"
+    },
+    {
+      "name": "magnetic-button",
+      "title": "Magnetic Button",
+      "description": "A button whose content is magnetically pulled toward the cursor within a sensor range, springing back on exit.",
+      "category": "Buttons",
+      "dependencies": ["framer-motion"],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add @godui/magnetic-button"
+    },
+    {
+      "name": "marquee",
+      "title": "Marquee",
+      "description": "An infinite, seamless scrolling row or column of content that pauses on hover.",
+      "category": "Effects",
+      "dependencies": [],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add @godui/marquee"
+    },
+    {
+      "name": "mask-button",
+      "title": "Mask Button",
+      "description": "A button whose face wipes away on hover via an animated CSS sprite-sheet mask, revealing the label behind it.",
+      "category": "Buttons",
+      "dependencies": [],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add @godui/mask-button"
+    },
+    {
+      "name": "number-ticker",
+      "title": "Number Ticker",
+      "description": "Animates a number to its target value with spring physics when scrolled into view.",
+      "category": "Text",
+      "dependencies": ["framer-motion"],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add @godui/number-ticker"
+    },
+    {
+      "name": "orbiting-circles",
+      "title": "Orbiting Circles",
+      "description": "Icons that orbit a center point on a configurable ring, staying upright as they travel.",
+      "category": "Visualizations",
+      "dependencies": ["framer-motion"],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add @godui/orbiting-circles"
+    },
+    {
+      "name": "pixel-grid",
+      "title": "Pixel Grid",
+      "description": "A grid of flickering squares with an optional cursor spotlight that lights up nearby pixels.",
+      "category": "Backgrounds",
+      "dependencies": [],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add @godui/pixel-grid"
+    },
+    {
+      "name": "progress-fold-button",
+      "title": "Progress Fold Button",
+      "description": "A button whose front face folds back to reveal a controlled progress bar while loading.",
+      "category": "Buttons",
+      "dependencies": [],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add @godui/progress-fold-button"
+    },
+    {
+      "name": "progressive-card-reveal",
+      "title": "Progressive Card Reveal",
+      "description": "A vertical stack of cards where one card expands to its full view while the rest collapse to compact pills, animating the morph between them.",
+      "category": "Layout",
+      "dependencies": ["framer-motion"],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add @godui/progressive-card-reveal"
+    },
+    {
+      "name": "scroll-reveal",
+      "title": "Scroll Reveal",
+      "description": "Reveals its children with a spring as they scroll into view, with optional scroll-velocity skew.",
+      "category": "Effects",
+      "dependencies": ["framer-motion"],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add @godui/scroll-reveal"
+    },
+    {
+      "name": "shimmer-button",
+      "title": "Shimmer Button",
+      "description": "A button with an animated shimmering border light that speeds up on hover.",
+      "category": "Buttons",
+      "dependencies": [],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add @godui/shimmer-button"
+    },
+    {
+      "name": "sparkles",
+      "title": "Sparkles",
+      "description": "A canvas field of twinkling particles rendered behind its content.",
+      "category": "Effects",
+      "dependencies": ["framer-motion"],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add @godui/sparkles"
+    },
+    {
+      "name": "spotlight-card",
+      "title": "Spotlight Card",
+      "description": "A card with a radial spotlight glow that follows the pointer, optionally lighting the border.",
+      "category": "Effects",
+      "dependencies": [],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add @godui/spotlight-card"
+    },
+    {
+      "name": "text-animate",
+      "title": "Text Animate",
+      "description": "Staggered text entrance animations (fade, blur, slide) by character, word, or line.",
+      "category": "Text",
+      "dependencies": ["framer-motion"],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add @godui/text-animate"
+    },
+    {
+      "name": "theme-toggle",
+      "title": "Theme Toggle",
+      "description": "A dark/light switch that reveals the new theme with a circular wipe from the click origin.",
+      "category": "Buttons",
+      "dependencies": ["framer-motion"],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add @godui/theme-toggle"
+    },
+    {
+      "name": "tilt-card",
+      "title": "Tilt Card",
+      "description": "A card that tilts in 3D toward the pointer with parallax depth and a specular glare.",
+      "category": "Layout",
+      "dependencies": ["framer-motion"],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add @godui/tilt-card"
+    },
+    {
+      "name": "toast",
+      "title": "Toast",
+      "description": "Stacked, swipe-dismissible toasts with an imperative toast() API and auto-dismiss.",
+      "category": "Overlays",
+      "dependencies": ["framer-motion"],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add @godui/toast"
+    }
+  ]
+}

--- a/apps/docs/scripts/generate-mcp-index.mjs
+++ b/apps/docs/scripts/generate-mcp-index.mjs
@@ -1,0 +1,59 @@
+// Generates apps/docs/public/r/index.json — a lightweight catalog the GodUI MCP
+// server (@godui/mcp) fetches to power list/search. Source of truth is the root
+// registry.json (names/titles/descriptions/deps); categories come from the docs
+// sidebar config (meta.json). Run via `pnpm build:registry`.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "../../..");
+
+const registry = JSON.parse(
+  readFileSync(resolve(repoRoot, "registry.json"), "utf8"),
+);
+const meta = JSON.parse(
+  readFileSync(resolve(repoRoot, "apps/docs/content/docs/meta.json"), "utf8"),
+);
+
+// Build component-name -> category from the meta.json sidebar. Entries look like
+// "---Buttons---" (a group header) followed by "components/buttons/magic-button".
+const categoryByName = {};
+let currentCategory = null;
+for (const entry of meta.pages) {
+  const header = /^---(.+)---$/.exec(entry);
+  if (header) {
+    currentCategory = header[1].trim();
+    continue;
+  }
+  const match = /^components\/[^/]+\/(.+)$/.exec(entry);
+  if (match && currentCategory) {
+    categoryByName[match[1]] = currentCategory;
+  }
+}
+
+const components = registry.items
+  .filter((item) => item.type !== "registry:theme")
+  .map((item) => ({
+    name: item.name,
+    title: item.title ?? item.name,
+    description: item.description ?? "",
+    category: categoryByName[item.name] ?? "Components",
+    dependencies: item.dependencies ?? [],
+    registryDependencies: item.registryDependencies ?? [],
+    install: `npx shadcn@latest add @godui/${item.name}`,
+  }))
+  .sort((a, b) => a.name.localeCompare(b.name));
+
+const index = {
+  name: registry.name,
+  homepage: registry.homepage,
+  generatedAt: new Date().toISOString(),
+  components,
+};
+
+const outPath = resolve(repoRoot, "apps/docs/public/r/index.json");
+writeFileSync(outPath, `${JSON.stringify(index, null, 2)}\n`);
+
+console.log(`Wrote ${components.length} components to ${outPath}`);

--- a/apps/docs/src/components/mcp-install.tsx
+++ b/apps/docs/src/components/mcp-install.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { DynamicCodeBlock } from "fumadocs-ui/components/dynamic-codeblock";
+import { useState } from "react";
+import { CopyButton } from "@/components/copy-button";
+import { DocsPanel, DocsTabs, PillTabs } from "@/components/docs-tabs";
+
+type PackageManager = "pnpm" | "npm" | "yarn" | "bun";
+
+const packageManagers: PackageManager[] = ["pnpm", "npm", "yarn", "bun"];
+
+/** Editors whose config the `@godui/cli` installer can write. */
+const clients = [
+  { value: "cursor", label: "Cursor" },
+  { value: "windsurf", label: "Windsurf" },
+  { value: "claude", label: "Claude" },
+  { value: "cline", label: "Cline" },
+  { value: "roo-cline", label: "Roo-Cline" },
+];
+
+const MANUAL_CONFIG = `{
+  "mcpServers": {
+    "godui": {
+      "command": "npx",
+      "args": ["-y", "@godui/mcp@latest"]
+    }
+  }
+}`;
+
+function getExecPrefix(manager: PackageManager) {
+  switch (manager) {
+    case "pnpm":
+      return "pnpm dlx";
+    case "npm":
+      return "npx";
+    case "yarn":
+      return "npx";
+    case "bun":
+      return "bunx --bun";
+  }
+}
+
+function TerminalIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      className="size-[15px] shrink-0 text-fd-muted-foreground"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="m4 17 6-6-6-6" />
+      <path d="M12 19h8" />
+    </svg>
+  );
+}
+
+export function MCPInstall() {
+  const [tab, setTab] = useState("cli");
+  const [manager, setManager] = useState<PackageManager>("pnpm");
+  const [client, setClient] = useState("cursor");
+
+  const cliCommand = `${getExecPrefix(manager)} @godui/cli@latest install ${client}`;
+
+  return (
+    <DocsPanel className="my-6">
+      <DocsTabs
+        tabs={[
+          { value: "cli", label: "CLI" },
+          { value: "manual", label: "Manual" },
+        ]}
+        value={tab}
+        onChange={setTab}
+      />
+
+      {tab === "cli" ? (
+        <div className="mt-4 space-y-3">
+          <PillTabs tabs={clients} value={client} onChange={setClient} />
+          <div className="overflow-hidden rounded-xl border border-fd-border bg-fd-card shadow-sm">
+            <div className="flex items-center justify-between gap-3 border-b border-fd-border px-4 py-3">
+              <PillTabs
+                tabs={packageManagers.map((value) => ({ value, label: value }))}
+                value={manager}
+                onChange={(value) => setManager(value as PackageManager)}
+              />
+              <CopyButton value={cliCommand} />
+            </div>
+            <div className="flex items-center gap-3 px-4 py-4">
+              <TerminalIcon />
+              <pre className="overflow-x-auto font-mono text-sm text-fd-foreground">
+                <code>{cliCommand}</code>
+              </pre>
+            </div>
+          </div>
+          <p className="text-sm text-fd-muted-foreground">
+            Then restart your IDE. The installer writes the GodUI server into{" "}
+            {clients.find((c) => c.value === client)?.label}&apos;s MCP config
+            without touching your other servers.
+          </p>
+        </div>
+      ) : (
+        <div className="mt-4 space-y-3">
+          <p className="text-sm text-fd-muted-foreground">
+            Add the following to your MCP config file, then restart your IDE:
+          </p>
+          <DynamicCodeBlock
+            lang="json"
+            code={MANUAL_CONFIG}
+            codeblock={{ allowCopy: true, className: "my-0" }}
+          />
+        </div>
+      )}
+    </DocsPanel>
+  );
+}

--- a/apps/docs/src/components/mdx.tsx
+++ b/apps/docs/src/components/mdx.tsx
@@ -4,6 +4,7 @@ import type { ComponentProps } from "react";
 import { BackgroundShowcase } from "@/components/background-showcase";
 import { ComponentInstall } from "@/components/component-install";
 import { ComponentPreview } from "@/components/component-preview";
+import { MCPInstall } from "@/components/mcp-install";
 
 function Table(props: ComponentProps<"table">) {
   return (
@@ -19,6 +20,7 @@ export function getMDXComponents(components?: MDXComponents) {
     table: Table,
     ComponentPreview,
     ComponentInstall,
+    MCPInstall,
     BackgroundShowcase,
     ...components,
   } satisfies MDXComponents;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "build": "turbo build",
-    "build:registry": "shadcn build --output apps/docs/public/r",
+    "build:registry": "shadcn build --output apps/docs/public/r && node apps/docs/scripts/generate-mcp-index.mjs",
     "dev": "turbo dev",
     "dev:portless": "portless",
     "lint": "turbo lint",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,46 @@
+# @godui/cli
+
+One command to add the [GodUI MCP server](https://www.npmjs.com/package/@godui/mcp)
+to your AI IDE. It writes the MCP config for you — no manual JSON editing.
+
+## Usage
+
+```bash
+npx @godui/cli@latest install cursor
+```
+
+Then **restart your IDE** and ask it for any GodUI component.
+
+### Supported clients
+
+```bash
+npx @godui/cli@latest install <client>
+```
+
+- `cursor`
+- `windsurf`
+- `claude` (Claude Desktop)
+- `cline`
+- `roo-cline`
+
+The command merges the GodUI server into the client's existing MCP config
+(creating it if needed) without touching your other servers.
+
+## What it writes
+
+```json
+{
+  "mcpServers": {
+    "godui": {
+      "command": "npx",
+      "args": ["-y", "@godui/mcp@latest"]
+    }
+  }
+}
+```
+
+Prefer to do it by hand? See the [Manual install](https://godui.design/docs/mcp).
+
+## License
+
+MIT

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@godui/cli",
+  "version": "0.1.0",
+  "description": "Install the GodUI MCP server into your AI IDE with one command.",
+  "keywords": [
+    "godui",
+    "cli",
+    "mcp",
+    "cursor",
+    "windsurf",
+    "claude",
+    "cline"
+  ],
+  "homepage": "https://godui.design",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/godui-design/godui.git",
+    "directory": "packages/cli"
+  },
+  "license": "MIT",
+  "type": "module",
+  "bin": {
+    "godui": "dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "start": "node dist/index.js",
+    "lint": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "tsup": "^8.3.5",
+    "typescript": "^5.9.3",
+    "vitest": "^3.0.0"
+  },
+  "engines": {
+    "node": ">=20.19.0"
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,97 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname } from "node:path";
+import {
+  getConfigPath,
+  mergeMcpConfig,
+  normalizeClient,
+  type PlatformEnv,
+  SUPPORTED_CLIENTS,
+} from "./install.js";
+
+const HELP = `godui — install the GodUI MCP server into your AI IDE
+
+Usage:
+  godui install <client>
+
+Clients:
+  ${SUPPORTED_CLIENTS.join(", ")}
+
+Examples:
+  npx @godui/cli@latest install cursor
+  pnpm dlx @godui/cli@latest install claude
+
+After running, restart your IDE. Then ask it for any GodUI component.`;
+
+function currentEnv(): PlatformEnv {
+  return {
+    platform: process.platform,
+    home: homedir(),
+    appData: process.env.APPDATA,
+  };
+}
+
+function fail(message: string): never {
+  console.error(`✖ ${message}`);
+  process.exit(1);
+}
+
+function run(argv: string[]) {
+  const [command, clientArg] = argv;
+
+  if (
+    !command ||
+    command === "--help" ||
+    command === "-h" ||
+    command === "help"
+  ) {
+    console.log(HELP);
+    return;
+  }
+
+  if (command !== "install") {
+    fail(`Unknown command "${command}". Run "godui --help".`);
+  }
+
+  if (!clientArg) {
+    fail(`Missing client. Choose one of: ${SUPPORTED_CLIENTS.join(", ")}.`);
+  }
+
+  const client = normalizeClient(clientArg);
+  if (!client) {
+    fail(
+      `Unknown client "${clientArg}". Choose one of: ${SUPPORTED_CLIENTS.join(", ")}.`,
+    );
+  }
+
+  const configPath = getConfigPath(client, currentEnv());
+
+  let existing: Record<string, unknown> | null = null;
+  try {
+    existing = JSON.parse(readFileSync(configPath, "utf8"));
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== "ENOENT") {
+      fail(
+        `Found ${configPath} but couldn't parse it as JSON. Fix or remove it, then retry. (${String(error)})`,
+      );
+    }
+    // ENOENT — first install, start from an empty config.
+  }
+
+  const merged = mergeMcpConfig(existing);
+
+  try {
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(configPath, `${JSON.stringify(merged, null, 2)}\n`);
+  } catch (error) {
+    fail(`Couldn't write ${configPath}: ${String(error)}`);
+  }
+
+  console.log(`✔ Added the GodUI MCP server to ${client}.`);
+  console.log(`  ${configPath}`);
+  console.log("");
+  console.log("Restart your IDE, then ask it to add any GodUI component.");
+}
+
+run(process.argv.slice(2));

--- a/packages/cli/src/install.test.ts
+++ b/packages/cli/src/install.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+  GODUI_SERVER,
+  GODUI_SERVER_KEY,
+  getConfigPath,
+  mergeMcpConfig,
+  normalizeClient,
+  type PlatformEnv,
+} from "./install.js";
+
+const mac: PlatformEnv = { platform: "darwin", home: "/Users/x" };
+const win: PlatformEnv = {
+  platform: "win32",
+  home: "C:\\Users\\x",
+  appData: "C:\\Users\\x\\AppData\\Roaming",
+};
+const linux: PlatformEnv = { platform: "linux", home: "/home/x" };
+
+describe("normalizeClient", () => {
+  it("maps aliases to canonical ids", () => {
+    expect(normalizeClient("Cursor")).toBe("cursor");
+    expect(normalizeClient("claude-desktop")).toBe("claude");
+    expect(normalizeClient("roo")).toBe("roo-cline");
+    expect(normalizeClient(" RooCode ")).toBe("roo-cline");
+  });
+
+  it("returns undefined for unknown clients", () => {
+    expect(normalizeClient("vim")).toBeUndefined();
+  });
+});
+
+describe("getConfigPath", () => {
+  it("resolves simple home-relative clients", () => {
+    expect(getConfigPath("cursor", mac)).toBe("/Users/x/.cursor/mcp.json");
+    expect(getConfigPath("windsurf", mac)).toBe(
+      "/Users/x/.codeium/windsurf/mcp_config.json",
+    );
+  });
+
+  it("resolves Claude Desktop per platform", () => {
+    expect(getConfigPath("claude", mac)).toBe(
+      "/Users/x/Library/Application Support/Claude/claude_desktop_config.json",
+    );
+    expect(getConfigPath("claude", linux)).toBe(
+      "/home/x/.config/Claude/claude_desktop_config.json",
+    );
+    // node:path joins with the host separator, so on a POSIX CI host the
+    // win32 base keeps backslashes while appended segments use "/". Assert on
+    // the parts rather than a fixed separator.
+    const winPath = getConfigPath("claude", win);
+    expect(winPath).toContain(win.appData as string);
+    expect(winPath).toContain("Claude");
+    expect(winPath.endsWith("claude_desktop_config.json")).toBe(true);
+  });
+
+  it("resolves Cline/Roo under VS Code globalStorage", () => {
+    expect(getConfigPath("cline", mac)).toBe(
+      "/Users/x/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json",
+    );
+    expect(getConfigPath("roo-cline", linux)).toBe(
+      "/home/x/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/mcp_settings.json",
+    );
+  });
+});
+
+describe("mergeMcpConfig", () => {
+  it("adds the godui server to an empty config", () => {
+    const out = mergeMcpConfig(null);
+    expect(out.mcpServers?.[GODUI_SERVER_KEY]).toEqual(GODUI_SERVER);
+  });
+
+  it("preserves existing servers and unrelated keys", () => {
+    const out = mergeMcpConfig({
+      schema: 1,
+      mcpServers: { other: { command: "x", args: [] } },
+    });
+    expect(out.schema).toBe(1);
+    expect(out.mcpServers?.other).toEqual({ command: "x", args: [] });
+    expect(out.mcpServers?.[GODUI_SERVER_KEY]).toEqual(GODUI_SERVER);
+  });
+
+  it("overwrites a stale godui entry", () => {
+    const out = mergeMcpConfig({
+      mcpServers: { godui: { command: "old", args: ["old"] } },
+    });
+    expect(out.mcpServers?.[GODUI_SERVER_KEY]).toEqual(GODUI_SERVER);
+  });
+});

--- a/packages/cli/src/install.ts
+++ b/packages/cli/src/install.ts
@@ -1,0 +1,145 @@
+// Pure config-resolution + merge logic for the GodUI CLI. Kept free of fs/process
+// side effects so it can be unit tested across platforms.
+
+import { join } from "node:path";
+
+export type ClientId = "cursor" | "windsurf" | "claude" | "cline" | "roo-cline";
+
+export const SUPPORTED_CLIENTS: ClientId[] = [
+  "cursor",
+  "windsurf",
+  "claude",
+  "cline",
+  "roo-cline",
+];
+
+/** Accept a few friendly aliases for client names. */
+export function normalizeClient(input: string): ClientId | undefined {
+  const value = input.trim().toLowerCase();
+  const aliases: Record<string, ClientId> = {
+    cursor: "cursor",
+    windsurf: "windsurf",
+    claude: "claude",
+    "claude-desktop": "claude",
+    cline: "cline",
+    roo: "roo-cline",
+    "roo-cline": "roo-cline",
+    roocode: "roo-cline",
+  };
+  return aliases[value];
+}
+
+export type PlatformEnv = {
+  platform: NodeJS.Platform;
+  home: string;
+  /** %APPDATA% on Windows; falsy elsewhere. */
+  appData?: string;
+};
+
+/** VS Code global storage dir, parent of per-extension MCP settings. */
+function vscodeGlobalStorage({ platform, home, appData }: PlatformEnv): string {
+  if (platform === "win32") {
+    return join(
+      appData ?? join(home, "AppData", "Roaming"),
+      "Code",
+      "User",
+      "globalStorage",
+    );
+  }
+  if (platform === "darwin") {
+    return join(
+      home,
+      "Library",
+      "Application Support",
+      "Code",
+      "User",
+      "globalStorage",
+    );
+  }
+  return join(home, ".config", "Code", "User", "globalStorage");
+}
+
+/** Resolve the MCP config file path for a client on the given platform. */
+export function getConfigPath(client: ClientId, env: PlatformEnv): string {
+  const { platform, home, appData } = env;
+
+  switch (client) {
+    case "cursor":
+      return join(home, ".cursor", "mcp.json");
+
+    case "windsurf":
+      return join(home, ".codeium", "windsurf", "mcp_config.json");
+
+    case "claude": {
+      if (platform === "win32") {
+        return join(
+          appData ?? join(home, "AppData", "Roaming"),
+          "Claude",
+          "claude_desktop_config.json",
+        );
+      }
+      if (platform === "darwin") {
+        return join(
+          home,
+          "Library",
+          "Application Support",
+          "Claude",
+          "claude_desktop_config.json",
+        );
+      }
+      return join(home, ".config", "Claude", "claude_desktop_config.json");
+    }
+
+    case "cline":
+      return join(
+        vscodeGlobalStorage(env),
+        "saoudrizwan.claude-dev",
+        "settings",
+        "cline_mcp_settings.json",
+      );
+
+    case "roo-cline":
+      return join(
+        vscodeGlobalStorage(env),
+        "rooveterinaryinc.roo-cline",
+        "settings",
+        "mcp_settings.json",
+      );
+  }
+}
+
+export type McpServerConfig = {
+  command: string;
+  args: string[];
+};
+
+/** The GodUI MCP server entry written into every client config. */
+export const GODUI_SERVER: McpServerConfig = {
+  command: "npx",
+  args: ["-y", "@godui/mcp@latest"],
+};
+
+export const GODUI_SERVER_KEY = "godui";
+
+type McpConfig = {
+  mcpServers?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+/**
+ * Merge the GodUI server into an existing config object without clobbering other
+ * servers or unrelated keys. Returns a new object.
+ */
+export function mergeMcpConfig(
+  existing: McpConfig | null | undefined,
+): McpConfig {
+  const base: McpConfig =
+    existing && typeof existing === "object" ? existing : {};
+  return {
+    ...base,
+    mcpServers: {
+      ...(base.mcpServers ?? {}),
+      [GODUI_SERVER_KEY]: GODUI_SERVER,
+    },
+  };
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "types": ["vitest/globals", "node"]
+  },
+  "include": ["src", "tsup.config.ts", "vitest.config.ts"]
+}

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  target: "node20",
+  clean: true,
+  minify: false,
+  // Shebang so the published bin is directly executable via npx.
+  banner: { js: "#!/usr/bin/env node" },
+});

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+  },
+});

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,58 @@
+# @godui/mcp
+
+Model Context Protocol server for [GodUI](https://godui.design). Add it to your
+AI IDE and ask for any GodUI component by description — the agent discovers it,
+gets the install command, and writes the source for you.
+
+## Install
+
+### Manual (any MCP client)
+
+Add this to your MCP config file:
+
+```json
+{
+  "mcpServers": {
+    "godui": {
+      "command": "npx",
+      "args": ["-y", "@godui/mcp@latest"]
+    }
+  }
+}
+```
+
+Then **restart your IDE**.
+
+- **Cursor** — `~/.cursor/mcp.json` (or `.cursor/mcp.json` in a project)
+- **Windsurf** — `~/.codeium/windsurf/mcp_config.json`
+- **Claude Desktop** — `claude_desktop_config.json`
+- **Cline / Roo-Cline** — the MCP settings JSON in the extension
+
+## Usage
+
+Ask your IDE to use any GodUI component:
+
+- "Add a GodUI magic button"
+- "Add a marquee of logos"
+- "Add an animated gradient background"
+- "Add a number ticker that counts to 1000"
+
+## Tools
+
+- **`list_components`** — list the full catalog, optionally filtered by category.
+- **`search_components`** — find components by what they do (natural language).
+- **`get_component`** — fetch one component's install command + full source.
+
+## How it works
+
+The server fetches the live GodUI registry at `https://godui.design/r`, so it
+always serves the latest components without an update. Override the base for
+local testing:
+
+```bash
+GODUI_REGISTRY_URL=http://localhost:3000/r npx @godui/mcp@latest
+```
+
+## License
+
+MIT

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@godui/mcp",
+  "version": "0.1.0",
+  "description": "Model Context Protocol server for GodUI — let your AI IDE discover and install GodUI components by description.",
+  "keywords": [
+    "godui",
+    "mcp",
+    "model-context-protocol",
+    "shadcn",
+    "ui",
+    "components",
+    "ai"
+  ],
+  "homepage": "https://godui.design",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/godui-design/godui.git",
+    "directory": "packages/mcp"
+  },
+  "license": "MIT",
+  "type": "module",
+  "bin": {
+    "godui-mcp": "dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "start": "node dist/index.js",
+    "lint": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^3.25.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "tsup": "^8.3.5",
+    "typescript": "^5.9.3",
+    "vitest": "^3.0.0"
+  },
+  "engines": {
+    "node": ">=20.19.0"
+  }
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,0 +1,84 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+import { createRegistryClient, registryBaseUrl } from "./registry-client.js";
+import { getComponent, listComponents, searchComponents } from "./tools.js";
+
+const client = createRegistryClient();
+
+const server = new McpServer({
+  name: "godui",
+  version: "0.1.0",
+});
+
+const text = (value: string) => ({
+  content: [{ type: "text" as const, text: value }],
+});
+
+server.registerTool(
+  "list_components",
+  {
+    title: "List GodUI components",
+    description:
+      "List every GodUI component in the catalog (name, title, description, category, install command). Call this first to see what's available. Optionally filter by category such as Buttons, Text, Effects, Backgrounds.",
+    inputSchema: {
+      category: z
+        .string()
+        .optional()
+        .describe(
+          "Optional category filter, e.g. 'Buttons', 'Text', 'Effects', 'Backgrounds'.",
+        ),
+    },
+  },
+  async ({ category }) => text(await listComponents(client, category)),
+);
+
+server.registerTool(
+  "search_components",
+  {
+    title: "Search GodUI components",
+    description:
+      "Find GodUI components by what they do. Use natural language, e.g. '3d button', 'marquee of logos', 'animated gradient background', 'number counter'. Returns the best matches to then fetch with get_component.",
+    inputSchema: {
+      query: z
+        .string()
+        .describe("What you want the component to do, in plain words."),
+    },
+  },
+  async ({ query }) => text(await searchComponents(client, query)),
+);
+
+server.registerTool(
+  "get_component",
+  {
+    title: "Get a GodUI component",
+    description:
+      "Fetch a single GodUI component by its exact name (from list_components or search_components). Returns the install command, dependencies, and full source code so you can install it or write the files directly. For background components, pass an optional variant.",
+    inputSchema: {
+      name: z
+        .string()
+        .describe(
+          "Exact component name, e.g. 'magic-button' (the '@godui/' prefix is optional).",
+        ),
+      variant: z
+        .string()
+        .optional()
+        .describe(
+          "Optional variant for background components, e.g. 'aurora-glow'.",
+        ),
+    },
+  },
+  async ({ name, variant }) => text(await getComponent(client, name, variant)),
+);
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  // stderr is safe; stdout is reserved for the MCP protocol stream.
+  console.error(`GodUI MCP server running (registry: ${registryBaseUrl})`);
+}
+
+main().catch((error) => {
+  console.error("GodUI MCP server failed to start:", error);
+  process.exit(1);
+});

--- a/packages/mcp/src/registry-client.test.ts
+++ b/packages/mcp/src/registry-client.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { createRegistryClient } from "./registry-client.js";
+
+describe("registry client", () => {
+  it("fetches the index from <base>/index.json and caches it", async () => {
+    const fetchJsonImpl = vi
+      .fn()
+      .mockResolvedValue({ name: "godui", homepage: "x", components: [] });
+    const client = createRegistryClient({
+      baseUrl: "http://localhost:3000/r",
+      fetchJsonImpl,
+    });
+
+    await client.getIndex();
+    await client.getIndex();
+
+    expect(fetchJsonImpl).toHaveBeenCalledTimes(1);
+    expect(fetchJsonImpl).toHaveBeenCalledWith(
+      "http://localhost:3000/r/index.json",
+    );
+  });
+
+  it("fetches a component, strips the @godui/ prefix, and caches per key", async () => {
+    const fetchJsonImpl = vi.fn().mockResolvedValue({ name: "magic-button" });
+    const client = createRegistryClient({
+      baseUrl: "http://localhost:3000/r",
+      fetchJsonImpl,
+    });
+
+    await client.getComponent("@godui/magic-button");
+    await client.getComponent("magic-button");
+
+    expect(fetchJsonImpl).toHaveBeenCalledTimes(1);
+    expect(fetchJsonImpl).toHaveBeenCalledWith(
+      "http://localhost:3000/r/magic-button.json",
+    );
+  });
+
+  it("appends a variant query for background components", async () => {
+    const fetchJsonImpl = vi.fn().mockResolvedValue({ name: "gradient" });
+    const client = createRegistryClient({
+      baseUrl: "http://localhost:3000/r",
+      fetchJsonImpl,
+    });
+
+    await client.getComponent("gradient-background", "aurora-glow");
+
+    expect(fetchJsonImpl).toHaveBeenCalledWith(
+      "http://localhost:3000/r/gradient-background.json?variant=aurora-glow",
+    );
+  });
+
+  it("trims a trailing slash from the base url", async () => {
+    const fetchJsonImpl = vi.fn().mockResolvedValue({ components: [] });
+    const client = createRegistryClient({
+      baseUrl: "http://localhost:3000/r/",
+      fetchJsonImpl,
+    });
+
+    await client.getIndex();
+
+    expect(fetchJsonImpl).toHaveBeenCalledWith(
+      "http://localhost:3000/r/index.json",
+    );
+  });
+});

--- a/packages/mcp/src/registry-client.ts
+++ b/packages/mcp/src/registry-client.ts
@@ -1,0 +1,100 @@
+// Thin HTTP client over the GodUI shadcn registry. Holds no bundled component
+// data — it fetches the live catalog so even an old pinned MCP version serves
+// the newest components after each site deploy. Results are cached per process.
+
+const DEFAULT_BASE_URL = "https://godui.design/r";
+
+/** Base registry URL, overridable for local testing (e.g. http://localhost:3000/r). */
+export const registryBaseUrl = (
+  process.env.GODUI_REGISTRY_URL ?? DEFAULT_BASE_URL
+).replace(/\/$/, "");
+
+export type CatalogComponent = {
+  name: string;
+  title: string;
+  description: string;
+  category: string;
+  dependencies: string[];
+  registryDependencies: string[];
+  install: string;
+};
+
+export type CatalogIndex = {
+  name: string;
+  homepage: string;
+  generatedAt?: string;
+  components: CatalogComponent[];
+};
+
+export type RegistryFile = {
+  path: string;
+  target?: string;
+  type?: string;
+  content?: string;
+};
+
+export type RegistryItem = {
+  name: string;
+  title?: string;
+  description?: string;
+  type?: string;
+  dependencies?: string[];
+  registryDependencies?: string[];
+  files?: RegistryFile[];
+  cssVars?: Record<string, unknown>;
+  css?: Record<string, unknown>;
+};
+
+export type RegistryClient = {
+  getIndex(): Promise<CatalogIndex>;
+  getComponent(name: string, variant?: string): Promise<RegistryItem>;
+};
+
+async function fetchJson<T>(url: string): Promise<T> {
+  let res: Response;
+  try {
+    res = await fetch(url, { headers: { accept: "application/json" } });
+  } catch (cause) {
+    throw new Error(
+      `Failed to reach GodUI registry at ${url}: ${String(cause)}`,
+    );
+  }
+  if (!res.ok) {
+    throw new Error(
+      `GodUI registry request failed (${res.status} ${res.statusText}): ${url}`,
+    );
+  }
+  return (await res.json()) as T;
+}
+
+/**
+ * Create a registry client. `fetchImpl` is injectable for tests; production
+ * uses the global `fetch`.
+ */
+export function createRegistryClient(
+  options: { baseUrl?: string; fetchJsonImpl?: typeof fetchJson } = {},
+): RegistryClient {
+  const baseUrl = (options.baseUrl ?? registryBaseUrl).replace(/\/$/, "");
+  const get = options.fetchJsonImpl ?? fetchJson;
+
+  let indexCache: Promise<CatalogIndex> | undefined;
+  const componentCache = new Map<string, Promise<RegistryItem>>();
+
+  return {
+    getIndex() {
+      indexCache ??= get<CatalogIndex>(`${baseUrl}/index.json`);
+      return indexCache;
+    },
+    getComponent(name, variant) {
+      const slug = name.trim().replace(/^@godui\//, "");
+      const query = variant ? `?variant=${encodeURIComponent(variant)}` : "";
+      const key = `${slug}${query}`;
+      let pending = componentCache.get(key);
+      if (!pending) {
+        pending = get<RegistryItem>(`${baseUrl}/${slug}.json${query}`);
+        componentCache.set(key, pending);
+      }
+      return pending;
+    },
+  };
+}

--- a/packages/mcp/src/tools.test.ts
+++ b/packages/mcp/src/tools.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import type {
+  CatalogIndex,
+  RegistryClient,
+  RegistryItem,
+} from "./registry-client.js";
+import { getComponent, listComponents, searchComponents } from "./tools.js";
+
+const index: CatalogIndex = {
+  name: "godui",
+  homepage: "https://godui.design",
+  components: [
+    {
+      name: "magic-button",
+      title: "Magic Button",
+      description: "A tactile 3D push button with an animated rainbow edge.",
+      category: "Buttons",
+      dependencies: [],
+      registryDependencies: ["@godui/godui-theme"],
+      install: "npx shadcn@latest add @godui/magic-button",
+    },
+    {
+      name: "marquee",
+      title: "Marquee",
+      description: "An infinite scrolling row of logos or cards.",
+      category: "Effects",
+      dependencies: [],
+      registryDependencies: ["@godui/godui-theme"],
+      install: "npx shadcn@latest add @godui/marquee",
+    },
+    {
+      name: "number-ticker",
+      title: "Number Ticker",
+      description: "Animates a number counting up to a target value.",
+      category: "Text",
+      dependencies: [],
+      registryDependencies: ["@godui/godui-theme"],
+      install: "npx shadcn@latest add @godui/number-ticker",
+    },
+  ],
+};
+
+const magicButtonItem: RegistryItem = {
+  name: "magic-button",
+  title: "Magic Button",
+  description: "A tactile 3D push button with an animated rainbow edge.",
+  dependencies: ["framer-motion"],
+  registryDependencies: ["@godui/godui-theme"],
+  files: [
+    {
+      path: "packages/components/src/magic-button/magic-button.tsx",
+      target: "components/godui/magic-button.tsx",
+      content: "export function MagicButton() { return null; }",
+    },
+  ],
+  cssVars: { theme: { "animate-magic-rainbow": "magic-rainbow 2s linear" } },
+};
+
+function fakeClient(overrides: Partial<RegistryClient> = {}): RegistryClient {
+  return {
+    getIndex: async () => index,
+    getComponent: async () => magicButtonItem,
+    ...overrides,
+  };
+}
+
+describe("listComponents", () => {
+  it("lists all components by default", async () => {
+    const out = await listComponents(fakeClient());
+    expect(out).toContain("GodUI components (3)");
+    expect(out).toContain("magic-button");
+    expect(out).toContain("marquee");
+    expect(out).toContain("number-ticker");
+  });
+
+  it("filters by category (case-insensitive)", async () => {
+    const out = await listComponents(fakeClient(), "buttons");
+    expect(out).toContain("magic-button");
+    expect(out).not.toContain("marquee");
+  });
+
+  it("reports available categories when the filter has no matches", async () => {
+    const out = await listComponents(fakeClient(), "nope");
+    expect(out).toContain("No GodUI components found");
+    expect(out).toContain("Buttons");
+  });
+});
+
+describe("searchComponents", () => {
+  it("matches on description terms", async () => {
+    const out = await searchComponents(fakeClient(), "scrolling logos");
+    expect(out.indexOf("marquee")).toBeGreaterThan(-1);
+  });
+
+  it("ranks name matches highest", async () => {
+    const out = await searchComponents(fakeClient(), "number");
+    const firstLine = out.split("\n").find((l) => l.startsWith("- "));
+    expect(firstLine).toContain("number-ticker");
+  });
+
+  it("returns a helpful message on no match", async () => {
+    const out = await searchComponents(fakeClient(), "xyzzy");
+    expect(out).toContain("No GodUI components matched");
+  });
+});
+
+describe("getComponent", () => {
+  it("returns install command, deps, and source", async () => {
+    const out = await getComponent(fakeClient(), "magic-button");
+    expect(out).toContain("npx shadcn@latest add @godui/magic-button");
+    expect(out).toContain("framer-motion");
+    expect(out).toContain("export function MagicButton()");
+    expect(out).toContain("CSS variables");
+  });
+
+  it("strips the @godui/ prefix from the name", async () => {
+    let received = "";
+    const client = fakeClient({
+      getComponent: async (name) => {
+        received = name;
+        return magicButtonItem;
+      },
+    });
+    await getComponent(client, "@godui/magic-button");
+    expect(received).toBe("magic-button");
+  });
+
+  it("uses a variant URL install command when a variant is given", async () => {
+    const out = await getComponent(
+      fakeClient(),
+      "gradient-background",
+      "aurora-glow",
+    );
+    expect(out).toContain(
+      'add "https://godui.design/r/gradient-background.json?variant=aurora-glow"',
+    );
+  });
+
+  it("returns a friendly error when the component is missing", async () => {
+    const client = fakeClient({
+      getComponent: async () => {
+        throw new Error("404 Not Found");
+      },
+    });
+    const out = await getComponent(client, "does-not-exist");
+    expect(out).toContain("Could not load GodUI component");
+    expect(out).toContain("does-not-exist");
+  });
+});

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1,0 +1,153 @@
+// Pure tool implementations — kept free of MCP wiring so they can be unit
+// tested directly. Each returns a plain string rendered to the agent.
+
+import type {
+  CatalogComponent,
+  RegistryClient,
+  RegistryItem,
+} from "./registry-client.js";
+
+function formatCatalogLine(c: CatalogComponent): string {
+  return `- ${c.name} — ${c.title}: ${c.description} [${c.category}]`;
+}
+
+/** List the full catalog, optionally filtered to a single category. */
+export async function listComponents(
+  client: RegistryClient,
+  category?: string,
+): Promise<string> {
+  const index = await client.getIndex();
+  let components = index.components;
+
+  if (category) {
+    const wanted = category.toLowerCase();
+    components = components.filter((c) => c.category.toLowerCase() === wanted);
+    if (components.length === 0) {
+      const categories = [...new Set(index.components.map((c) => c.category))]
+        .sort()
+        .join(", ");
+      return `No GodUI components found in category "${category}". Available categories: ${categories}.`;
+    }
+  }
+
+  const header = category
+    ? `GodUI components in "${category}" (${components.length}):`
+    : `GodUI components (${components.length}). Install any with: npx shadcn@latest add @godui/<name>`;
+
+  return `${header}\n${components.map(formatCatalogLine).join("\n")}`;
+}
+
+function scoreMatch(c: CatalogComponent, terms: string[]): number {
+  const haystack =
+    `${c.name} ${c.title} ${c.description} ${c.category}`.toLowerCase();
+  let score = 0;
+  for (const term of terms) {
+    if (!haystack.includes(term)) continue;
+    score += 1;
+    if (c.name.toLowerCase().includes(term)) score += 2;
+    if (c.title.toLowerCase().includes(term)) score += 1;
+  }
+  return score;
+}
+
+/** Rank catalog entries against a free-text query. */
+export async function searchComponents(
+  client: RegistryClient,
+  query: string,
+): Promise<string> {
+  const terms = query
+    .toLowerCase()
+    .split(/\s+/)
+    .map((t) => t.trim())
+    .filter(Boolean);
+
+  const index = await client.getIndex();
+  if (terms.length === 0) {
+    return listComponents(client);
+  }
+
+  const ranked = index.components
+    .map((c) => ({ c, score: scoreMatch(c, terms) }))
+    .filter((r) => r.score > 0)
+    .sort((a, b) => b.score - a.score || a.c.name.localeCompare(b.c.name))
+    .slice(0, 10);
+
+  if (ranked.length === 0) {
+    return `No GodUI components matched "${query}". Use list_components to browse the full catalog.`;
+  }
+
+  return `GodUI components matching "${query}":\n${ranked
+    .map((r) => formatCatalogLine(r.c))
+    .join(
+      "\n",
+    )}\n\nUse get_component with a name above to fetch its source and install command.`;
+}
+
+function renderRecord(label: string, record?: Record<string, unknown>): string {
+  if (!record || Object.keys(record).length === 0) return "";
+  return `\n## ${label}\n\n\`\`\`json\n${JSON.stringify(record, null, 2)}\n\`\`\``;
+}
+
+/** Full component payload: metadata, install command, and source files. */
+export async function getComponent(
+  client: RegistryClient,
+  name: string,
+  variant?: string,
+): Promise<string> {
+  const slug = name.trim().replace(/^@godui\//, "");
+  let item: RegistryItem;
+  try {
+    item = await client.getComponent(slug, variant);
+  } catch (error) {
+    return `Could not load GodUI component "${slug}": ${
+      error instanceof Error ? error.message : String(error)
+    }\nUse list_components or search_components to find a valid name.`;
+  }
+
+  const installTarget = variant
+    ? `"https://godui.design/r/${slug}.json?variant=${variant}"`
+    : `@godui/${slug}`;
+
+  const parts: string[] = [
+    `# ${item.title ?? slug}`,
+    "",
+    item.description ?? "",
+    "",
+    "## Install",
+    "",
+    "```bash",
+    `npx shadcn@latest add ${installTarget}`,
+    "```",
+    "",
+    "This copies the source into `components/godui/` and merges GodUI theme tokens + styles into your global stylesheet automatically.",
+  ];
+
+  if (item.dependencies?.length) {
+    parts.push("", `**npm dependencies:** ${item.dependencies.join(", ")}`);
+  }
+  if (item.registryDependencies?.length) {
+    parts.push(
+      "",
+      `**Registry dependencies:** ${item.registryDependencies.join(", ")}`,
+    );
+  }
+
+  for (const file of item.files ?? []) {
+    parts.push(
+      "",
+      `## Source — \`${file.target ?? file.path}\``,
+      "",
+      "```tsx",
+      file.content ?? "(source not inlined — install via the command above)",
+      "```",
+    );
+  }
+
+  parts.push(renderRecord("CSS variables", item.cssVars));
+  parts.push(renderRecord("CSS", item.css));
+
+  return parts
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "types": ["vitest/globals", "node"]
+  },
+  "include": ["src", "tsup.config.ts", "vitest.config.ts"]
+}

--- a/packages/mcp/tsup.config.ts
+++ b/packages/mcp/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  target: "node20",
+  clean: true,
+  minify: false,
+  // Shebang so the published bin is directly executable via npx.
+  banner: { js: "#!/usr/bin/env node" },
+});

--- a/packages/mcp/vitest.config.ts
+++ b/packages/mcp/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,13 +40,13 @@ importers:
         version: 12.40.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       fumadocs-core:
         specifier: 16.10.2
-        version: 16.10.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.4))(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
+        version: 16.10.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.4))(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76)
       fumadocs-mdx:
         specifier: 15.0.12
-        version: 15.0.12(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.10.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.4))(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0))
+        version: 15.0.12(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.10.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.4))(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76))(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0))
       fumadocs-ui:
         specifier: 16.10.2
-        version: 16.10.2(@tailwindcss/oxide@4.3.1)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.10.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.4))(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.3.1)
+        version: 16.10.2(@tailwindcss/oxide@4.3.1)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.10.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.4))(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76))(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.3.1)
       geist:
         specifier: ^1.7.2
         version: 1.7.2(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
@@ -158,6 +158,21 @@ importers:
         specifier: ^7.3.1
         version: 7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)
 
+  packages/cli:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.20.0
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))
+
   packages/components:
     dependencies:
       canvas-confetti:
@@ -224,6 +239,28 @@ importers:
       vitest:
         specifier: ^3.0.0
         version: 3.2.6(@types/debug@4.1.13)(@types/node@25.9.3)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.9.3)(typescript@5.9.3))
+
+  packages/mcp:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@3.25.76)
+      zod:
+        specifier: ^3.25.0
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.20.0
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))
 
 packages:
 
@@ -2343,6 +2380,9 @@ packages:
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
+  '@types/node@22.20.0':
+    resolution: {integrity: sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==}
 
   '@types/node@25.9.3':
     resolution: {integrity: sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==}
@@ -5780,6 +5820,9 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
@@ -6790,12 +6833,33 @@ snapshots:
 
   '@inquirer/ansi@2.0.7': {}
 
+  '@inquirer/confirm@6.1.1(@types/node@22.20.0)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@22.20.0)
+      '@inquirer/type': 4.0.7(@types/node@22.20.0)
+    optionalDependencies:
+      '@types/node': 22.20.0
+    optional: true
+
   '@inquirer/confirm@6.1.1(@types/node@25.9.3)':
     dependencies:
       '@inquirer/core': 11.2.1(@types/node@25.9.3)
       '@inquirer/type': 4.0.7(@types/node@25.9.3)
     optionalDependencies:
       '@types/node': 25.9.3
+
+  '@inquirer/core@11.2.1(@types/node@22.20.0)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@22.20.0)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.2
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 22.20.0
+    optional: true
 
   '@inquirer/core@11.2.1(@types/node@25.9.3)':
     dependencies:
@@ -6810,6 +6874,11 @@ snapshots:
       '@types/node': 25.9.3
 
   '@inquirer/figures@2.0.7': {}
+
+  '@inquirer/type@4.0.7(@types/node@22.20.0)':
+    optionalDependencies:
+      '@types/node': 22.20.0
+    optional: true
 
   '@inquirer/type@4.0.7(@types/node@25.9.3)':
     optionalDependencies:
@@ -7898,6 +7967,10 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/node@22.20.0':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@25.9.3':
     dependencies:
       undici-types: 7.24.6
@@ -7914,7 +7987,7 @@ snapshots:
 
   '@types/set-cookie-parser@2.4.10':
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 22.20.0
 
   '@types/statuses@2.0.6': {}
 
@@ -8126,6 +8199,15 @@ snapshots:
       '@vitest/utils': 3.2.6
       chai: 5.3.3
       tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.6(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@vitest/spy': 3.2.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.14.6(@types/node@22.20.0)(typescript@5.9.3)
+      vite: 7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)
 
   '@vitest/mocker@3.2.6(msw@2.14.6(@types/node@25.9.3)(typescript@5.9.3))(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0))':
     dependencies:
@@ -8923,7 +9005,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
@@ -8956,7 +9038,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -8971,7 +9053,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -9025,8 +9107,8 @@ snapshots:
       '@babel/parser': 7.29.7
       eslint: 9.39.4(jiti@2.7.0)
       hermes-parser: 0.25.1
-      zod: 4.4.3
-      zod-validation-error: 4.0.2(zod@4.4.3)
+      zod: 3.25.76
+      zod-validation-error: 4.0.2(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
 
@@ -9380,7 +9462,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@16.10.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.4))(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3):
+  fumadocs-core@16.10.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.4))(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76):
     dependencies:
       '@fuma-translate/react': 1.0.2(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@orama/orama': 3.1.18
@@ -9410,18 +9492,18 @@ snapshots:
       next: 16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      zod: 4.4.3
+      zod: 3.25.76
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@15.0.12(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.10.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.4))(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)):
+  fumadocs-mdx@15.0.12(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.10.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.4))(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76))(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.28.1
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.10.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.4))(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
+      fumadocs-core: 16.10.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.4))(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76)
       js-yaml: 4.2.0
       mdast-util-mdx: 3.0.0
       picocolors: 1.1.1
@@ -9443,7 +9525,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@16.10.2(@tailwindcss/oxide@4.3.1)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.10.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.4))(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.3.1):
+  fumadocs-ui@16.10.2(@tailwindcss/oxide@4.3.1)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.10.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.4))(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76))(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.3.1):
     dependencies:
       '@fuma-translate/react': 1.0.2(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@fumadocs/tailwind': 0.0.5(@tailwindcss/oxide@4.3.1)(tailwindcss@4.3.1)
@@ -9458,7 +9540,7 @@ snapshots:
       '@radix-ui/react-slot': 1.2.5(@types/react@19.2.17)(react@19.2.4)
       '@radix-ui/react-tabs': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.10.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.4))(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
+      fumadocs-core: 16.10.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.4))(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76)
       lucide-react: 1.21.0(react@19.2.4)
       motion: 12.40.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -10681,6 +10763,32 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
 
   ms@2.1.3: {}
+
+  msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3):
+    dependencies:
+      '@inquirer/confirm': 6.1.1(@types/node@22.20.0)
+      '@mswjs/interceptors': 0.41.9
+      '@open-draft/deferred-promise': 3.0.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.14.2
+      headers-polyfill: 5.0.1
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.11.11
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.1
+      type-fest: 5.7.0
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
 
   msw@2.14.6(@types/node@25.9.3)(typescript@5.9.3):
     dependencies:
@@ -12058,6 +12166,8 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
+  undici-types@6.21.0: {}
+
   undici-types@7.24.6: {}
 
   undici@7.28.0: {}
@@ -12196,6 +12306,27 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-node@3.2.4(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite-node@3.2.4(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0):
     dependencies:
       cac: 6.7.14
@@ -12217,6 +12348,20 @@ snapshots:
       - tsx
       - yaml
 
+  vite@7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0):
+    dependencies:
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rollup: 4.62.0
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 22.20.0
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+
   vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.27.7
@@ -12230,6 +12375,49 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
       lightningcss: 1.32.0
+
+  vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3)):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.6
+      '@vitest/mocker': 3.2.6(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0))
+      '@vitest/pretty-format': 3.2.6
+      '@vitest/runner': 3.2.6
+      '@vitest/snapshot': 3.2.6
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)
+      vite-node: 3.2.4(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.13
+      '@types/node': 22.20.0
+      jsdom: 25.0.1
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vitest@3.2.6(@types/debug@4.1.13)(@types/node@25.9.3)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.9.3)(typescript@5.9.3)):
     dependencies:
@@ -12408,9 +12596,9 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
-  zod-validation-error@4.0.2(zod@4.4.3):
+  zod-validation-error@4.0.2(zod@3.25.76):
     dependencies:
-      zod: 4.4.3
+      zod: 3.25.76
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
Adds two publishable packages so users can pull GodUI components straight from their AI IDE. `@godui/mcp` is an MCP (stdio) server exposing `list_components`, `search_components`, and `get_component`, live-fetching the registry at `godui.design/r` so new components appear without republishing. `@godui/cli` (`godui install <ide>`) writes the MCP config into Cursor/Windsurf/Claude/Cline/Roo-Cline, merging without clobbering existing servers. A new `generate-mcp-index.mjs` build step emits `public/r/index.json` (catalog + categories) consumed by the server, and the docs gain an MCP page with a CLI/Manual tabbed installer. Both packages ship tag-triggered npm release workflows (`mcp-v*`, `cli-v*`).

Verified: lint + tests green across all workspaces, plus real end-to-end smoke tests of the MCP tools over stdio and the CLI writing/merging config.