### PR TITLE
feat(storybook): one interactive Playground per component

### DIFF
--- a/apps/docs/src/app/docs/_components/docs-header.tsx
+++ b/apps/docs/src/app/docs/_components/docs-header.tsx
@@ -6,7 +6,7 @@ import {
   FullSearchTrigger,
   SearchTrigger,
 } from "fumadocs-ui/layouts/shared/slots/search-trigger";
-import { Menu } from "lucide-react";
+import { ArrowUpRight, Menu } from "lucide-react";
 import type { ComponentProps } from "react";
 import { cn } from "@/lib/cn";
 import { GitHubStars } from "./github-stars";
@@ -51,9 +51,10 @@ export function DocsHeader({
           href={ANIMATED_ICONS_URL}
           target="_blank"
           rel="noreferrer"
-          className="font-medium text-fd-muted-foreground text-sm transition-colors hover:text-fd-foreground"
+          className="group inline-flex items-center gap-1 font-medium text-fd-muted-foreground text-sm transition-colors hover:text-fd-foreground"
         >
           Animated Icons
+          <ArrowUpRight className="size-3.5 transition-transform group-hover:-translate-y-px group-hover:translate-x-px" />
         </a>
       </nav>
       <div className="flex-1" />

--- a/apps/docs/src/app/docs/_components/mobile-menu.tsx
+++ b/apps/docs/src/app/docs/_components/mobile-menu.tsx
@@ -1,5 +1,5 @@
 import Link from "fumadocs-core/link";
-import { Component, Sparkles } from "lucide-react";
+import { ArrowUpRight, Component, Sparkles } from "lucide-react";
 import { ANIMATED_ICONS_URL } from "./docs-header";
 
 const itemClass =
@@ -28,6 +28,7 @@ export function MobileMenu() {
       >
         <Sparkles />
         Animated Icons
+        <ArrowUpRight className="ml-auto text-fd-muted-foreground/60" />
       </a>
     </div>
   );

--- a/apps/storybook/src/playground/argtypes.ts
+++ b/apps/storybook/src/playground/argtypes.ts
@@ -1,0 +1,92 @@
+import type { InputType } from "storybook/internal/types";
+
+/**
+ * argType builders for the GodUI Playground. They keep every story's Controls
+ * panel uniform: one consistent control mapping, one set of category buckets,
+ * and zero per-file boilerplate. Use them inside a `meta.argTypes` map.
+ *
+ * Categories order the Controls panel into readable groups. Keep to this set so
+ * every component reads the same way.
+ */
+export type Category =
+  | "Appearance"
+  | "Behavior"
+  | "Content"
+  | "State"
+  | "Events";
+
+const cat = (category?: Category): Pick<InputType, "table"> =>
+  category ? { table: { category } } : {};
+
+/** Dropdown of string-literal union options. */
+export const select = (
+  options: readonly string[],
+  category?: Category,
+): InputType => ({
+  control: { type: "select" },
+  options: [...options],
+  ...cat(category),
+});
+
+/** Inline radio for short option sets (2–4 values) you want visible at a glance. */
+export const radio = (
+  options: readonly string[],
+  category?: Category,
+): InputType => ({
+  control: { type: "inline-radio" },
+  options: [...options],
+  ...cat(category),
+});
+
+/** Boolean toggle. */
+export const toggle = (category?: Category): InputType => ({
+  control: { type: "boolean" },
+  ...cat(category),
+});
+
+/** Numeric slider with explicit bounds, so users can't push values off-design. */
+export const range = (
+  min: number,
+  max: number,
+  step: number,
+  category?: Category,
+): InputType => ({
+  control: { type: "range", min, max, step },
+  ...cat(category),
+});
+
+/** Plain number input (unbounded). Prefer `range` when sensible bounds exist. */
+export const number = (category?: Category): InputType => ({
+  control: { type: "number" },
+  ...cat(category),
+});
+
+/** Color picker. */
+export const color = (category?: Category): InputType => ({
+  control: { type: "color" },
+  ...cat(category),
+});
+
+/** Free text input. */
+export const text = (category?: Category): InputType => ({
+  control: { type: "text" },
+  ...cat(category),
+});
+
+/**
+ * Callback prop → Actions panel entry. Pair with `fn()` in `args` so the spy is
+ * wired and interactions get logged. Always grouped under "Events".
+ */
+export const action = (name: string): InputType => ({
+  action: name,
+  table: { category: "Events" },
+});
+
+/**
+ * Complex props (data arrays, refs, render props) that shouldn't appear as a
+ * control. Hidden from the Controls table but still passed through `args`.
+ */
+export const hidden = (): InputType => ({
+  control: false,
+  table: { disable: true },
+});

--- a/apps/storybook/src/playground/presets.ts
+++ b/apps/storybook/src/playground/presets.ts
@@ -1,0 +1,54 @@
+import type { ReactElement } from "react";
+import type { InputType } from "storybook/internal/types";
+import type { Category } from "./argtypes";
+
+/**
+ * Preset machinery for visual / effect components whose interesting props are
+ * numbers and colors that don't make sense as a pile of raw sliders. Instead we
+ * expose one curated `preset` selector that swaps a whole tuned look, plus any
+ * orthogonal controls (e.g. an `interactive` toggle) the story declares
+ * normally.
+ *
+ * Usage:
+ *   const presets = {
+ *     Aurora: { colors: [...], speed: 1, gooeyness: 16 },
+ *     Sunset: { colors: [...], speed: 0.7, gooeyness: 22 },
+ *   } satisfies PresetMap<LiquidMetaballsProps>;
+ *
+ *   const meta = {
+ *     argTypes: {
+ *       preset: presetSelect(presets, "Appearance"),
+ *       interactive: toggle("Behavior"),
+ *     },
+ *     args: { preset: "Aurora", interactive: true },
+ *     render: renderPreset(presets, (cfg) => <LiquidMetaballs {...cfg} />),
+ *   };
+ *
+ * The chosen preset is spread first; any other declared args (the orthogonal
+ * controls) are layered on top, so they always win. The synthetic `preset` key
+ * is stripped before reaching the component.
+ */
+export type PresetMap<P> = Record<string, Partial<P>>;
+
+/** Synthetic `preset` argType: a select over the preset names. */
+export const presetSelect = (
+  presets: PresetMap<unknown>,
+  category?: Category,
+): InputType => ({
+  name: "Preset",
+  control: { type: "select" },
+  options: Object.keys(presets),
+  table: category ? { category } : undefined,
+});
+
+/** Build a story `render` that resolves the active preset and merges overrides. */
+export function renderPreset<
+  P,
+  A extends Partial<P> & { preset?: string } = Partial<P> & { preset?: string },
+>(presets: PresetMap<P>, renderFn: (cfg: P) => ReactElement) {
+  return (args: A): ReactElement => {
+    const { preset, ...rest } = args;
+    const base = (preset && presets[preset]) || {};
+    return renderFn({ ...base, ...(rest as unknown as Partial<P>) } as P);
+  };
+}

--- a/apps/storybook/src/playground/stage.tsx
+++ b/apps/storybook/src/playground/stage.tsx
@@ -1,0 +1,84 @@
+import type { Decorator } from "@storybook/react";
+
+/**
+ * Framing decorators for the GodUI Playground. They replace the ad-hoc
+ * `<div style={{ maxWidth }}>` wrappers scattered across stories so every
+ * component is presented on a consistent, premium-feeling stage.
+ */
+
+/** Center the component in the canvas, optionally capping its width. */
+export const centered =
+  (maxWidth?: number): Decorator =>
+  (Story) => (
+    <div className="flex w-full items-center justify-center">
+      <div style={maxWidth ? { width: "100%", maxWidth } : undefined}>
+        <Story />
+      </div>
+    </div>
+  );
+
+/** Constrained, left-aligned column for wider components (forms, composers). */
+export const padded =
+  (maxWidth = 640): Decorator =>
+  (Story) => (
+    <div className="mx-auto w-full" style={{ maxWidth }}>
+      <Story />
+    </div>
+  );
+
+export type EffectStageOptions = {
+  /** Headline overlaid on the effect. */
+  title?: string;
+  /** Sub-line under the headline. */
+  subtitle?: string;
+  /** Stage height. Number → px, string → raw CSS (e.g. "60vh"). */
+  height?: number | string;
+  /** Hide the overlay text entirely (let the effect speak for itself). */
+  bare?: boolean;
+};
+
+/**
+ * Full-bleed framed stage for background / effect components: a `relative`,
+ * `overflow-hidden` surface that hosts the effect as its first child with an
+ * optional centered heading floating above it.
+ */
+export const effectStage =
+  ({
+    title,
+    subtitle,
+    height = "60vh",
+    bare = false,
+  }: EffectStageOptions = {}): Decorator =>
+  (Story) => (
+    <div
+      className="relative flex w-full items-center justify-center overflow-hidden rounded-xl border border-border bg-background"
+      style={{ minHeight: typeof height === "number" ? `${height}px` : height }}
+    >
+      <Story />
+      {!bare && (title || subtitle) ? (
+        <div className="pointer-events-none relative z-raised px-6 text-center">
+          {title ? (
+            <h1 className="font-semibold text-4xl tracking-tight">{title}</h1>
+          ) : null}
+          {subtitle ? (
+            <p className="mt-2 text-muted-foreground">{subtitle}</p>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+
+/** Generic fixed-size box for components that just need room to render. */
+export const box =
+  (width: number | string, height: number | string): Decorator =>
+  (Story) => (
+    <div
+      className="flex items-center justify-center"
+      style={{
+        width: typeof width === "number" ? `${width}px` : width,
+        height: typeof height === "number" ? `${height}px` : height,
+      }}
+    >
+      <Story />
+    </div>
+  );

--- a/apps/storybook/src/stories/accordion.stories.tsx
+++ b/apps/storybook/src/stories/accordion.stories.tsx
@@ -1,5 +1,7 @@
 import { Accordion } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { hidden, select, toggle } from "../playground/argtypes";
+import { padded } from "../playground/stage";
 
 const items = [
   {
@@ -25,18 +27,22 @@ const meta = {
   component: Accordion,
   tags: ["autodocs"],
   parameters: { layout: "padded" },
-  args: { items },
-  decorators: [
-    (Story) => (
-      <div style={{ maxWidth: 520, margin: "0 auto" }}>
-        <Story />
-      </div>
-    ),
-  ],
+  decorators: [padded(520)],
+  argTypes: {
+    items: hidden(),
+    defaultValue: hidden(),
+    type: select(["single", "multiple"], "Behavior"),
+    collapsible: toggle("Behavior"),
+  },
+  args: {
+    items,
+    type: "single",
+    defaultValue: "what",
+    collapsible: true,
+  },
 } satisfies Meta<typeof Accordion>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Single: Story = { args: { type: "single", defaultValue: "what" } };
-export const Multiple: Story = { args: { type: "multiple" } };
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/agent-timeline.stories.tsx
+++ b/apps/storybook/src/stories/agent-timeline.stories.tsx
@@ -1,20 +1,16 @@
 import { AgentStep, AgentTimeline } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { centered } from "../playground/stage";
 
 const meta = {
   title: "AI/AgentTimeline",
   component: AgentTimeline,
   subcomponents: { AgentStep },
   tags: ["autodocs"],
-  parameters: { layout: "padded" },
-} satisfies Meta<typeof AgentTimeline>;
-
-export default meta;
-type Story = StoryObj<typeof meta>;
-
-export const Running: Story = {
+  parameters: { layout: "centered" },
+  decorators: [centered(448)],
   render: (args) => (
-    <div className="mx-auto max-w-md rounded-2xl border border-border bg-card p-4">
+    <div className="w-full rounded-2xl border border-border bg-card p-4">
       <AgentTimeline {...args}>
         <AgentStep status="success" title="Read the repository" meta="0.4s">
           Indexed 128 files across 6 packages.
@@ -35,39 +31,9 @@ export const Running: Story = {
       </AgentTimeline>
     </div>
   ),
-};
+} satisfies Meta<typeof AgentTimeline>;
 
-export const ReasoningOnly: Story = {
-  render: () => (
-    <div className="mx-auto max-w-md rounded-2xl border border-border bg-card p-4">
-      <AgentTimeline>
-        <AgentStep status="success" title="Thinking" defaultOpen last>
-          The user wants the div centered. The cleanest 2026 approach is a CSS
-          grid parent with `place-items-center` — one declaration, no flex
-          alignment juggling. I'll show that.
-        </AgentStep>
-      </AgentTimeline>
-    </div>
-  ),
-};
+export default meta;
+type Story = StoryObj<typeof meta>;
 
-export const WithError: Story = {
-  render: () => (
-    <div className="mx-auto max-w-md rounded-2xl border border-border bg-card p-4">
-      <AgentTimeline>
-        <AgentStep status="success" title="Install dependencies" meta="3.2s" />
-        <AgentStep
-          status="error"
-          title="Build failed"
-          meta="1.8s"
-          defaultOpen
-          last
-        >
-          <pre className="whitespace-pre-wrap font-mono text-destructive">
-            error TS2304: Cannot find name 'PromptComposer'.
-          </pre>
-        </AgentStep>
-      </AgentTimeline>
-    </div>
-  ),
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/animated-beam.stories.tsx
+++ b/apps/storybook/src/stories/animated-beam.stories.tsx
@@ -1,18 +1,57 @@
-import { AnimatedBeam } from "@godui/components";
+import { AnimatedBeam, type AnimatedBeamProps } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import * as React from "react";
+import { color, range, toggle } from "../playground/argtypes";
 
-const meta: Meta<typeof AnimatedBeam> = {
+// AnimatedBeam needs live element refs (container/from/to) to measure and draw
+// the path, so the refs can't be wired to Controls. We expose only the scalar
+// props as controls and rebuild the demo scene inside `render`.
+type PlaygroundArgs = Pick<
+  AnimatedBeamProps,
+  | "curvature"
+  | "reverse"
+  | "duration"
+  | "delay"
+  | "pathColor"
+  | "pathWidth"
+  | "pathOpacity"
+  | "gradientStartColor"
+  | "gradientStopColor"
+>;
+
+const meta: Meta<PlaygroundArgs> = {
   title: "Effects/Animated Beam",
-  component: AnimatedBeam,
+  // Cast: the refs are required props but supplied inside `render`, never via
+  // Controls, so the Playground args only cover the scalar props.
+  component: AnimatedBeam as unknown as React.ComponentType<PlaygroundArgs>,
   tags: ["autodocs"],
   parameters: { layout: "centered" },
+  argTypes: {
+    curvature: range(-100, 100, 1, "Appearance"),
+    pathColor: color("Appearance"),
+    pathWidth: range(1, 8, 0.5, "Appearance"),
+    pathOpacity: range(0, 1, 0.05, "Appearance"),
+    gradientStartColor: color("Appearance"),
+    gradientStopColor: color("Appearance"),
+    reverse: toggle("Behavior"),
+    duration: range(1, 10, 0.5, "Behavior"),
+    delay: range(0, 5, 0.5, "Behavior"),
+  },
+  args: {
+    curvature: 0,
+    reverse: false,
+    duration: 3,
+    delay: 0,
+    pathWidth: 2,
+    pathOpacity: 0.2,
+  },
+  render: (args) => <BeamScene {...args} />,
 };
 
 export default meta;
-type Story = StoryObj<typeof AnimatedBeam>;
+type Story = StoryObj<PlaygroundArgs>;
 
-function BeamScene() {
+function BeamScene(args: PlaygroundArgs) {
   const containerRef = React.useRef<HTMLDivElement>(null);
   const fromRef = React.useRef<HTMLDivElement>(null);
   const toRef = React.useRef<HTMLDivElement>(null);
@@ -34,11 +73,10 @@ function BeamScene() {
         containerRef={containerRef}
         fromRef={fromRef}
         toRef={toRef}
+        {...args}
       />
     </div>
   );
 }
 
-export const Default: Story = {
-  render: () => <BeamScene />,
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/animated-testimonials.stories.tsx
+++ b/apps/storybook/src/stories/animated-testimonials.stories.tsx
@@ -1,5 +1,7 @@
 import { AnimatedTestimonials } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { hidden, range, toggle } from "../playground/argtypes";
+import { centered } from "../playground/stage";
 
 const testimonials = [
   {
@@ -28,12 +30,20 @@ const meta = {
   component: AnimatedTestimonials,
   tags: ["autodocs"],
   parameters: { layout: "centered" },
-  args: { testimonials, autoplay: true, interval: 5000 },
+  decorators: [centered()],
+  argTypes: {
+    testimonials: hidden(),
+    autoplay: toggle("Behavior"),
+    interval: range(1000, 10000, 500, "Behavior"),
+  },
+  args: {
+    testimonials,
+    autoplay: true,
+    interval: 5000,
+  },
 } satisfies Meta<typeof AnimatedTestimonials>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
-
-export const NoAutoplay: Story = { args: { autoplay: false } };
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/animated-tooltip.stories.tsx
+++ b/apps/storybook/src/stories/animated-tooltip.stories.tsx
@@ -1,12 +1,19 @@
 import { AnimatedTooltip } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import type { ReactNode } from "react";
+import { hidden, select, text } from "../playground/argtypes";
+import { box } from "../playground/stage";
 
 const meta = {
   title: "Overlays/AnimatedTooltip",
   component: AnimatedTooltip,
   tags: ["autodocs"],
   parameters: { layout: "centered" },
+  decorators: [box("100%", 160)],
+  argTypes: {
+    content: text("Content"),
+    side: select(["top", "bottom"], "Appearance"),
+    children: hidden(),
+  },
   args: {
     content: "Design Engineer",
     side: "top",
@@ -24,124 +31,4 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-  render: (args) => (
-    <div className="flex h-40 items-center justify-center">
-      <AnimatedTooltip {...args} />
-    </div>
-  ),
-};
-
-const TEAM = [
-  {
-    name: "Ada Lovelace",
-    role: "Design Engineer",
-    initials: "AL",
-    gradient: "from-indigo-500 to-violet-500",
-  },
-  {
-    name: "Grace Hopper",
-    role: "Staff Engineer",
-    initials: "GH",
-    gradient: "from-rose-500 to-orange-500",
-  },
-  {
-    name: "Alan Turing",
-    role: "Founder",
-    initials: "AT",
-    gradient: "from-emerald-500 to-teal-500",
-  },
-  {
-    name: "Katherine Johnson",
-    role: "Product Design",
-    initials: "KJ",
-    gradient: "from-sky-500 to-cyan-500",
-  },
-  {
-    name: "Linus Carlsson",
-    role: "Frontend Lead",
-    initials: "LC",
-    gradient: "from-fuchsia-500 to-pink-500",
-  },
-];
-
-export const TeamStack: Story = {
-  render: () => (
-    <div className="flex flex-col items-center gap-4">
-      <p className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
-        Crafted by design engineers
-      </p>
-      <div className="flex">
-        {TEAM.map((m) => (
-          <AnimatedTooltip
-            key={m.name}
-            className="-ml-3 first:ml-0"
-            content={
-              <span className="flex flex-col">
-                <span className="font-semibold">{m.name}</span>
-                <span className="text-background/70">{m.role}</span>
-              </span>
-            }
-          >
-            <span
-              className={`flex size-12 items-center justify-center rounded-full bg-gradient-to-br ${m.gradient} text-sm font-semibold text-white ring-2 ring-background`}
-            >
-              {m.initials}
-            </span>
-          </AnimatedTooltip>
-        ))}
-      </div>
-    </div>
-  ),
-};
-
-const icon = (path: ReactNode) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={2}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    className="size-4"
-    aria-hidden="true"
-  >
-    {path}
-  </svg>
-);
-
-const TOOLS = [
-  {
-    label: "Bold",
-    node: icon(<path d="M6 4h8a4 4 0 0 1 0 8H6zM6 12h9a4 4 0 0 1 0 8H6z" />),
-  },
-  { label: "Italic", node: icon(<path d="M19 4h-9M14 20H5M15 4 9 20" />) },
-  {
-    label: "Underline",
-    node: icon(<path d="M6 4v6a6 6 0 0 0 12 0V4M4 20h16" />),
-  },
-  {
-    label: "Link",
-    node: icon(
-      <path d="M10 13a5 5 0 0 0 7 0l3-3a5 5 0 0 0-7-7l-1 1M14 11a5 5 0 0 0-7 0l-3 3a5 5 0 0 0 7 7l1-1" />,
-    ),
-  },
-];
-
-export const Toolbar: Story = {
-  render: () => (
-    <div className="flex items-center gap-1 rounded-xl border border-border bg-card p-1.5 shadow-sm">
-      {TOOLS.map((t) => (
-        <AnimatedTooltip key={t.label} content={t.label}>
-          <button
-            type="button"
-            aria-label={t.label}
-            className="flex size-9 items-center justify-center rounded-lg text-muted-foreground hover:bg-accent hover:text-foreground"
-          >
-            {t.node}
-          </button>
-        </AnimatedTooltip>
-      ))}
-    </div>
-  ),
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/aurora-text.stories.tsx
+++ b/apps/storybook/src/stories/aurora-text.stories.tsx
@@ -1,41 +1,28 @@
-import { AuroraText, type AuroraTextProps } from "@godui/components";
+import { AuroraText } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { hidden, range, text } from "../playground/argtypes";
+import { centered } from "../playground/stage";
 
 const meta = {
   title: "Text/AuroraText",
   component: AuroraText,
   tags: ["autodocs"],
-  parameters: {
-    layout: "centered",
+  parameters: { layout: "centered" },
+  decorators: [centered()],
+  argTypes: {
+    children: text("Content"),
+    speed: range(0.5, 5, 0.5, "Behavior"),
+    colors: hidden(),
+    className: hidden(),
   },
   args: {
     children: "Aurora",
+    speed: 1,
     className: "text-6xl font-bold tracking-tight",
-  } satisfies AuroraTextProps,
+  },
 } satisfies Meta<typeof AuroraText>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Rainbow: Story = {
-  args: {
-    children: "Aurora",
-    className: "text-6xl font-bold tracking-tight",
-  },
-};
-
-export const Fast: Story = {
-  args: {
-    children: "Lightspeed",
-    speed: 3,
-    className: "text-6xl font-bold tracking-tight",
-  },
-};
-
-export const CustomColors: Story = {
-  args: {
-    children: "Sunset",
-    colors: ["#ff512f", "#dd2476", "#ff512f"],
-    className: "text-6xl font-bold tracking-tight",
-  },
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/avatar-group.stories.tsx
+++ b/apps/storybook/src/stories/avatar-group.stories.tsx
@@ -1,5 +1,7 @@
 import { AvatarGroup } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { hidden, range, select, toggle } from "../playground/argtypes";
+import { centered } from "../playground/stage";
 
 const avatars = [
   { src: "https://i.pravatar.cc/80?img=1", alt: "Ada" },
@@ -15,24 +17,22 @@ const meta = {
   component: AvatarGroup,
   tags: ["autodocs"],
   parameters: { layout: "centered" },
-  args: { avatars },
+  decorators: [centered()],
+  argTypes: {
+    avatars: hidden(),
+    max: range(1, 6, 1, "Behavior"),
+    size: select(["sm", "md", "lg"], "Appearance"),
+    spreadOnHover: toggle("Behavior"),
+  },
+  args: {
+    avatars,
+    max: 4,
+    size: "md",
+    spreadOnHover: true,
+  },
 } satisfies Meta<typeof AvatarGroup>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = { args: { max: 4 } };
-export const Small: Story = { args: { size: "sm", max: 4 } };
-export const Large: Story = { args: { size: "lg", max: 4 } };
-export const Initials: Story = {
-  args: {
-    max: 4,
-    avatars: [
-      { fallback: "AB", alt: "Ada" },
-      { fallback: "CD", alt: "Carl" },
-      { fallback: "EF", alt: "Eve" },
-      { fallback: "GH", alt: "Gus" },
-      { fallback: "IJ", alt: "Ivy" },
-    ],
-  },
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/bento-grid.stories.tsx
+++ b/apps/storybook/src/stories/bento-grid.stories.tsx
@@ -1,17 +1,8 @@
 import { BentoCard, BentoGrid } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { ReactNode } from "react";
-
-const meta = {
-  title: "Layout/BentoGrid",
-  component: BentoGrid,
-  subcomponents: { BentoCard },
-  tags: ["autodocs"],
-  parameters: { layout: "padded" },
-} satisfies Meta<typeof BentoGrid>;
-
-export default meta;
-type Story = StoryObj<typeof meta>;
+import { select } from "../playground/argtypes";
+import { padded } from "../playground/stage";
 
 function Icon({ children }: { children: ReactNode }) {
   return (
@@ -61,9 +52,21 @@ function MiniBars() {
   );
 }
 
-export const Default: Story = {
-  render: () => (
-    <BentoGrid className="max-w-4xl">
+const meta = {
+  title: "Layout/BentoGrid",
+  component: BentoGrid,
+  subcomponents: { BentoCard },
+  tags: ["autodocs"],
+  parameters: { layout: "padded" },
+  decorators: [padded(896)],
+  argTypes: {
+    columns: select(["2", "3", "4"], "Appearance"),
+  },
+  args: {
+    columns: 4,
+  },
+  render: ({ columns }) => (
+    <BentoGrid columns={Number(columns) as 2 | 3 | 4} className="max-w-4xl">
       <BentoCard
         colSpan={2}
         icon={<Icon>{sparkles}</Icon>}
@@ -107,4 +110,9 @@ export const Default: Story = {
       />
     </BentoGrid>
   ),
-};
+} satisfies Meta<typeof BentoGrid>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/blueprint-grid.stories.tsx
+++ b/apps/storybook/src/stories/blueprint-grid.stories.tsx
@@ -1,5 +1,7 @@
 import { BlueprintGrid, type BlueprintGridProps } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { color, range, select, toggle } from "../playground/argtypes";
+import { effectStage } from "../playground/stage";
 
 const meta = {
   title: "Backgrounds/Blueprint Grid",
@@ -7,34 +9,27 @@ const meta = {
   tags: ["autodocs"],
   parameters: { layout: "fullscreen" },
   decorators: [
-    (Story) => (
-      <div className="relative flex min-h-[60vh] w-full items-center justify-center overflow-hidden bg-background">
-        <Story />
-        <div className="relative z-raised text-center">
-          <h1 className="font-semibold text-4xl tracking-tight">
-            Blueprint Grid
-          </h1>
-          <p className="mt-2 text-muted-foreground">
-            Technical, precise, alive.
-          </p>
-        </div>
-      </div>
-    ),
+    effectStage({
+      title: "Blueprint Grid",
+      subtitle: "Technical, precise, alive.",
+    }),
   ],
+  argTypes: {
+    variant: select(["lines", "dots", "perspective"], "Appearance"),
+    cellSize: range(16, 80, 4, "Appearance"),
+    color: color("Appearance"),
+    sweep: toggle("Behavior"),
+    spotlight: toggle("Behavior"),
+  },
+  args: {
+    variant: "lines",
+    cellSize: 32,
+    sweep: true,
+    spotlight: true,
+  },
 } satisfies Meta<typeof BlueprintGrid>;
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<BlueprintGridProps>;
 
-export const Lines: Story = {
-  args: { variant: "lines" } satisfies BlueprintGridProps,
-};
-export const Dots: Story = {
-  args: { variant: "dots" } satisfies BlueprintGridProps,
-};
-export const Perspective: Story = {
-  args: { variant: "perspective" } satisfies BlueprintGridProps,
-};
-export const Tinted: Story = {
-  args: { color: "#6366f1", cellSize: 40 } satisfies BlueprintGridProps,
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/border-beam.stories.tsx
+++ b/apps/storybook/src/stories/border-beam.stories.tsx
@@ -1,14 +1,40 @@
 import { BorderBeam } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type * as React from "react";
+import { color, range, toggle } from "../playground/argtypes";
 
 const meta = {
   title: "Effects/Border Beam",
   component: BorderBeam,
   tags: ["autodocs"],
-  parameters: {
-    layout: "centered",
+  parameters: { layout: "centered" },
+  argTypes: {
+    size: range(20, 120, 1, "Appearance"),
+    borderWidth: range(1, 6, 0.5, "Appearance"),
+    colorFrom: color("Appearance"),
+    colorTo: color("Appearance"),
+    glow: toggle("Appearance"),
+    rainbow: toggle("Appearance"),
+    duration: range(2, 20, 1, "Behavior"),
+    delay: range(0, 10, 0.5, "Behavior"),
+    initialOffset: range(0, 100, 1, "Behavior"),
+    reverse: toggle("Behavior"),
   },
+  args: {
+    size: 70,
+    borderWidth: 1,
+    glow: false,
+    rainbow: false,
+    duration: 15,
+    delay: 0,
+    initialOffset: 0,
+    reverse: false,
+  },
+  render: (args) => (
+    <DemoCard>
+      <BorderBeam {...args} />
+    </DemoCard>
+  ),
 } satisfies Meta<typeof BorderBeam>;
 
 export default meta;
@@ -28,56 +54,4 @@ function DemoCard({ children }: { children: React.ReactNode }) {
   );
 }
 
-export const Default: Story = {
-  render: (args) => (
-    <DemoCard>
-      <BorderBeam {...args} />
-    </DemoCard>
-  ),
-};
-
-export const FastLargeBeam: Story = {
-  render: () => (
-    <DemoCard>
-      <BorderBeam duration={8} size={70} />
-    </DemoCard>
-  ),
-};
-
-export const Reverse: Story = {
-  render: () => (
-    <DemoCard>
-      <BorderBeam size={70} reverse />
-    </DemoCard>
-  ),
-};
-
-export const Glow: Story = {
-  render: () => (
-    <DemoCard>
-      <BorderBeam size={80} glow />
-    </DemoCard>
-  ),
-};
-
-export const ThickColored: Story = {
-  render: () => (
-    <DemoCard>
-      <BorderBeam
-        size={70}
-        borderWidth={2}
-        colorFrom="var(--chart-2)"
-        colorTo="var(--chart-4)"
-      />
-    </DemoCard>
-  ),
-};
-
-export const DualBeams: Story = {
-  render: () => (
-    <DemoCard>
-      <BorderBeam size={70} duration={6} />
-      <BorderBeam size={70} duration={6} delay={3} />
-    </DemoCard>
-  ),
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/breadcrumbs.stories.tsx
+++ b/apps/storybook/src/stories/breadcrumbs.stories.tsx
@@ -1,11 +1,16 @@
 import { Breadcrumbs } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+import { action, hidden, range, toggle } from "../playground/argtypes";
+import { centered } from "../playground/stage";
 
 const items = [
   { label: "Home", href: "/" },
-  { label: "Components", href: "/components" },
-  { label: "Navigation", href: "/components/navigation" },
-  { label: "Breadcrumbs" },
+  { label: "Workspace", href: "/w" },
+  { label: "Projects", href: "/w/p" },
+  { label: "GodUI", href: "/w/p/godui" },
+  { label: "Settings", href: "/w/p/godui/settings" },
+  { label: "Billing" },
 ];
 
 const meta = {
@@ -13,24 +18,18 @@ const meta = {
   component: Breadcrumbs,
   tags: ["autodocs"],
   parameters: { layout: "centered" },
-  args: { items },
+  decorators: [centered()],
+  argTypes: {
+    items: hidden(),
+    separator: hidden(),
+    maxItems: range(0, 8, 1, "Behavior"),
+    collapsible: toggle("Behavior"),
+    onNavigate: action("navigate"),
+  },
+  args: { items, maxItems: 4, collapsible: true, onNavigate: fn() },
 } satisfies Meta<typeof Breadcrumbs>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
-
-export const Collapsed: Story = {
-  args: {
-    maxItems: 3,
-    items: [
-      { label: "Home", href: "/" },
-      { label: "Workspace", href: "/w" },
-      { label: "Projects", href: "/w/p" },
-      { label: "GodUI", href: "/w/p/godui" },
-      { label: "Settings", href: "/w/p/godui/settings" },
-      { label: "Billing" },
-    ],
-  },
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/combobox.stories.tsx
+++ b/apps/storybook/src/stories/combobox.stories.tsx
@@ -1,5 +1,7 @@
 import { Combobox, type ComboboxOption } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+import { action, hidden, text } from "../playground/argtypes";
 
 const frameworks: ComboboxOption[] = [
   { label: "Next.js", value: "next", description: "The React framework" },
@@ -19,7 +21,6 @@ const meta = {
   component: Combobox,
   tags: ["autodocs"],
   parameters: { layout: "centered" },
-  args: { options: frameworks, placeholder: "Search frameworks…" },
   decorators: [
     (Story) => (
       <div className="flex h-80 items-start justify-center pt-4">
@@ -27,22 +28,22 @@ const meta = {
       </div>
     ),
   ],
+  argTypes: {
+    options: hidden(),
+    onSearch: hidden(),
+    value: hidden(),
+    placeholder: text("Content"),
+    emptyMessage: text("Content"),
+    onChange: action("change"),
+  },
+  args: {
+    options: frameworks,
+    placeholder: "Search frameworks…",
+    onChange: fn(),
+  },
 } satisfies Meta<typeof Combobox>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
-export const Preselected: Story = { args: { defaultValue: "astro" } };
-
-export const Async: Story = {
-  args: {
-    options: undefined,
-    onSearch: async (q: string) => {
-      await new Promise((r) => setTimeout(r, 400));
-      return frameworks.filter((f) =>
-        f.label.toLowerCase().includes(q.toLowerCase()),
-      );
-    },
-  },
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/command-palette.stories.tsx
+++ b/apps/storybook/src/stories/command-palette.stories.tsx
@@ -1,17 +1,7 @@
 import { type CommandGroup, CommandPalette } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import * as React from "react";
-
-const meta = {
-  title: "Overlays/CommandPalette",
-  component: CommandPalette,
-  tags: ["autodocs"],
-  parameters: { layout: "centered" },
-  args: { open: false, onOpenChange: () => {}, groups: [] },
-} satisfies Meta<typeof CommandPalette>;
-
-export default meta;
-type Story = StoryObj<typeof meta>;
+import { hidden, text, toggle } from "../playground/argtypes";
 
 const groups: CommandGroup[] = [
   {
@@ -37,8 +27,32 @@ const groups: CommandGroup[] = [
   },
 ];
 
-export const Default: Story = {
-  render: () => {
+const meta = {
+  title: "Overlays/CommandPalette",
+  component: CommandPalette,
+  tags: ["autodocs"],
+  parameters: { layout: "centered" },
+  argTypes: {
+    placeholder: text("Content"),
+    enableShortcut: toggle("Behavior"),
+    open: hidden(),
+    onOpenChange: hidden(),
+    groups: hidden(),
+  },
+  args: {
+    placeholder: "Type a command or search…",
+    enableShortcut: true,
+    open: false,
+    onOpenChange: () => {},
+    groups,
+  },
+} satisfies Meta<typeof CommandPalette>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  render: (args) => {
     const [open, setOpen] = React.useState(false);
     return (
       <>
@@ -49,7 +63,7 @@ export const Default: Story = {
         >
           Open palette (or press ⌘K)
         </button>
-        <CommandPalette open={open} onOpenChange={setOpen} groups={groups} />
+        <CommandPalette {...args} open={open} onOpenChange={setOpen} />
       </>
     );
   },

--- a/apps/storybook/src/stories/comment-pin.stories.tsx
+++ b/apps/storybook/src/stories/comment-pin.stories.tsx
@@ -1,16 +1,7 @@
 import { CommentPin } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-
-const meta = {
-  title: "Collaboration/CommentPin",
-  component: CommentPin,
-  tags: ["autodocs"],
-  parameters: { layout: "centered" },
-  args: { x: 0, y: 0 },
-} satisfies Meta<typeof CommentPin>;
-
-export default meta;
-type Story = StoryObj<typeof meta>;
+import { fn } from "storybook/test";
+import { action, hidden, range, text, toggle } from "../playground/argtypes";
 
 const Frame = ({ children }: { children: React.ReactNode }) => (
   <div className="relative h-80 w-[40rem] max-w-[90vw] overflow-hidden rounded-2xl border border-border bg-card">
@@ -36,34 +27,41 @@ const comments = [
   },
 ];
 
-export const Threaded: Story = {
-  render: () => (
-    <Frame>
-      <CommentPin
-        x={12}
-        y={14}
-        comments={comments}
-        defaultOpen
-        onReply={() => {}}
-      />
-      <CommentPin
-        x={70}
-        y={18}
-        comments={[{ id: "c3", author: "Priya Nair", body: "Love this card." }]}
-      />
-    </Frame>
-  ),
-};
+const meta = {
+  title: "Collaboration/CommentPin",
+  component: CommentPin,
+  tags: ["autodocs"],
+  parameters: { layout: "centered" },
+  decorators: [
+    (Story) => (
+      <Frame>
+        <Story />
+      </Frame>
+    ),
+  ],
+  argTypes: {
+    x: range(0, 100, 1, "Appearance"),
+    y: range(0, 100, 1, "Appearance"),
+    label: text("Content"),
+    color: hidden(),
+    resolved: toggle("State"),
+    defaultOpen: toggle("State"),
+    comments: hidden(),
+    onReply: action("reply"),
+    onOpenChange: action("openChange"),
+  },
+  args: {
+    x: 12,
+    y: 14,
+    resolved: false,
+    defaultOpen: true,
+    comments,
+    onReply: fn(),
+    onOpenChange: fn(),
+  },
+} satisfies Meta<typeof CommentPin>;
 
-export const Resolved: Story = {
-  render: () => (
-    <Frame>
-      <CommentPin
-        x={20}
-        y={70}
-        resolved
-        comments={[{ id: "c4", author: "Jules Kim", body: "Fixed in latest." }]}
-      />
-    </Frame>
-  ),
-};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/confetti.stories.tsx
+++ b/apps/storybook/src/stories/confetti.stories.tsx
@@ -1,29 +1,51 @@
 import { ConfettiButton } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+import { action, range, text } from "../playground/argtypes";
+import { centered } from "../playground/stage";
 
-const meta = {
+// The burst is tuned through a single `options` object, so we expose its scalar
+// knobs as flat controls and reassemble them into `options` in `render`.
+type PlaygroundArgs = {
+  label: string;
+  particleCount: number;
+  spread: number;
+  startVelocity: number;
+  onClick: React.MouseEventHandler<HTMLButtonElement>;
+};
+
+const meta: Meta<PlaygroundArgs> = {
   title: "Effects/Confetti",
   component: ConfettiButton,
   tags: ["autodocs"],
   parameters: { layout: "centered" },
-} satisfies Meta<typeof ConfettiButton>;
+  decorators: [centered()],
+  argTypes: {
+    label: text("Content"),
+    particleCount: range(20, 400, 5, "Appearance"),
+    spread: range(20, 180, 5, "Appearance"),
+    startVelocity: range(15, 90, 1, "Appearance"),
+    onClick: action("click"),
+  },
+  args: {
+    label: "Celebrate 🎉",
+    particleCount: 120,
+    spread: 70,
+    startVelocity: 45,
+    onClick: fn(),
+  },
+  render: ({ label, particleCount, spread, startVelocity, onClick }) => (
+    <ConfettiButton
+      className="rounded-lg bg-primary px-5 py-2.5 text-sm font-semibold text-primary-foreground"
+      options={{ particleCount, spread, startVelocity }}
+      onClick={onClick}
+    >
+      {label}
+    </ConfettiButton>
+  ),
+};
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<PlaygroundArgs>;
 
-export const Button: Story = {
-  args: {
-    children: "Celebrate 🎉",
-    className:
-      "rounded-lg bg-primary px-5 py-2.5 text-sm font-semibold text-primary-foreground",
-  },
-};
-
-export const BigBurst: Story = {
-  args: {
-    children: "Big burst",
-    className:
-      "rounded-lg bg-primary px-5 py-2.5 text-sm font-semibold text-primary-foreground",
-    options: { particleCount: 250, spread: 120, startVelocity: 55 },
-  },
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/context-menu.stories.tsx
+++ b/apps/storybook/src/stories/context-menu.stories.tsx
@@ -1,5 +1,7 @@
 import { ContextMenu, type ContextMenuItem } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { hidden } from "../playground/argtypes";
+import { centered } from "../playground/stage";
 
 const items: ContextMenuItem[] = [
   { type: "label", label: "Actions" },
@@ -16,6 +18,11 @@ const meta = {
   component: ContextMenu,
   tags: ["autodocs"],
   parameters: { layout: "centered" },
+  decorators: [centered()],
+  argTypes: {
+    items: hidden(),
+    children: hidden(),
+  },
   args: {
     items,
     children: (
@@ -29,4 +36,4 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/conversation-thread.stories.tsx
+++ b/apps/storybook/src/stories/conversation-thread.stories.tsx
@@ -1,22 +1,7 @@
 // biome-ignore-all lint/a11y/useValidAriaRole: "role" is a chat-message domain prop, not an ARIA role
-import {
-  ConversationMessage,
-  ConversationThread,
-  StreamingText,
-} from "@godui/components";
+import { ConversationMessage, ConversationThread } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { useState } from "react";
-
-const meta = {
-  title: "AI/ConversationThread",
-  component: ConversationThread,
-  subcomponents: { ConversationMessage },
-  tags: ["autodocs"],
-  parameters: { layout: "padded" },
-} satisfies Meta<typeof ConversationThread>;
-
-export default meta;
-type Story = StoryObj<typeof meta>;
+import { hidden, select, toggle } from "../playground/argtypes";
 
 const copyAction = {
   label: "Copy",
@@ -35,7 +20,21 @@ const copyAction = {
   ),
 };
 
-export const Bubbles: Story = {
+const meta = {
+  title: "AI/ConversationThread",
+  component: ConversationThread,
+  subcomponents: { ConversationMessage },
+  tags: ["autodocs"],
+  parameters: { layout: "padded" },
+  argTypes: {
+    variant: select(["bubbles", "document", "compact"], "Appearance"),
+    autoScroll: toggle("Behavior"),
+    children: hidden(),
+  },
+  args: {
+    variant: "bubbles",
+    autoScroll: true,
+  },
   render: (args) => (
     <div className="mx-auto h-[420px] max-w-2xl rounded-2xl border border-border bg-background">
       <ConversationThread {...args}>
@@ -65,55 +64,9 @@ export const Bubbles: Story = {
       </ConversationThread>
     </div>
   ),
-  args: { variant: "bubbles" },
-};
+} satisfies Meta<typeof ConversationThread>;
 
-export const Document: Story = {
-  render: () => (
-    <div className="mx-auto h-[420px] max-w-2xl rounded-2xl border border-border bg-background">
-      <ConversationThread variant="document">
-        <ConversationMessage role="user" name="You">
-          Summarize the design-engineer role in one paragraph.
-        </ConversationMessage>
-        <ConversationMessage
-          role="assistant"
-          name="GodUI"
-          actions={[copyAction]}
-        >
-          A design engineer bridges product design and frontend engineering —
-          shipping interfaces with the polish of a designer and the rigor of an
-          engineer, owning motion, accessibility, and the last 10% that makes a
-          product feel premium.
-        </ConversationMessage>
-      </ConversationThread>
-    </div>
-  ),
-};
+export default meta;
+type Story = StoryObj<typeof meta>;
 
-export const LiveStreaming: Story = {
-  render: () => {
-    function Demo() {
-      const [done, setDone] = useState(false);
-      return (
-        <div className="mx-auto h-[300px] max-w-2xl rounded-2xl border border-border bg-background">
-          <ConversationThread>
-            <ConversationMessage role="user" name="You">
-              Give me a tagline for GodUI.
-            </ConversationMessage>
-            <ConversationMessage
-              role="assistant"
-              name="GodUI"
-              streaming={!done}
-            >
-              <StreamingText
-                text="Animated UI components for design engineers — own the code, keep the magic."
-                onDone={() => setDone(true)}
-              />
-            </ConversationMessage>
-          </ConversationThread>
-        </div>
-      );
-    }
-    return <Demo />;
-  },
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/decorative-background.stories.tsx
+++ b/apps/storybook/src/stories/decorative-background.stories.tsx
@@ -6,50 +6,36 @@ import {
   decorativeBackgroundVariants,
 } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { select } from "../playground/argtypes";
+import { effectStage } from "../playground/stage";
 
-type ShowcaseArgs = DecorativeBackgroundProps & {
+type PlaygroundArgs = DecorativeBackgroundProps & {
   variant: DecorativeBackgroundVariant;
 };
 
-const meta: Meta<ShowcaseArgs> = {
+const meta: Meta<PlaygroundArgs> = {
   title: "Backgrounds/Decorative Background",
   component: DecorativeBackground,
   tags: ["autodocs"],
   parameters: { layout: "fullscreen" },
+  decorators: [
+    effectStage({
+      title: "Decorative Background",
+      subtitle: "Drop-in full-bleed surfaces.",
+    }),
+  ],
   argTypes: {
-    variant: { control: "select", options: decorativeBackgroundVariants },
+    variant: select(decorativeBackgroundVariants, "Appearance"),
   },
-  args: { variant: decorativeBackgroundVariants[0] },
+  args: {
+    variant: decorativeBackgroundVariants[0],
+  },
+  render: ({ variant }) => (
+    <DecorativeBackground style={decorativeBackgroundPresets[variant]} />
+  ),
 };
 
 export default meta;
-type Story = StoryObj<ShowcaseArgs>;
+type Story = StoryObj<PlaygroundArgs>;
 
-export const Default: Story = {
-  render: ({ variant }) => (
-    <div className="relative flex min-h-[420px] w-full items-center justify-center overflow-hidden">
-      <DecorativeBackground style={decorativeBackgroundPresets[variant]} />
-      <p className="relative z-raised rounded-lg bg-background/70 px-4 py-2 text-sm font-medium text-foreground backdrop-blur">
-        {variant}
-      </p>
-    </div>
-  ),
-};
-
-export const Gallery: Story = {
-  render: () => (
-    <div className="grid grid-cols-2 gap-4 p-4 sm:grid-cols-3">
-      {decorativeBackgroundVariants.map((variant) => (
-        <div
-          key={variant}
-          className="relative flex h-40 items-end overflow-hidden rounded-lg border border-border"
-        >
-          <DecorativeBackground style={decorativeBackgroundPresets[variant]} />
-          <span className="relative z-raised w-full truncate bg-background/70 px-2 py-1 text-xs text-foreground backdrop-blur">
-            {variant}
-          </span>
-        </div>
-      ))}
-    </div>
-  ),
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/dock.stories.tsx
+++ b/apps/storybook/src/stories/dock.stories.tsx
@@ -1,17 +1,7 @@
 import { Dock, DockItem } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { ReactNode } from "react";
-
-const meta = {
-  title: "Navigation/Dock",
-  component: Dock,
-  subcomponents: { DockItem },
-  tags: ["autodocs"],
-  parameters: { layout: "centered" },
-} satisfies Meta<typeof Dock>;
-
-export default meta;
-type Story = StoryObj<typeof meta>;
+import { range } from "../playground/argtypes";
 
 function Icon({ children }: { children: ReactNode }) {
   return (
@@ -93,31 +83,36 @@ const items: { label: string; color: string; icon: ReactNode }[] = [
   },
 ];
 
-function renderItems() {
-  return items.map((item) => (
-    <DockItem key={item.label} label={item.label}>
-      <span
-        className={`flex size-full items-center justify-center ${item.color}`}
-      >
-        {item.icon}
-      </span>
-    </DockItem>
-  ));
-}
-
-export const Default: Story = {
-  render: (args) => (
-    <div className="flex h-48 items-end">
-      <Dock {...args}>{renderItems()}</Dock>
-    </div>
-  ),
-};
-
-export const StrongMagnify: Story = {
-  args: { magnification: 96, distance: 180 },
+const meta = {
+  title: "Navigation/Dock",
+  component: Dock,
+  subcomponents: { DockItem },
+  tags: ["autodocs"],
+  parameters: { layout: "centered" },
+  argTypes: {
+    baseSize: range(32, 80, 4, "Appearance"),
+    magnification: range(48, 128, 4, "Behavior"),
+    distance: range(80, 240, 10, "Behavior"),
+  },
+  args: { baseSize: 48, magnification: 72, distance: 140 },
   render: (args) => (
     <div className="flex h-56 items-end">
-      <Dock {...args}>{renderItems()}</Dock>
+      <Dock {...args}>
+        {items.map((item) => (
+          <DockItem key={item.label} label={item.label}>
+            <span
+              className={`flex size-full items-center justify-center ${item.color}`}
+            >
+              {item.icon}
+            </span>
+          </DockItem>
+        ))}
+      </Dock>
     </div>
   ),
-};
+} satisfies Meta<typeof Dock>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/drawer.stories.tsx
+++ b/apps/storybook/src/stories/drawer.stories.tsx
@@ -1,213 +1,76 @@
 import { Drawer } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import * as React from "react";
+import { hidden, select, text } from "../playground/argtypes";
 
 const meta = {
   title: "Overlays/Drawer",
   component: Drawer,
   tags: ["autodocs"],
   parameters: { layout: "centered" },
-  args: { open: false, onOpenChange: () => {} },
+  argTypes: {
+    side: select(["bottom", "right"], "Appearance"),
+    title: text("Content"),
+    open: hidden(),
+    onOpenChange: hidden(),
+    children: hidden(),
+  },
+  args: {
+    side: "right",
+    title: "Filters",
+    open: false,
+    onOpenChange: () => {},
+  },
 } satisfies Meta<typeof Drawer>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const money = (n: number) => `$${n.toLocaleString("en-US")}`;
-
-const CATALOG = [
-  {
-    id: "hp",
-    name: "Studio Headphones",
-    price: 349,
-    swatch: "bg-indigo-500/15",
-  },
-  { id: "watch", name: "Aurora Watch", price: 429, swatch: "bg-rose-500/15" },
-  {
-    id: "kb",
-    name: "Mechanical Keyboard",
-    price: 189,
-    swatch: "bg-emerald-500/15",
-  },
-];
-
-function CartDrawerDemo() {
-  const [open, setOpen] = React.useState(false);
-  const [cart, setCart] = React.useState<Record<string, number>>({ watch: 1 });
-
-  const add = (id: string) =>
-    setCart((c) => ({ ...c, [id]: (c[id] ?? 0) + 1 }));
-  const sub = (id: string) =>
-    setCart((c) => {
-      const next = { ...c };
-      const qty = (next[id] ?? 0) - 1;
-      if (qty <= 0) delete next[id];
-      else next[id] = qty;
-      return next;
-    });
-
-  const lines = CATALOG.filter((p) => cart[p.id] > 0);
-  const count = Object.values(cart).reduce((a, b) => a + b, 0);
-  const subtotal = lines.reduce((s, p) => s + p.price * cart[p.id], 0);
-  const shipping = subtotal === 0 || subtotal > 500 ? 0 : 12;
-  const total = subtotal + shipping;
-
-  return (
-    <div className="w-full max-w-md overflow-hidden rounded-xl border border-border bg-card">
-      <div className="flex items-center justify-between border-b border-border px-4 py-3">
-        <span className="text-sm font-semibold tracking-tight text-foreground">
-          ◆ Northwind Goods
-        </span>
+export const Playground: Story = {
+  render: (args) => {
+    const [open, setOpen] = React.useState(false);
+    return (
+      <>
         <button
           type="button"
           onClick={() => setOpen(true)}
-          className="rounded-lg bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground"
+          className="rounded-lg border border-border bg-card px-4 py-2 text-sm font-medium text-foreground"
         >
-          Cart · {count}
+          Filters
         </button>
-      </div>
-      <div className="grid gap-3 p-4 sm:grid-cols-3">
-        {CATALOG.map((p) => (
-          <div
-            key={p.id}
-            className="flex flex-col rounded-lg border border-border p-3"
+        <Drawer {...args} open={open} onOpenChange={setOpen}>
+          <div className="space-y-5">
+            <div>
+              <div className="mb-2 text-xs font-medium uppercase text-muted-foreground">
+                Category
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {["Audio", "Wearables", "Desk", "Mobile"].map((c) => (
+                  <span
+                    key={c}
+                    className="rounded-full border border-border px-3 py-1 text-sm text-foreground"
+                  >
+                    {c}
+                  </span>
+                ))}
+              </div>
+            </div>
+            <div>
+              <div className="mb-2 text-xs font-medium uppercase text-muted-foreground">
+                Price
+              </div>
+              <input type="range" className="w-full accent-[var(--primary)]" />
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => setOpen(false)}
+            className="mt-6 w-full rounded-lg bg-primary py-2.5 text-sm font-semibold text-primary-foreground"
           >
-            <div className={`mb-3 aspect-square rounded-md ${p.swatch}`} />
-            <div className="text-xs font-medium text-foreground">{p.name}</div>
-            <div className="mt-0.5 text-xs tabular-nums text-muted-foreground">
-              {money(p.price)}
-            </div>
-            <button
-              type="button"
-              onClick={() => add(p.id)}
-              className="mt-2 rounded-md bg-muted px-2 py-1 text-xs font-medium text-foreground hover:bg-accent"
-            >
-              Add
-            </button>
-          </div>
-        ))}
-      </div>
-
-      <Drawer open={open} onOpenChange={setOpen} title="Your cart">
-        {lines.length === 0 ? (
-          <p className="py-8 text-center text-sm text-muted-foreground">
-            Your cart is empty.
-          </p>
-        ) : (
-          <>
-            <ul className="space-y-3">
-              {lines.map((p) => (
-                <li key={p.id} className="flex items-center gap-3">
-                  <div className={`size-12 shrink-0 rounded-md ${p.swatch}`} />
-                  <div className="min-w-0 flex-1">
-                    <div className="truncate text-sm font-medium text-foreground">
-                      {p.name}
-                    </div>
-                    <div className="text-xs tabular-nums text-muted-foreground">
-                      {money(p.price)}
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <button
-                      type="button"
-                      aria-label="Decrease quantity"
-                      onClick={() => sub(p.id)}
-                      className="flex size-7 items-center justify-center rounded-md border border-border text-foreground hover:bg-accent"
-                    >
-                      −
-                    </button>
-                    <span className="w-5 text-center text-sm tabular-nums">
-                      {cart[p.id]}
-                    </span>
-                    <button
-                      type="button"
-                      aria-label="Increase quantity"
-                      onClick={() => add(p.id)}
-                      className="flex size-7 items-center justify-center rounded-md border border-border text-foreground hover:bg-accent"
-                    >
-                      +
-                    </button>
-                  </div>
-                </li>
-              ))}
-            </ul>
-            <dl className="mt-5 space-y-1.5 border-t border-border pt-4 text-sm">
-              <div className="flex justify-between text-muted-foreground">
-                <dt>Subtotal</dt>
-                <dd className="tabular-nums">{money(subtotal)}</dd>
-              </div>
-              <div className="flex justify-between text-muted-foreground">
-                <dt>Shipping</dt>
-                <dd className="tabular-nums">
-                  {shipping === 0 ? "Free" : money(shipping)}
-                </dd>
-              </div>
-              <div className="flex justify-between pt-1 text-base font-semibold text-foreground">
-                <dt>Total</dt>
-                <dd className="tabular-nums">{money(total)}</dd>
-              </div>
-            </dl>
-            <button
-              type="button"
-              onClick={() => setOpen(false)}
-              className="mt-4 w-full rounded-lg bg-primary py-2.5 text-sm font-semibold text-primary-foreground"
-            >
-              Checkout · {money(total)}
-            </button>
-          </>
-        )}
-      </Drawer>
-    </div>
-  );
-}
-
-function FilterPanelDemo() {
-  const [open, setOpen] = React.useState(false);
-  return (
-    <>
-      <button
-        type="button"
-        onClick={() => setOpen(true)}
-        className="rounded-lg border border-border bg-card px-4 py-2 text-sm font-medium text-foreground"
-      >
-        Filters
-      </button>
-      <Drawer open={open} onOpenChange={setOpen} side="right" title="Filters">
-        <div className="space-y-5">
-          <div>
-            <div className="mb-2 text-xs font-medium uppercase text-muted-foreground">
-              Category
-            </div>
-            <div className="flex flex-wrap gap-2">
-              {["Audio", "Wearables", "Desk", "Mobile"].map((c) => (
-                <span
-                  key={c}
-                  className="rounded-full border border-border px-3 py-1 text-sm text-foreground"
-                >
-                  {c}
-                </span>
-              ))}
-            </div>
-          </div>
-          <div>
-            <div className="mb-2 text-xs font-medium uppercase text-muted-foreground">
-              Price
-            </div>
-            <input type="range" className="w-full accent-[var(--primary)]" />
-          </div>
-        </div>
-        <button
-          type="button"
-          onClick={() => setOpen(false)}
-          className="mt-6 w-full rounded-lg bg-primary py-2.5 text-sm font-semibold text-primary-foreground"
-        >
-          Show results
-        </button>
-      </Drawer>
-    </>
-  );
-}
-
-export const Cart: Story = { render: () => <CartDrawerDemo /> };
-
-export const FilterPanel: Story = { render: () => <FilterPanelDemo /> };
+            Show results
+          </button>
+        </Drawer>
+      </>
+    );
+  },
+};

--- a/apps/storybook/src/stories/dropdown-menu.stories.tsx
+++ b/apps/storybook/src/stories/dropdown-menu.stories.tsx
@@ -1,5 +1,6 @@
 import { DropdownMenu, type DropdownMenuItem } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { hidden, select } from "../playground/argtypes";
 
 const items: DropdownMenuItem[] = [
   { type: "label", label: "My account" },
@@ -29,7 +30,6 @@ const meta = {
   component: DropdownMenu,
   tags: ["autodocs"],
   parameters: { layout: "centered" },
-  args: { trigger, items },
   decorators: [
     (Story) => (
       <div className="flex h-72 items-start justify-center pt-4">
@@ -37,11 +37,16 @@ const meta = {
       </div>
     ),
   ],
+  argTypes: {
+    trigger: hidden(),
+    items: hidden(),
+    side: select(["top", "bottom", "left", "right"], "Behavior"),
+    align: select(["start", "center", "end"], "Behavior"),
+  },
+  args: { trigger, items, side: "bottom", align: "start" },
 } satisfies Meta<typeof DropdownMenu>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
-export const AlignEnd: Story = { args: { align: "end" } };
-export const SideRight: Story = { args: { side: "right" } };
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/dynamic-island.stories.tsx
+++ b/apps/storybook/src/stories/dynamic-island.stories.tsx
@@ -1,5 +1,6 @@
 import { DynamicIsland } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { hidden, select } from "../playground/argtypes";
 
 const meta = {
   title: "Overlays/Dynamic Island",
@@ -7,26 +8,20 @@ const meta = {
   tags: ["autodocs"],
   parameters: { layout: "centered" },
   argTypes: {
-    size: {
-      control: "select",
-      options: ["compact", "default", "long", "tall", "large"],
-    },
+    size: select(["compact", "default", "long", "tall", "large"], "Appearance"),
+    presenceKey: hidden(),
+    children: hidden(),
   },
+  args: { size: "default" },
 } satisfies Meta<typeof DynamicIsland>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-  args: { size: "default" },
+export const Playground: Story = {
   render: (args) => (
     <DynamicIsland {...args}>
       <span className="text-sm">Now playing</span>
     </DynamicIsland>
   ),
-};
-
-export const Large: Story = {
-  ...Default,
-  args: { size: "large" },
 };

--- a/apps/storybook/src/stories/effect-background.stories.tsx
+++ b/apps/storybook/src/stories/effect-background.stories.tsx
@@ -6,50 +6,36 @@ import {
   effectBackgroundVariants,
 } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { select } from "../playground/argtypes";
+import { effectStage } from "../playground/stage";
 
-type ShowcaseArgs = EffectBackgroundProps & {
+type PlaygroundArgs = EffectBackgroundProps & {
   variant: EffectBackgroundVariant;
 };
 
-const meta: Meta<ShowcaseArgs> = {
+const meta: Meta<PlaygroundArgs> = {
   title: "Backgrounds/Effect Background",
   component: EffectBackground,
   tags: ["autodocs"],
   parameters: { layout: "fullscreen" },
+  decorators: [
+    effectStage({
+      title: "Effect Background",
+      subtitle: "Layered gradient washes.",
+    }),
+  ],
   argTypes: {
-    variant: { control: "select", options: effectBackgroundVariants },
+    variant: select(effectBackgroundVariants, "Appearance"),
   },
-  args: { variant: effectBackgroundVariants[0] },
+  args: {
+    variant: effectBackgroundVariants[0],
+  },
+  render: ({ variant }) => (
+    <EffectBackground style={effectBackgroundPresets[variant]} />
+  ),
 };
 
 export default meta;
-type Story = StoryObj<ShowcaseArgs>;
+type Story = StoryObj<PlaygroundArgs>;
 
-export const Default: Story = {
-  render: ({ variant }) => (
-    <div className="relative flex min-h-[420px] w-full items-center justify-center overflow-hidden">
-      <EffectBackground style={effectBackgroundPresets[variant]} />
-      <p className="relative z-raised rounded-lg bg-background/70 px-4 py-2 text-sm font-medium text-foreground backdrop-blur">
-        {variant}
-      </p>
-    </div>
-  ),
-};
-
-export const Gallery: Story = {
-  render: () => (
-    <div className="grid grid-cols-2 gap-4 p-4 sm:grid-cols-3">
-      {effectBackgroundVariants.map((variant) => (
-        <div
-          key={variant}
-          className="relative flex h-40 items-end overflow-hidden rounded-lg border border-border"
-        >
-          <EffectBackground style={effectBackgroundPresets[variant]} />
-          <span className="relative z-raised w-full truncate bg-background/70 px-2 py-1 text-xs text-foreground backdrop-blur">
-            {variant}
-          </span>
-        </div>
-      ))}
-    </div>
-  ),
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/elastic-text.stories.tsx
+++ b/apps/storybook/src/stories/elastic-text.stories.tsx
@@ -1,34 +1,33 @@
-import { ElasticText, type ElasticTextProps } from "@godui/components";
+import { ElasticText } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { hidden, radio, range, text, toggle } from "../playground/argtypes";
+import { centered } from "../playground/stage";
 
 const meta = {
   title: "Text/ElasticText",
   component: ElasticText,
   tags: ["autodocs"],
-  parameters: {
-    layout: "centered",
+  parameters: { layout: "centered" },
+  decorators: [centered()],
+  argTypes: {
+    children: text("Content"),
+    mode: radio(["auto", "hover"], "Behavior"),
+    minWeight: range(100, 900, 100, "Appearance"),
+    maxWeight: range(100, 900, 100, "Appearance"),
+    duration: range(1, 8, 0.5, "Behavior"),
+    loop: toggle("Behavior"),
+    startOnView: toggle("Behavior"),
+    radius: range(40, 240, 10, "Behavior"),
+    className: hidden(),
   },
   args: {
     children: "Design for Humans",
     mode: "auto",
-  } satisfies ElasticTextProps,
+    className: "text-4xl tracking-tight",
+  },
 } satisfies Meta<typeof ElasticText>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Auto: Story = {
-  args: {
-    mode: "auto",
-    children: "Design for Humans",
-    className: "text-4xl tracking-tight",
-  },
-};
-
-export const Hover: Story = {
-  args: {
-    mode: "hover",
-    children: "Move Your Mouse",
-    className: "text-4xl tracking-tight",
-  },
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/filter-bar.stories.tsx
+++ b/apps/storybook/src/stories/filter-bar.stories.tsx
@@ -1,5 +1,8 @@
 import { type Facet, FilterBar } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+import { action, hidden, toggle } from "../playground/argtypes";
+import { padded } from "../playground/stage";
 
 const facets: Facet[] = [
   {
@@ -36,23 +39,19 @@ const meta = {
   component: FilterBar,
   tags: ["autodocs"],
   parameters: { layout: "centered" },
-  args: { facets },
-  decorators: [
-    (Story) => (
-      <div className="w-[640px] max-w-full">
-        <Story />
-      </div>
-    ),
-  ],
+  decorators: [padded()],
+  argTypes: {
+    facets: hidden(),
+    value: hidden(),
+    defaultValue: hidden(),
+    searchable: toggle("Behavior"),
+    showCounts: toggle("Appearance"),
+    onChange: action("change"),
+  },
+  args: { facets, searchable: true, showCounts: true, onChange: fn() },
 } satisfies Meta<typeof FilterBar>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
-
-export const Preselected: Story = {
-  args: { defaultValue: { status: ["open"], type: ["bug", "feature"] } },
-};
-
-export const NoCounts: Story = { args: { showCounts: false } };
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/floating-toolbar.stories.tsx
+++ b/apps/storybook/src/stories/floating-toolbar.stories.tsx
@@ -1,5 +1,6 @@
 import { FloatingToolbar } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { hidden, toggle } from "../playground/argtypes";
 
 const icon = (path: string) => (
   <svg
@@ -28,10 +29,15 @@ const meta = {
   component: FloatingToolbar,
   tags: ["autodocs"],
   parameters: { layout: "centered" },
+  argTypes: {
+    open: toggle("State"),
+    actions: hidden(),
+    children: hidden(),
+  },
   args: { actions, open: true },
 } satisfies Meta<typeof FloatingToolbar>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/flow-field.stories.tsx
+++ b/apps/storybook/src/stories/flow-field.stories.tsx
@@ -1,35 +1,42 @@
 import { FlowField, type FlowFieldProps } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  type PresetMap,
+  presetSelect,
+  renderPreset,
+} from "../playground/presets";
+import { effectStage } from "../playground/stage";
 
-const meta = {
+const presets = {
+  Calm: { speed: 1, fade: 0.06, noiseScale: 0.0016 },
+  "Long Trails": { speed: 1.2, fade: 0.02, noiseScale: 0.0016 },
+  Emerald: { color: "#10b981", speed: 1, fade: 0.05, noiseScale: 0.0024 },
+  Crisp: { speed: 0.8, fade: 0.12, noiseScale: 0.002 },
+} satisfies PresetMap<FlowFieldProps>;
+
+type PlaygroundArgs = FlowFieldProps & { preset: keyof typeof presets };
+
+const meta: Meta<PlaygroundArgs> = {
   title: "Backgrounds/Flow Field",
   component: FlowField,
   tags: ["autodocs"],
   parameters: { layout: "fullscreen" },
   decorators: [
-    (Story) => (
-      <div className="relative flex min-h-[60vh] w-full items-center justify-center overflow-hidden bg-background">
-        <Story />
-        <div className="relative z-raised text-center">
-          <h1 className="font-semibold text-4xl tracking-tight">Flow Field</h1>
-          <p className="mt-2 text-muted-foreground">
-            Particles riding the currents.
-          </p>
-        </div>
-      </div>
-    ),
+    effectStage({
+      title: "Flow Field",
+      subtitle: "Particles riding the currents.",
+    }),
   ],
-} satisfies Meta<typeof FlowField>;
+  argTypes: {
+    preset: presetSelect(presets, "Appearance"),
+  },
+  args: {
+    preset: "Calm",
+  },
+  render: renderPreset(presets, (cfg) => <FlowField {...cfg} />),
+};
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<PlaygroundArgs>;
 
-export const Default: Story = { args: {} satisfies FlowFieldProps };
-
-export const LongTrails: Story = {
-  args: { fade: 0.02, speed: 1.2 } satisfies FlowFieldProps,
-};
-
-export const Tinted: Story = {
-  args: { color: "#10b981", noiseScale: 0.0024 } satisfies FlowFieldProps,
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/geometric-background.stories.tsx
+++ b/apps/storybook/src/stories/geometric-background.stories.tsx
@@ -6,50 +6,36 @@ import {
   geometricBackgroundVariants,
 } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { select } from "../playground/argtypes";
+import { effectStage } from "../playground/stage";
 
-type ShowcaseArgs = GeometricBackgroundProps & {
+type PlaygroundArgs = GeometricBackgroundProps & {
   variant: GeometricBackgroundVariant;
 };
 
-const meta: Meta<ShowcaseArgs> = {
+const meta: Meta<PlaygroundArgs> = {
   title: "Backgrounds/Geometric Background",
   component: GeometricBackground,
   tags: ["autodocs"],
   parameters: { layout: "fullscreen" },
+  decorators: [
+    effectStage({
+      title: "Geometric Background",
+      subtitle: "Ruled grids meet soft glows.",
+    }),
+  ],
   argTypes: {
-    variant: { control: "select", options: geometricBackgroundVariants },
+    variant: select(geometricBackgroundVariants, "Appearance"),
   },
-  args: { variant: geometricBackgroundVariants[0] },
+  args: {
+    variant: geometricBackgroundVariants[0],
+  },
+  render: ({ variant }) => (
+    <GeometricBackground style={geometricBackgroundPresets[variant]} />
+  ),
 };
 
 export default meta;
-type Story = StoryObj<ShowcaseArgs>;
+type Story = StoryObj<PlaygroundArgs>;
 
-export const Default: Story = {
-  render: ({ variant }) => (
-    <div className="relative flex min-h-[420px] w-full items-center justify-center overflow-hidden">
-      <GeometricBackground style={geometricBackgroundPresets[variant]} />
-      <p className="relative z-raised rounded-lg bg-background/70 px-4 py-2 text-sm font-medium text-foreground backdrop-blur">
-        {variant}
-      </p>
-    </div>
-  ),
-};
-
-export const Gallery: Story = {
-  render: () => (
-    <div className="grid grid-cols-2 gap-4 p-4 sm:grid-cols-3">
-      {geometricBackgroundVariants.map((variant) => (
-        <div
-          key={variant}
-          className="relative flex h-40 items-end overflow-hidden rounded-lg border border-border"
-        >
-          <GeometricBackground style={geometricBackgroundPresets[variant]} />
-          <span className="relative z-raised w-full truncate bg-background/70 px-2 py-1 text-xs text-foreground backdrop-blur">
-            {variant}
-          </span>
-        </div>
-      ))}
-    </div>
-  ),
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/globe.stories.tsx
+++ b/apps/storybook/src/stories/globe.stories.tsx
@@ -1,20 +1,55 @@
-import { Globe } from "@godui/components";
+import { Globe, type GlobeProps } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  type PresetMap,
+  presetSelect,
+  renderPreset,
+} from "../playground/presets";
+import { box } from "../playground/stage";
 
-const meta = {
+// Globe is driven by a single `config` object (cobe options) rather than flat
+// scalar props, so we expose a curated set of config presets instead of a pile
+// of raw controls.
+const presets: PresetMap<GlobeProps> = {
+  Default: {},
+  Night: {
+    config: {
+      dark: 1,
+      baseColor: [0.3, 0.3, 0.36],
+      glowColor: [0.15, 0.15, 0.2],
+      markerColor: [0.9, 0.6, 0.2],
+    },
+  },
+  Emerald: {
+    config: {
+      diffuse: 1.2,
+      markerColor: [0.13, 0.77, 0.55],
+      glowColor: [0.6, 0.95, 0.8],
+    },
+  },
+  Magenta: {
+    config: {
+      diffuse: 0.8,
+      markerColor: [0.85, 0.2, 0.6],
+      glowColor: [1, 0.7, 0.9],
+    },
+  },
+};
+
+type PlaygroundArgs = GlobeProps & { preset: string };
+
+const meta: Meta<PlaygroundArgs> = {
   title: "Effects/Globe",
   component: Globe,
   tags: ["autodocs"],
   parameters: { layout: "centered" },
-} satisfies Meta<typeof Globe>;
+  decorators: [box(440, 440)],
+  argTypes: { preset: presetSelect(presets, "Appearance") },
+  args: { preset: "Default" },
+  render: renderPreset(presets, (cfg) => <Globe {...cfg} />),
+};
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<PlaygroundArgs>;
 
-export const Default: Story = {
-  render: () => (
-    <div className="flex h-[440px] w-[440px] items-center justify-center">
-      <Globe />
-    </div>
-  ),
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/gradient-background.stories.tsx
+++ b/apps/storybook/src/stories/gradient-background.stories.tsx
@@ -6,50 +6,36 @@ import {
   gradientBackgroundVariants,
 } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { select } from "../playground/argtypes";
+import { effectStage } from "../playground/stage";
 
-type ShowcaseArgs = GradientBackgroundProps & {
+type PlaygroundArgs = GradientBackgroundProps & {
   variant: GradientBackgroundVariant;
 };
 
-const meta: Meta<ShowcaseArgs> = {
+const meta: Meta<PlaygroundArgs> = {
   title: "Backgrounds/Gradient Background",
   component: GradientBackground,
   tags: ["autodocs"],
   parameters: { layout: "fullscreen" },
+  decorators: [
+    effectStage({
+      title: "Gradient Background",
+      subtitle: "Spotlit radial washes.",
+    }),
+  ],
   argTypes: {
-    variant: { control: "select", options: gradientBackgroundVariants },
+    variant: select(gradientBackgroundVariants, "Appearance"),
   },
-  args: { variant: gradientBackgroundVariants[0] },
+  args: {
+    variant: gradientBackgroundVariants[0],
+  },
+  render: ({ variant }) => (
+    <GradientBackground style={gradientBackgroundPresets[variant]} />
+  ),
 };
 
 export default meta;
-type Story = StoryObj<ShowcaseArgs>;
+type Story = StoryObj<PlaygroundArgs>;
 
-export const Default: Story = {
-  render: ({ variant }) => (
-    <div className="relative flex min-h-[420px] w-full items-center justify-center overflow-hidden">
-      <GradientBackground style={gradientBackgroundPresets[variant]} />
-      <p className="relative z-raised rounded-lg bg-background/70 px-4 py-2 text-sm font-medium text-foreground backdrop-blur">
-        {variant}
-      </p>
-    </div>
-  ),
-};
-
-export const Gallery: Story = {
-  render: () => (
-    <div className="grid grid-cols-2 gap-4 p-4 sm:grid-cols-3">
-      {gradientBackgroundVariants.map((variant) => (
-        <div
-          key={variant}
-          className="relative flex h-40 items-end overflow-hidden rounded-lg border border-border"
-        >
-          <GradientBackground style={gradientBackgroundPresets[variant]} />
-          <span className="relative z-raised w-full truncate bg-background/70 px-2 py-1 text-xs text-foreground backdrop-blur">
-            {variant}
-          </span>
-        </div>
-      ))}
-    </div>
-  ),
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/highlighter.stories.tsx
+++ b/apps/storybook/src/stories/highlighter.stories.tsx
@@ -1,101 +1,52 @@
-import { Highlighter, type HighlighterProps } from "@godui/components";
+import { Highlighter } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  color,
+  hidden,
+  range,
+  select,
+  text,
+  toggle,
+} from "../playground/argtypes";
+import { centered } from "../playground/stage";
 
 const meta = {
   title: "Text/Highlighter",
   component: Highlighter,
   tags: ["autodocs"],
-  parameters: {
-    layout: "centered",
+  parameters: { layout: "centered" },
+  decorators: [centered()],
+  argTypes: {
+    children: text("Content"),
+    action: select(
+      [
+        "highlight",
+        "underline",
+        "box",
+        "circle",
+        "strike-through",
+        "crossed-off",
+        "bracket",
+      ],
+      "Appearance",
+    ),
+    color: color("Appearance"),
+    strokeWidth: range(1, 6, 0.5, "Appearance"),
+    animationDuration: range(200, 3000, 100, "Behavior"),
+    iterations: range(1, 5, 1, "Appearance"),
+    padding: range(0, 16, 1, "Appearance"),
+    multiline: toggle("Behavior"),
+    isView: toggle("Behavior"),
+    className: hidden(),
   },
   args: {
     children: "highlight",
     action: "highlight",
     className: "text-3xl font-sans",
-  } satisfies HighlighterProps,
+  },
 } satisfies Meta<typeof Highlighter>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Highlight: Story = {
-  args: {
-    action: "highlight",
-    children: "highlight",
-  },
-};
-
-export const Underline: Story = {
-  args: {
-    action: "underline",
-    color: "#60a5fa",
-    children: "underline",
-  },
-};
-
-export const Box: Story = {
-  args: {
-    action: "box",
-    color: "#f59e0b",
-    children: "box",
-  },
-};
-
-export const Circle: Story = {
-  args: {
-    action: "circle",
-    color: "#34d399",
-    children: "circle",
-  },
-};
-
-export const StrikeThrough: Story = {
-  args: {
-    action: "strike-through",
-    color: "#f87171",
-    children: "strike-through",
-  },
-};
-
-export const CrossedOff: Story = {
-  args: {
-    action: "crossed-off",
-    color: "#a78bfa",
-    children: "crossed-off",
-  },
-};
-
-export const Bracket: Story = {
-  args: {
-    action: "bracket",
-    color: "#fb7185",
-    children: "bracket",
-  },
-};
-
-export const CustomColor: Story = {
-  args: {
-    action: "highlight",
-    color: "#22d3ee",
-    children: "custom color",
-  },
-};
-
-export const InView: Story = {
-  args: {
-    action: "underline",
-    isView: true,
-    children: "Scroll into view to animate",
-    className: "text-3xl font-sans",
-  },
-  decorators: [
-    (Story) => (
-      <div style={{ height: "200vh", paddingTop: "120vh" }}>
-        <Story />
-      </div>
-    ),
-  ],
-  parameters: {
-    layout: "padded",
-  },
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/image-compare.stories.tsx
+++ b/apps/storybook/src/stories/image-compare.stories.tsx
@@ -1,11 +1,24 @@
 import { ImageCompare } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+import { action, hidden, range, select, text } from "../playground/argtypes";
+import { box } from "../playground/stage";
 
 const meta = {
   title: "Layout/Image Compare",
   component: ImageCompare,
   tags: ["autodocs"],
   parameters: { layout: "centered" },
+  decorators: [box(420, 315)],
+  argTypes: {
+    before: hidden(),
+    after: hidden(),
+    beforeLabel: text("Content"),
+    afterLabel: text("Content"),
+    orientation: select(["horizontal", "vertical"], "Appearance"),
+    initial: range(0, 100, 5, "State"),
+    onChange: action("change"),
+  },
   args: {
     before: <img src="https://picsum.photos/id/1015/800/600" alt="Color" />,
     after: (
@@ -15,19 +28,15 @@ const meta = {
         className="grayscale"
       />
     ),
+    beforeLabel: "Color",
+    afterLabel: "B&W",
+    orientation: "horizontal",
+    initial: 50,
+    onChange: fn(),
   },
-  render: (args) => (
-    <div style={{ width: 420, aspectRatio: "4 / 3" }}>
-      <ImageCompare {...args} />
-    </div>
-  ),
 } satisfies Meta<typeof ImageCompare>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-  args: { beforeLabel: "Color", afterLabel: "B&W" },
-};
-export const Vertical: Story = { args: { orientation: "vertical" } };
-export const StartLeft: Story = { args: { initial: 15 } };
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/lamp.stories.tsx
+++ b/apps/storybook/src/stories/lamp.stories.tsx
@@ -1,22 +1,36 @@
 import { Lamp } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { color, text } from "../playground/argtypes";
 
-const meta = {
+// Lamp wraps headline content under a conic spotlight; we expose the accent
+// color plus the headline text and render the latter as children.
+type PlaygroundArgs = {
+  color: string;
+  headline: string;
+};
+
+const meta: Meta<PlaygroundArgs> = {
   title: "Effects/Lamp",
   component: Lamp,
   tags: ["autodocs"],
   parameters: { layout: "fullscreen" },
-} satisfies Meta<typeof Lamp>;
-
-export default meta;
-type Story = StoryObj<typeof meta>;
-
-export const Default: Story = {
-  render: () => (
-    <Lamp>
+  argTypes: {
+    color: color("Appearance"),
+    headline: text("Content"),
+  },
+  args: {
+    headline: "Ship in the spotlight",
+  },
+  render: ({ color: accent, headline }) => (
+    <Lamp color={accent || undefined}>
       <h2 className="text-3xl font-semibold tracking-tight text-foreground md:text-4xl">
-        Ship in the spotlight
+        {headline}
       </h2>
     </Lamp>
   ),
 };
+
+export default meta;
+type Story = StoryObj<PlaygroundArgs>;
+
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/light-rays.stories.tsx
+++ b/apps/storybook/src/stories/light-rays.stories.tsx
@@ -1,39 +1,48 @@
 import { LightRays, type LightRaysProps } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  type PresetMap,
+  presetSelect,
+  renderPreset,
+} from "../playground/presets";
+import { effectStage } from "../playground/stage";
 
-const meta = {
+const presets = {
+  Soft: { rayCount: 14, intensity: 0.6, angle: 0, speed: 1, grain: 0.05 },
+  Warm: {
+    color: "#f59e0b",
+    rayCount: 18,
+    intensity: 0.7,
+    speed: 1,
+    grain: 0.05,
+  },
+  Angled: { rayCount: 14, intensity: 0.6, angle: -20, speed: 1.3, grain: 0.05 },
+  Dense: { rayCount: 26, intensity: 0.5, angle: 0, speed: 0.8, grain: 0.08 },
+} satisfies PresetMap<LightRaysProps>;
+
+type PlaygroundArgs = LightRaysProps & { preset: keyof typeof presets };
+
+const meta: Meta<PlaygroundArgs> = {
   title: "Backgrounds/Light Rays",
   component: LightRays,
   tags: ["autodocs"],
   parameters: { layout: "fullscreen" },
   decorators: [
-    (Story) => (
-      <div className="relative flex min-h-[60vh] w-full items-center justify-center overflow-hidden bg-background">
-        <Story />
-        <div className="relative z-raised text-center">
-          <h1 className="font-semibold text-4xl tracking-tight">Light Rays</h1>
-          <p className="mt-2 text-muted-foreground">
-            Volumetric god-rays, breathing.
-          </p>
-        </div>
-      </div>
-    ),
+    effectStage({
+      title: "Light Rays",
+      subtitle: "Volumetric god-rays, breathing.",
+    }),
   ],
-} satisfies Meta<typeof LightRays>;
+  argTypes: {
+    preset: presetSelect(presets, "Appearance"),
+  },
+  args: {
+    preset: "Soft",
+  },
+  render: renderPreset(presets, (cfg) => <LightRays {...cfg} />),
+};
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<PlaygroundArgs>;
 
-export const Default: Story = { args: {} satisfies LightRaysProps };
-
-export const Warm: Story = {
-  args: {
-    color: "#f59e0b",
-    rayCount: 18,
-    intensity: 0.7,
-  } satisfies LightRaysProps,
-};
-
-export const Angled: Story = {
-  args: { angle: -20, speed: 1.3 } satisfies LightRaysProps,
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/liquid-glass-card.stories.tsx
+++ b/apps/storybook/src/stories/liquid-glass-card.stories.tsx
@@ -1,6 +1,7 @@
 import { LiquidGlassCard, type LiquidGlassCardProps } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { ReactNode } from "react";
+import { color, range } from "../playground/argtypes";
 
 const meta: Meta<LiquidGlassCardProps> = {
   title: "Effects/Liquid Glass Card",
@@ -8,12 +9,13 @@ const meta: Meta<LiquidGlassCardProps> = {
   tags: ["autodocs"],
   parameters: { layout: "fullscreen" },
   argTypes: {
-    radius: { control: { type: "range", min: 0, max: 64, step: 1 } },
-    blur: { control: { type: "range", min: 0, max: 20, step: 0.5 } },
-    strength: { control: { type: "range", min: 0, max: 160, step: 1 } },
-    dispersion: { control: { type: "range", min: 0, max: 1, step: 0.01 } },
-    saturation: { control: { type: "range", min: 1, max: 3, step: 0.1 } },
-    sheen: { control: { type: "range", min: 0, max: 1, step: 0.01 } },
+    radius: range(0, 64, 1, "Appearance"),
+    blur: range(0, 20, 0.5, "Appearance"),
+    strength: range(0, 160, 1, "Appearance"),
+    dispersion: range(0, 1, 0.01, "Appearance"),
+    saturation: range(1, 3, 0.1, "Appearance"),
+    sheen: range(0, 1, 0.01, "Appearance"),
+    tint: color("Appearance"),
   },
   args: {
     radius: 28,
@@ -23,21 +25,6 @@ const meta: Meta<LiquidGlassCardProps> = {
     saturation: 1.6,
     sheen: 0.5,
   },
-};
-
-export default meta;
-type Story = StoryObj<LiquidGlassCardProps>;
-
-// A busy backdrop so the refraction and color fringing are obvious.
-const Backdrop = ({ children }: { children: ReactNode }) => (
-  <div className="relative flex min-h-[480px] w-full items-center justify-center overflow-hidden p-10">
-    <div className="absolute inset-0 [background:conic-gradient(from_0deg,#ff2d55,#ff9500,#ffd60a,#34c759,#0a84ff,#5e5ce6,#bf5af2,#ff2d55)] opacity-90" />
-    <div className="absolute inset-0 [background-image:linear-gradient(#0003_1px,transparent_1px),linear-gradient(90deg,#0003_1px,transparent_1px)] [background-size:32px_32px]" />
-    {children}
-  </div>
-);
-
-export const Default: Story = {
   render: (args) => (
     <Backdrop>
       <LiquidGlassCard {...args} className="w-80 p-8">
@@ -53,18 +40,16 @@ export const Default: Story = {
   ),
 };
 
-export const Cards: Story = {
-  render: (args) => (
-    <Backdrop>
-      <div className="flex flex-wrap items-center justify-center gap-6">
-        {["Refract", "Disperse", "Reflect"].map((label) => (
-          <LiquidGlassCard key={label} {...args} className="w-48 p-6">
-            <span className="text-lg font-semibold text-white drop-shadow">
-              {label}
-            </span>
-          </LiquidGlassCard>
-        ))}
-      </div>
-    </Backdrop>
-  ),
-};
+export default meta;
+type Story = StoryObj<LiquidGlassCardProps>;
+
+// A busy backdrop so the refraction and color fringing are obvious.
+const Backdrop = ({ children }: { children: ReactNode }) => (
+  <div className="relative flex min-h-[480px] w-full items-center justify-center overflow-hidden p-10">
+    <div className="absolute inset-0 [background:conic-gradient(from_0deg,#ff2d55,#ff9500,#ffd60a,#34c759,#0a84ff,#5e5ce6,#bf5af2,#ff2d55)] opacity-90" />
+    <div className="absolute inset-0 [background-image:linear-gradient(#0003_1px,transparent_1px),linear-gradient(90deg,#0003_1px,transparent_1px)] [background-size:32px_32px]" />
+    {children}
+  </div>
+);
+
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/liquid-glass-lens.stories.tsx
+++ b/apps/storybook/src/stories/liquid-glass-lens.stories.tsx
@@ -1,5 +1,6 @@
 import { LiquidGlassLens, type LiquidGlassLensProps } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { color, range } from "../playground/argtypes";
 
 const meta: Meta<LiquidGlassLensProps> = {
   title: "Effects/Liquid Glass Lens",
@@ -7,12 +8,13 @@ const meta: Meta<LiquidGlassLensProps> = {
   tags: ["autodocs"],
   parameters: { layout: "fullscreen" },
   argTypes: {
-    size: { control: { type: "range", min: 80, max: 320, step: 4 } },
-    blur: { control: { type: "range", min: 0, max: 20, step: 0.5 } },
-    strength: { control: { type: "range", min: 0, max: 160, step: 1 } },
-    dispersion: { control: { type: "range", min: 0, max: 1, step: 0.01 } },
-    saturation: { control: { type: "range", min: 1, max: 3, step: 0.1 } },
-    sheen: { control: { type: "range", min: 0, max: 1, step: 0.01 } },
+    size: range(80, 320, 4, "Appearance"),
+    blur: range(0, 20, 0.5, "Appearance"),
+    strength: range(0, 160, 1, "Appearance"),
+    dispersion: range(0, 1, 0.01, "Appearance"),
+    saturation: range(1, 3, 0.1, "Appearance"),
+    sheen: range(0, 1, 0.01, "Appearance"),
+    tint: color("Appearance"),
   },
   args: {
     size: 220,
@@ -22,12 +24,6 @@ const meta: Meta<LiquidGlassLensProps> = {
     saturation: 1.6,
     sheen: 0.5,
   },
-};
-
-export default meta;
-type Story = StoryObj<LiquidGlassLensProps>;
-
-export const Default: Story = {
   render: (args) => (
     <div className="relative flex min-h-[480px] w-full items-center justify-center overflow-hidden p-10">
       <div className="absolute inset-0 [background:conic-gradient(from_0deg,#ff2d55,#ff9500,#ffd60a,#34c759,#0a84ff,#5e5ce6,#bf5af2,#ff2d55)] opacity-90" />
@@ -39,3 +35,8 @@ export const Default: Story = {
     </div>
   ),
 };
+
+export default meta;
+type Story = StoryObj<LiquidGlassLensProps>;
+
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/liquid-metaballs.stories.tsx
+++ b/apps/storybook/src/stories/liquid-metaballs.stories.tsx
@@ -1,40 +1,65 @@
 import { LiquidMetaballs, type LiquidMetaballsProps } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { toggle } from "../playground/argtypes";
+import {
+  type PresetMap,
+  presetSelect,
+  renderPreset,
+} from "../playground/presets";
+import { effectStage } from "../playground/stage";
 
-const meta = {
+const presets = {
+  Aurora: {
+    colors: ["#6366f1", "#a855f7", "#ec4899", "#06b6d4"],
+    speed: 1,
+    gooeyness: 16,
+    blobCount: 7,
+  },
+  Sunset: {
+    colors: ["#f97316", "#f43f5e", "#f59e0b"],
+    speed: 0.7,
+    gooeyness: 22,
+    blobCount: 6,
+  },
+  Ocean: {
+    colors: ["#0ea5e9", "#06b6d4", "#14b8a6"],
+    speed: 1.2,
+    gooeyness: 14,
+    blobCount: 9,
+  },
+  Mono: {
+    colors: ["#94a3b8", "#cbd5e1", "#64748b"],
+    speed: 0.8,
+    gooeyness: 18,
+    blobCount: 7,
+  },
+} satisfies PresetMap<LiquidMetaballsProps>;
+
+type PlaygroundArgs = LiquidMetaballsProps & { preset: keyof typeof presets };
+
+const meta: Meta<PlaygroundArgs> = {
   title: "Backgrounds/Liquid Metaballs",
   component: LiquidMetaballs,
   tags: ["autodocs"],
   parameters: { layout: "fullscreen" },
   decorators: [
-    (Story) => (
-      <div className="relative flex min-h-[60vh] w-full items-center justify-center overflow-hidden bg-background">
-        <Story />
-        <div className="relative z-raised text-center">
-          <h1 className="font-semibold text-4xl tracking-tight">
-            Liquid Metaballs
-          </h1>
-          <p className="mt-2 text-muted-foreground">
-            Gooey blobs that merge and split.
-          </p>
-        </div>
-      </div>
-    ),
+    effectStage({
+      title: "Liquid Metaballs",
+      subtitle: "Gooey blobs that merge and split.",
+    }),
   ],
-} satisfies Meta<typeof LiquidMetaballs>;
+  argTypes: {
+    preset: presetSelect(presets, "Appearance"),
+    interactive: toggle("Behavior"),
+  },
+  args: {
+    preset: "Aurora",
+    interactive: true,
+  },
+  render: renderPreset(presets, (cfg) => <LiquidMetaballs {...cfg} />),
+};
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<PlaygroundArgs>;
 
-export const Default: Story = { args: {} satisfies LiquidMetaballsProps };
-
-export const Gooey: Story = {
-  args: { gooeyness: 24, blobCount: 9 } satisfies LiquidMetaballsProps,
-};
-
-export const Duotone: Story = {
-  args: {
-    colors: ["#6366f1", "#06b6d4"],
-    speed: 0.7,
-  } satisfies LiquidMetaballsProps,
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/live-cursors.stories.tsx
+++ b/apps/storybook/src/stories/live-cursors.stories.tsx
@@ -1,17 +1,6 @@
 import { LiveCursors, SimulatedCursors } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-
-const meta = {
-  title: "Collaboration/LiveCursors",
-  component: LiveCursors,
-  subcomponents: { SimulatedCursors },
-  tags: ["autodocs"],
-  parameters: { layout: "centered" },
-  args: { cursors: [] },
-} satisfies Meta<typeof LiveCursors>;
-
-export default meta;
-type Story = StoryObj<typeof meta>;
+import { hidden, toggle } from "../playground/argtypes";
 
 const Canvas = ({ children }: { children: React.ReactNode }) => (
   <div className="relative h-80 w-[40rem] max-w-[90vw] overflow-hidden rounded-2xl border border-border bg-[radial-gradient(oklch(0.7_0_0/0.12)_1px,transparent_1px)] [background-size:18px_18px]">
@@ -19,41 +8,45 @@ const Canvas = ({ children }: { children: React.ReactNode }) => (
   </div>
 );
 
-export const SimulatedPeers: Story = {
-  render: () => (
-    <Canvas>
-      <div className="pointer-events-none absolute inset-0 grid place-items-center text-sm text-muted-foreground">
-        Live teammates moving around the canvas
-      </div>
-      <SimulatedCursors names={["Ana", "Marco", "Priya", "Jules"]} />
-    </Canvas>
-  ),
-};
+const cursors = [
+  {
+    id: "1",
+    name: "Ana",
+    x: 120,
+    y: 80,
+    message: "shipping this now 🚀",
+  },
+  { id: "2", name: "Marco", x: 360, y: 180 },
+  { id: "3", name: "Priya", x: 240, y: 240, message: "lgtm!" },
+];
 
-export const CursorChat: Story = {
-  render: () => (
-    <Canvas>
-      <LiveCursors
-        cursors={[
-          {
-            id: "1",
-            name: "Ana",
-            x: 120,
-            y: 80,
-            message: "shipping this now 🚀",
-          },
-          { id: "2", name: "Marco", x: 360, y: 180 },
-          { id: "3", name: "Priya", x: 240, y: 240, message: "lgtm!" },
-        ]}
-      />
-    </Canvas>
-  ),
-};
+const meta = {
+  title: "Collaboration/LiveCursors",
+  component: LiveCursors,
+  subcomponents: { SimulatedCursors },
+  tags: ["autodocs"],
+  parameters: { layout: "centered" },
+  decorators: [
+    (Story) => (
+      <Canvas>
+        <div className="pointer-events-none absolute inset-0 grid place-items-center text-sm text-muted-foreground">
+          Live teammates moving around the canvas
+        </div>
+        <Story />
+      </Canvas>
+    ),
+  ],
+  argTypes: {
+    hideNames: toggle("Appearance"),
+    cursors: hidden(),
+  },
+  args: {
+    hideNames: false,
+    cursors,
+  },
+} satisfies Meta<typeof LiveCursors>;
 
-export const PointersOnly: Story = {
-  render: () => (
-    <Canvas>
-      <SimulatedCursors hideNames names={["A", "B", "C", "D", "E"]} />
-    </Canvas>
-  ),
-};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/magic-button.stories.tsx
+++ b/apps/storybook/src/stories/magic-button.stories.tsx
@@ -1,63 +1,34 @@
-import { MagicButton, type MagicButtonProps } from "@godui/components";
+import { MagicButton } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+import { action, select, text, toggle } from "../playground/argtypes";
+import { centered } from "../playground/stage";
 
 const meta = {
   title: "Buttons/Magic Button",
   component: MagicButton,
   tags: ["autodocs"],
-  parameters: {
-    layout: "centered",
+  parameters: { layout: "centered" },
+  decorators: [centered()],
+  argTypes: {
+    children: text("Content"),
+    variant: select(["default", "secondary"], "Appearance"),
+    size: select(["sm", "md", "lg"], "Appearance"),
+    rainbow: toggle("Appearance"),
+    disabled: toggle("State"),
+    onClick: action("click"),
+  },
+  args: {
+    children: "Push me",
+    variant: "default",
+    size: "md",
+    rainbow: true,
+    disabled: false,
+    onClick: fn(),
   },
 } satisfies Meta<typeof MagicButton>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-  args: {
-    children: "Push me",
-    variant: "default",
-  } satisfies MagicButtonProps,
-};
-
-export const Secondary: Story = {
-  args: {
-    children: "Push me",
-    variant: "secondary",
-  } satisfies MagicButtonProps,
-};
-
-export const Disabled: Story = {
-  args: {
-    children: "Push me",
-    variant: "default",
-    disabled: true,
-  } satisfies MagicButtonProps,
-};
-
-export const Sizes: Story = {
-  render: () => (
-    <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
-      <MagicButton size="sm">Small</MagicButton>
-      <MagicButton size="md">Medium</MagicButton>
-      <MagicButton size="lg">Large</MagicButton>
-    </div>
-  ),
-};
-
-export const Playground: Story = {
-  args: {
-    children: "Push me",
-    variant: "default",
-    size: "md",
-    rainbow: true,
-  } satisfies MagicButtonProps,
-};
-
-export const WithoutRainbow: Story = {
-  args: {
-    children: "Push me",
-    variant: "default",
-    rainbow: false,
-  } satisfies MagicButtonProps,
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/magic-input.stories.tsx
+++ b/apps/storybook/src/stories/magic-input.stories.tsx
@@ -1,146 +1,44 @@
-import { MagicInput, type MagicInputProps } from "@godui/components";
+import { MagicInput } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import * as React from "react";
+import { fn } from "storybook/test";
+import { action, range, select, text, toggle } from "../playground/argtypes";
+import { centered } from "../playground/stage";
 
 const meta = {
   title: "Inputs/Magic Input",
   component: MagicInput,
   tags: ["autodocs"],
-  parameters: {
-    layout: "centered",
+  parameters: { layout: "centered" },
+  decorators: [centered(320)],
+  argTypes: {
+    variant: select(["primary", "secondary"], "Appearance"),
+    size: select(["sm", "md", "lg"], "Appearance"),
+    depth: select(["focus", "always"], "Appearance"),
+    rainbow: toggle("Appearance"),
+    submitButton: toggle("Behavior"),
+    submitLabel: text("Content"),
+    placeholder: text("Content"),
+    status: select(["idle", "loading", "success", "error"], "State"),
+    progress: range(0, 100, 1, "State"),
+    disabled: toggle("State"),
+    onSubmit: action("submit"),
+  },
+  args: {
+    variant: "primary",
+    size: "md",
+    depth: "focus",
+    rainbow: true,
+    submitButton: false,
+    submitLabel: "Go",
+    placeholder: "Focus me",
+    status: "idle",
+    progress: 0,
+    disabled: false,
+    onSubmit: fn(),
   },
 } satisfies Meta<typeof MagicInput>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-  args: {
-    placeholder: "Focus me",
-    variant: "primary",
-  } satisfies MagicInputProps,
-};
-
-export const Secondary: Story = {
-  args: {
-    placeholder: "Focus me",
-    variant: "secondary",
-  } satisfies MagicInputProps,
-};
-
-export const AlwaysRaised: Story = {
-  args: {
-    placeholder: "Always 3D",
-    depth: "always",
-  } satisfies MagicInputProps,
-};
-
-export const WithoutRainbow: Story = {
-  args: {
-    placeholder: "Focus me",
-    rainbow: false,
-  } satisfies MagicInputProps,
-};
-
-export const Disabled: Story = {
-  args: {
-    placeholder: "Disabled",
-    disabled: true,
-  } satisfies MagicInputProps,
-};
-
-export const Sizes: Story = {
-  render: () => (
-    <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-      <MagicInput size="sm" placeholder="Small" />
-      <MagicInput size="md" placeholder="Medium" />
-      <MagicInput size="lg" placeholder="Large" />
-    </div>
-  ),
-};
-
-export const WithSubmitButton: Story = {
-  args: {
-    placeholder: "Type and submit",
-    onSubmit: (value: string) => alert(value),
-  } satisfies MagicInputProps,
-};
-
-export const LoadingIndeterminate: Story = {
-  args: {
-    placeholder: "Submitting…",
-    onSubmit: () => {},
-    status: "loading",
-  } satisfies MagicInputProps,
-};
-
-export const LoadingDeterminate: Story = {
-  args: {
-    placeholder: "Uploading…",
-    onSubmit: () => {},
-    status: "loading",
-    progress: 60,
-  } satisfies MagicInputProps,
-};
-
-export const Success: Story = {
-  args: {
-    placeholder: "Done",
-    onSubmit: () => {},
-    status: "success",
-  } satisfies MagicInputProps,
-};
-
-export const ErrorState: Story = {
-  name: "Error",
-  args: {
-    placeholder: "Failed",
-    onSubmit: () => {},
-    status: "error",
-  } satisfies MagicInputProps,
-};
-
-export const SubmitFlow: Story = {
-  render: () => {
-    const [status, setStatus] =
-      React.useState<MagicInputProps["status"]>("idle");
-    const [progress, setProgress] = React.useState(0);
-
-    const run = () => {
-      if (status !== "idle") return;
-      setStatus("loading");
-      setProgress(0);
-      let p = 0;
-      const id = setInterval(() => {
-        p += 12;
-        setProgress(Math.min(p, 100));
-        if (p >= 100) {
-          clearInterval(id);
-          setStatus("success");
-          setTimeout(() => setStatus("idle"), 1600);
-        }
-      }, 250);
-    };
-
-    return (
-      <div style={{ width: 280 }}>
-        <MagicInput
-          placeholder="Type and submit"
-          status={status}
-          progress={status === "loading" ? progress : undefined}
-          onSubmit={run}
-        />
-      </div>
-    );
-  },
-};
-
-export const Playground: Story = {
-  args: {
-    placeholder: "Focus me",
-    variant: "primary",
-    size: "md",
-    depth: "focus",
-    rainbow: true,
-  } satisfies MagicInputProps,
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/magic-tab.stories.tsx
+++ b/apps/storybook/src/stories/magic-tab.stories.tsx
@@ -1,6 +1,8 @@
-import { MagicTab, type MagicTabProps } from "@godui/components";
+import { MagicTab } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { useState } from "react";
+import { fn } from "storybook/test";
+import { action, hidden, select, toggle } from "../playground/argtypes";
+import { centered } from "../playground/stage";
 
 const items = [
   { value: "overview", label: "Overview" },
@@ -13,77 +15,31 @@ const meta = {
   title: "Navigation/Magic Tab",
   component: MagicTab,
   tags: ["autodocs"],
-  parameters: {
-    layout: "centered",
+  parameters: { layout: "centered" },
+  decorators: [centered()],
+  argTypes: {
+    items: hidden(),
+    value: hidden(),
+    variant: select(["default", "secondary"], "Appearance"),
+    size: select(["sm", "md", "lg"], "Appearance"),
+    rainbow: toggle("Appearance"),
+    defaultValue: select(
+      ["overview", "analytics", "reports", "settings"],
+      "State",
+    ),
+    onValueChange: action("valueChange"),
   },
-  args: {
-    items,
-  } satisfies Partial<MagicTabProps>,
-} satisfies Meta<typeof MagicTab>;
-
-export default meta;
-type Story = StoryObj<typeof meta>;
-
-export const Default: Story = {
-  args: {
-    items,
-    variant: "default",
-  } satisfies MagicTabProps,
-};
-
-export const Secondary: Story = {
-  args: {
-    items,
-    variant: "secondary",
-  } satisfies MagicTabProps,
-};
-
-export const WithoutRainbow: Story = {
-  args: {
-    items,
-    rainbow: false,
-  } satisfies MagicTabProps,
-};
-
-export const WithDisabledTab: Story = {
-  args: {
-    items: [
-      { value: "overview", label: "Overview" },
-      { value: "analytics", label: "Analytics", disabled: true },
-      { value: "reports", label: "Reports" },
-    ],
-  } satisfies MagicTabProps,
-};
-
-export const Sizes: Story = {
-  render: () => (
-    <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-      <MagicTab items={items} size="sm" />
-      <MagicTab items={items} size="md" />
-      <MagicTab items={items} size="lg" />
-    </div>
-  ),
-};
-
-export const Controlled: Story = {
-  render: () => {
-    const [value, setValue] = useState("analytics");
-    return (
-      <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-        <MagicTab items={items} value={value} onValueChange={setValue} />
-        <p style={{ textAlign: "center", margin: 0 }}>
-          Selected: <strong>{value}</strong>
-        </p>
-      </div>
-    );
-  },
-};
-
-export const Playground: Story = {
   args: {
     items,
     variant: "default",
     size: "md",
     rainbow: true,
-  } satisfies MagicTabProps,
-};
+    defaultValue: "overview",
+    onValueChange: fn(),
+  },
+} satisfies Meta<typeof MagicTab>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/magnetic-button.stories.tsx
+++ b/apps/storybook/src/stories/magnetic-button.stories.tsx
@@ -1,80 +1,38 @@
-import { MagneticButton, type MagneticButtonProps } from "@godui/components";
+import { MagneticButton } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+import { action, range, select, text, toggle } from "../playground/argtypes";
+import { centered } from "../playground/stage";
 
 const meta = {
   title: "Buttons/Magnetic Button",
   component: MagneticButton,
   tags: ["autodocs"],
   parameters: { layout: "centered" },
+  decorators: [centered()],
   argTypes: {
-    variant: {
-      control: "select",
-      options: ["default", "secondary", "outline"],
-    },
-    size: { control: "select", options: ["sm", "md", "lg"] },
-    strength: { control: { type: "range", min: 0, max: 1, step: 0.05 } },
-    range: { control: { type: "range", min: 0, max: 64, step: 4 } },
+    children: text("Content"),
+    variant: select(["default", "secondary", "outline"], "Appearance"),
+    size: select(["sm", "md", "lg"], "Appearance"),
+    strength: range(0, 1, 0.05, "Behavior"),
+    range: range(0, 64, 4, "Behavior"),
+    staticLabel: toggle("Behavior"),
+    disabled: toggle("State"),
+    onClick: action("click"),
+  },
+  args: {
+    children: "Get started",
+    variant: "default",
+    size: "md",
+    strength: 0.4,
+    range: 32,
+    staticLabel: false,
+    disabled: false,
+    onClick: fn(),
   },
 } satisfies Meta<typeof MagneticButton>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-  args: {
-    children: "Get started",
-    variant: "default",
-    size: "md",
-    strength: 0.4,
-  } satisfies MagneticButtonProps,
-};
-
-export const Variants: Story = {
-  render: () => (
-    <div className="flex items-center gap-4">
-      <MagneticButton variant="default">Default</MagneticButton>
-      <MagneticButton variant="secondary">Secondary</MagneticButton>
-      <MagneticButton variant="outline">Outline</MagneticButton>
-    </div>
-  ),
-};
-
-export const Sizes: Story = {
-  render: () => (
-    <div className="flex items-center gap-4">
-      <MagneticButton size="sm">Small</MagneticButton>
-      <MagneticButton size="md">Medium</MagneticButton>
-      <MagneticButton size="lg">Large</MagneticButton>
-    </div>
-  ),
-};
-
-export const StrongPull: Story = {
-  args: {
-    children: "Strong pull",
-    strength: 0.8,
-  } satisfies MagneticButtonProps,
-};
-
-export const WithSensorRange: Story = {
-  args: {
-    children: "Wide sensor",
-    range: 48,
-  } satisfies MagneticButtonProps,
-};
-
-export const StaticLabel: Story = {
-  args: {
-    children: "Label stays centered",
-    variant: "secondary",
-    range: 44,
-    staticLabel: true,
-  } satisfies MagneticButtonProps,
-};
-
-export const Disabled: Story = {
-  args: {
-    children: "Disabled",
-    disabled: true,
-  } satisfies MagneticButtonProps,
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/marquee.stories.tsx
+++ b/apps/storybook/src/stories/marquee.stories.tsx
@@ -1,6 +1,7 @@
 import { Marquee, type MarqueeProps } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { ReactNode } from "react";
+import { range, select, toggle } from "../playground/argtypes";
 
 const logos: { name: string; mark: ReactNode }[] = [
   { name: "Northwind", mark: <circle cx="12" cy="12" r="9" /> },
@@ -32,35 +33,25 @@ function LogoCloud() {
   ));
 }
 
-const reviews = [
-  { name: "Ada", body: "The smoothest UI I've shipped this year." },
-  { name: "Linus", body: "Spring physics that actually feel right." },
-  { name: "Grace", body: "Dropped it in and it just worked." },
-  { name: "Alan", body: "My landing page finally feels premium." },
-];
-
-function ReviewCards() {
-  return reviews.map((r) => (
-    <figure
-      key={r.name}
-      className="w-64 rounded-xl border border-border bg-card p-4 shadow-sm"
-    >
-      <figcaption className="text-sm font-semibold text-foreground">
-        {r.name}
-      </figcaption>
-      <blockquote className="mt-2 text-sm text-muted-foreground">
-        {r.body}
-      </blockquote>
-    </figure>
-  ));
-}
-
 const meta = {
   title: "Effects/Marquee",
   component: Marquee,
   tags: ["autodocs"],
   parameters: { layout: "fullscreen" },
-  args: { direction: "left", speed: 28, pauseOnHover: true, fade: true },
+  argTypes: {
+    direction: select(["left", "right", "up", "down"], "Behavior"),
+    speed: range(5, 60, 1, "Behavior"),
+    repeat: range(2, 6, 1, "Behavior"),
+    pauseOnHover: toggle("Behavior"),
+    fade: toggle("Appearance"),
+  },
+  args: {
+    direction: "left",
+    speed: 28,
+    repeat: 2,
+    pauseOnHover: true,
+    fade: true,
+  },
   render: (args: MarqueeProps) => (
     <div className="p-10">
       <p className="mb-6 text-center text-sm font-medium uppercase tracking-wide text-muted-foreground">
@@ -76,31 +67,4 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const LogoCloudStory: Story = { name: "Logo Cloud" };
-
-export const Reviews: Story = {
-  render: (args: MarqueeProps) => (
-    <div className="p-10">
-      <Marquee {...args}>
-        <ReviewCards />
-      </Marquee>
-    </div>
-  ),
-};
-
-export const Reverse: Story = { args: { direction: "right" } };
-
-export const Fast: Story = { args: { speed: 15 } };
-
-export const NoFade: Story = { args: { fade: false } };
-
-export const Vertical: Story = {
-  args: { direction: "up" },
-  render: (args: MarqueeProps) => (
-    <div className="flex h-[420px] items-center justify-center p-8">
-      <Marquee {...args} className="h-full">
-        <ReviewCards />
-      </Marquee>
-    </div>
-  ),
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/mask-button.stories.tsx
+++ b/apps/storybook/src/stories/mask-button.stories.tsx
@@ -1,61 +1,34 @@
-import { MaskButton, type MaskButtonProps } from "@godui/components";
+import { MaskButton } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+import { action, select, text, toggle } from "../playground/argtypes";
+import { centered } from "../playground/stage";
 
 const meta = {
   title: "Buttons/Mask Button",
   component: MaskButton,
   tags: ["autodocs"],
-  parameters: {
-    layout: "centered",
+  parameters: { layout: "centered" },
+  decorators: [centered()],
+  argTypes: {
+    children: text("Content"),
+    mask: select(["nature", "urban", "forest"], "Appearance"),
+    variant: select(["primary", "secondary"], "Appearance"),
+    size: select(["sm", "md", "lg"], "Appearance"),
+    disabled: toggle("State"),
+    onClick: action("click"),
+  },
+  args: {
+    children: "Hover me",
+    mask: "nature",
+    variant: "primary",
+    size: "md",
+    disabled: false,
+    onClick: fn(),
   },
 } satisfies Meta<typeof MaskButton>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Nature: Story = {
-  args: {
-    children: "Hover me",
-    mask: "nature",
-  } satisfies MaskButtonProps,
-};
-
-export const Secondary: Story = {
-  args: {
-    children: "Hover me",
-    mask: "nature",
-    variant: "secondary",
-  } satisfies MaskButtonProps,
-};
-
-export const Urban: Story = {
-  args: {
-    children: "Hover me",
-    mask: "urban",
-  } satisfies MaskButtonProps,
-};
-
-export const Forest: Story = {
-  args: {
-    children: "Hover me",
-    mask: "forest",
-  } satisfies MaskButtonProps,
-};
-
-export const Disabled: Story = {
-  args: {
-    children: "Hover me",
-    mask: "nature",
-    disabled: true,
-  } satisfies MaskButtonProps,
-};
-
-export const Sizes: Story = {
-  render: () => (
-    <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
-      <MaskButton size="sm">Small</MaskButton>
-      <MaskButton size="md">Medium</MaskButton>
-      <MaskButton size="lg">Large</MaskButton>
-    </div>
-  ),
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/mega-menu.stories.tsx
+++ b/apps/storybook/src/stories/mega-menu.stories.tsx
@@ -1,5 +1,7 @@
 import { MegaMenu, type MegaMenuItem } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+import { action, hidden, range } from "../playground/argtypes";
 
 const items: MegaMenuItem[] = [
   {
@@ -56,17 +58,23 @@ const meta = {
   component: MegaMenu,
   tags: ["autodocs"],
   parameters: { layout: "centered" },
-  args: { items },
   decorators: [
     (Story) => (
-      <div className="flex h-80 items-start justify-center pt-6">
+      <div className="flex h-80 w-full items-start justify-center pt-6">
         <Story />
       </div>
     ),
   ],
+  argTypes: {
+    items: hidden(),
+    openDelay: range(0, 400, 20, "Behavior"),
+    closeDelay: range(0, 600, 20, "Behavior"),
+    onNavigate: action("navigate"),
+  },
+  args: { items, openDelay: 80, closeDelay: 160, onNavigate: fn() },
 } satisfies Meta<typeof MegaMenu>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/neural-grid.stories.tsx
+++ b/apps/storybook/src/stories/neural-grid.stories.tsx
@@ -1,39 +1,48 @@
 import { NeuralGrid, type NeuralGridProps } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  type PresetMap,
+  presetSelect,
+  renderPreset,
+} from "../playground/presets";
+import { effectStage } from "../playground/stage";
 
-const meta = {
+const presets = {
+  Calm: { nodeCount: 48, density: 0.5, pulseSpeed: 1, nodeSize: 2 },
+  Busy: { nodeCount: 80, density: 0.9, pulseSpeed: 1.4, nodeSize: 2 },
+  Cyan: {
+    color: "#22d3ee",
+    nodeCount: 48,
+    density: 0.5,
+    pulseSpeed: 1,
+    nodeSize: 2.5,
+  },
+  Sparse: { nodeCount: 28, density: 0.3, pulseSpeed: 0.8, nodeSize: 3 },
+} satisfies PresetMap<NeuralGridProps>;
+
+type PlaygroundArgs = NeuralGridProps & { preset: keyof typeof presets };
+
+const meta: Meta<PlaygroundArgs> = {
   title: "Backgrounds/Neural Grid",
   component: NeuralGrid,
   tags: ["autodocs"],
   parameters: { layout: "fullscreen" },
   decorators: [
-    (Story) => (
-      <div className="relative flex min-h-[60vh] w-full items-center justify-center overflow-hidden bg-background">
-        <Story />
-        <div className="relative z-raised text-center">
-          <h1 className="font-semibold text-4xl tracking-tight">Neural Grid</h1>
-          <p className="mt-2 text-muted-foreground">
-            Signals firing across a lattice.
-          </p>
-        </div>
-      </div>
-    ),
+    effectStage({
+      title: "Neural Grid",
+      subtitle: "Signals firing across a lattice.",
+    }),
   ],
-} satisfies Meta<typeof NeuralGrid>;
+  argTypes: {
+    preset: presetSelect(presets, "Appearance"),
+  },
+  args: {
+    preset: "Calm",
+  },
+  render: renderPreset(presets, (cfg) => <NeuralGrid {...cfg} />),
+};
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<PlaygroundArgs>;
 
-export const Default: Story = { args: {} satisfies NeuralGridProps };
-
-export const Busy: Story = {
-  args: {
-    nodeCount: 80,
-    density: 0.9,
-    pulseSpeed: 1.4,
-  } satisfies NeuralGridProps,
-};
-
-export const Tinted: Story = {
-  args: { color: "#22d3ee", nodeSize: 2.5 } satisfies NeuralGridProps,
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/notification-inbox.stories.tsx
+++ b/apps/storybook/src/stories/notification-inbox.stories.tsx
@@ -1,19 +1,10 @@
 import { type Notification, NotificationInbox } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { useState } from "react";
+import { fn } from "storybook/test";
+import { action, hidden, text } from "../playground/argtypes";
+import { centered } from "../playground/stage";
 
-const meta = {
-  title: "Collaboration/NotificationInbox",
-  component: NotificationInbox,
-  tags: ["autodocs"],
-  parameters: { layout: "padded" },
-  args: { notifications: [] },
-} satisfies Meta<typeof NotificationInbox>;
-
-export default meta;
-type Story = StoryObj<typeof meta>;
-
-const seed: Notification[] = [
+const notifications: Notification[] = [
   {
     id: "1",
     actor: "Ana Reyes",
@@ -59,35 +50,29 @@ const seed: Notification[] = [
   },
 ];
 
-export const Default: Story = {
-  render: () => {
-    function Demo() {
-      const [items, setItems] = useState(seed);
-      return (
-        <div className="mx-auto max-w-sm">
-          <NotificationInbox
-            notifications={items}
-            onRead={(id) =>
-              setItems((p) =>
-                p.map((n) => (n.id === id ? { ...n, read: true } : n)),
-              )
-            }
-            onArchive={(id) => setItems((p) => p.filter((n) => n.id !== id))}
-            onMarkAllRead={() =>
-              setItems((p) => p.map((n) => ({ ...n, read: true })))
-            }
-          />
-        </div>
-      );
-    }
-    return <Demo />;
+const meta = {
+  title: "Collaboration/NotificationInbox",
+  component: NotificationInbox,
+  tags: ["autodocs"],
+  parameters: { layout: "centered" },
+  decorators: [centered(384)],
+  argTypes: {
+    title: text("Content"),
+    notifications: hidden(),
+    onRead: action("read"),
+    onArchive: action("archive"),
+    onMarkAllRead: action("markAllRead"),
   },
-};
+  args: {
+    title: "Inbox",
+    notifications,
+    onRead: fn(),
+    onArchive: fn(),
+    onMarkAllRead: fn(),
+  },
+} satisfies Meta<typeof NotificationInbox>;
 
-export const Empty: Story = {
-  render: () => (
-    <div className="mx-auto max-w-sm">
-      <NotificationInbox notifications={[]} />
-    </div>
-  ),
-};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/number-ticker.stories.tsx
+++ b/apps/storybook/src/stories/number-ticker.stories.tsx
@@ -1,49 +1,31 @@
-import { NumberTicker, type NumberTickerProps } from "@godui/components";
+import { NumberTicker } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { hidden, number, radio, range } from "../playground/argtypes";
+import { centered } from "../playground/stage";
 
 const meta = {
   title: "Text/NumberTicker",
   component: NumberTicker,
   tags: ["autodocs"],
-  parameters: {
-    layout: "centered",
+  parameters: { layout: "centered" },
+  decorators: [centered()],
+  argTypes: {
+    value: number("Content"),
+    startValue: number("Content"),
+    direction: radio(["up", "down"], "Behavior"),
+    delay: range(0, 3, 0.1, "Behavior"),
+    decimalPlaces: range(0, 4, 1, "Appearance"),
+    damping: range(10, 120, 5, "Behavior"),
+    stiffness: range(20, 300, 10, "Behavior"),
+    className: hidden(),
   },
   args: {
     value: 100,
     className: "text-6xl font-bold tracking-tight",
-  } satisfies NumberTickerProps,
+  },
 } satisfies Meta<typeof NumberTicker>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-  args: {
-    value: 100,
-    className: "text-6xl font-bold tracking-tight",
-  },
-};
-
-export const Decimals: Story = {
-  args: {
-    value: 1984.42,
-    decimalPlaces: 2,
-    className: "text-6xl font-bold tracking-tight",
-  },
-};
-
-export const CountDown: Story = {
-  args: {
-    value: 100,
-    direction: "down",
-    className: "text-6xl font-bold tracking-tight",
-  },
-};
-
-export const Delayed: Story = {
-  args: {
-    value: 5000,
-    delay: 0.5,
-    className: "text-6xl font-bold tracking-tight",
-  },
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/orbiting-circles.stories.tsx
+++ b/apps/storybook/src/stories/orbiting-circles.stories.tsx
@@ -1,15 +1,6 @@
-import { OrbitingCircles } from "@godui/components";
+import { OrbitingCircles, type OrbitingCirclesProps } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-
-const meta = {
-  title: "Effects/Orbiting Circles",
-  component: OrbitingCircles,
-  tags: ["autodocs"],
-  parameters: { layout: "centered" },
-} satisfies Meta<typeof OrbitingCircles>;
-
-export default meta;
-type Story = StoryObj<typeof meta>;
+import { range, toggle } from "../playground/argtypes";
 
 function Chip({ children }: { children: string }) {
   return (
@@ -19,10 +10,30 @@ function Chip({ children }: { children: string }) {
   );
 }
 
-export const Default: Story = {
-  render: () => (
+const meta = {
+  title: "Effects/Orbiting Circles",
+  component: OrbitingCircles,
+  tags: ["autodocs"],
+  parameters: { layout: "centered" },
+  argTypes: {
+    radius: range(40, 160, 5, "Appearance"),
+    iconSize: range(24, 64, 2, "Appearance"),
+    duration: range(6, 40, 1, "Behavior"),
+    delay: range(0, 10, 0.5, "Behavior"),
+    reverse: toggle("Behavior"),
+    showPath: toggle("Appearance"),
+  },
+  args: {
+    radius: 120,
+    iconSize: 40,
+    duration: 20,
+    delay: 0,
+    reverse: false,
+    showPath: false,
+  },
+  render: (args: OrbitingCirclesProps) => (
     <div className="relative flex size-[320px] items-center justify-center">
-      <OrbitingCircles radius={120} duration={20} iconSize={40}>
+      <OrbitingCircles {...args}>
         <Chip>A</Chip>
         <Chip>B</Chip>
         <Chip>C</Chip>
@@ -30,20 +41,9 @@ export const Default: Story = {
       </OrbitingCircles>
     </div>
   ),
-};
+} satisfies Meta<typeof OrbitingCircles>;
 
-export const TwoRings: Story = {
-  render: () => (
-    <div className="relative flex size-[320px] items-center justify-center">
-      <OrbitingCircles className="absolute" radius={60} duration={14}>
-        <Chip>1</Chip>
-        <Chip>2</Chip>
-      </OrbitingCircles>
-      <OrbitingCircles className="absolute" radius={130} duration={26} reverse>
-        <Chip>3</Chip>
-        <Chip>4</Chip>
-        <Chip>5</Chip>
-      </OrbitingCircles>
-    </div>
-  ),
-};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/otp-input.stories.tsx
+++ b/apps/storybook/src/stories/otp-input.stories.tsx
@@ -1,22 +1,36 @@
 import { OTPInput } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+import { action, range, select, toggle } from "../playground/argtypes";
+import { centered } from "../playground/stage";
 
 const meta = {
   title: "Inputs/OTP Input",
   component: OTPInput,
   tags: ["autodocs"],
   parameters: { layout: "centered" },
+  decorators: [centered()],
+  argTypes: {
+    length: range(4, 8, 1, "Appearance"),
+    type: select(["numeric", "alphanumeric"], "Behavior"),
+    mask: toggle("Appearance"),
+    disabled: toggle("State"),
+    status: select(["idle", "error", "success"], "State"),
+    onChange: action("change"),
+    onComplete: action("complete"),
+  },
+  args: {
+    length: 6,
+    type: "numeric",
+    mask: false,
+    disabled: false,
+    status: "idle",
+    onChange: fn(),
+    onComplete: fn(),
+  },
 } satisfies Meta<typeof OTPInput>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = { args: { length: 6 } };
-export const FourDigit: Story = { args: { length: 4 } };
-export const Masked: Story = { args: { length: 6, mask: true } };
-export const Alphanumeric: Story = {
-  args: { length: 5, type: "alphanumeric" },
-};
-export const Errored: Story = { args: { length: 6, status: "error" } };
-export const Success: Story = { args: { length: 6, status: "success" } };
-export const Disabled: Story = { args: { length: 6, disabled: true } };
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/pagination.stories.tsx
+++ b/apps/storybook/src/stories/pagination.stories.tsx
@@ -1,20 +1,33 @@
 import { Pagination } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+import { action, hidden, range } from "../playground/argtypes";
+import { centered } from "../playground/stage";
 
 const meta = {
   title: "Navigation/Pagination",
   component: Pagination,
   tags: ["autodocs"],
   parameters: { layout: "centered" },
-  args: { total: 10, defaultPage: 1 },
+  decorators: [centered()],
+  argTypes: {
+    page: hidden(),
+    total: range(1, 100, 1, "Content"),
+    defaultPage: range(1, 100, 1, "State"),
+    boundaryCount: range(0, 4, 1, "Behavior"),
+    siblingCount: range(0, 4, 1, "Behavior"),
+    onPageChange: action("pageChange"),
+  },
+  args: {
+    total: 50,
+    defaultPage: 25,
+    boundaryCount: 1,
+    siblingCount: 1,
+    onPageChange: fn(),
+  },
 } satisfies Meta<typeof Pagination>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
-export const Middle: Story = { args: { total: 50, defaultPage: 25 } };
-export const FewPages: Story = { args: { total: 4, defaultPage: 2 } };
-export const WiderSiblings: Story = {
-  args: { total: 50, defaultPage: 25, siblingCount: 2, boundaryCount: 2 },
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/pixel-grid.stories.tsx
+++ b/apps/storybook/src/stories/pixel-grid.stories.tsx
@@ -1,72 +1,53 @@
 import { PixelGrid, type PixelGridProps } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { radio, toggle } from "../playground/argtypes";
+import {
+  type PresetMap,
+  presetSelect,
+  renderPreset,
+} from "../playground/presets";
+import { effectStage } from "../playground/stage";
 
-const meta: Meta<PixelGridProps> = {
+const presets = {
+  Default: { squareSize: 4, gridGap: 6, flickerChance: 0.3, maxOpacity: 0.3 },
+  Dense: { squareSize: 2, gridGap: 2, flickerChance: 0.2, maxOpacity: 0.4 },
+  Violet: {
+    squareSize: 4,
+    gridGap: 6,
+    flickerChance: 0.3,
+    maxOpacity: 0.5,
+    color: "oklch(0.7 0.18 280)",
+  },
+  Chunky: { squareSize: 8, gridGap: 8, flickerChance: 0.35, maxOpacity: 0.35 },
+} satisfies PresetMap<PixelGridProps>;
+
+type PlaygroundArgs = PixelGridProps & { preset: keyof typeof presets };
+
+const meta: Meta<PlaygroundArgs> = {
   title: "Backgrounds/Pixel Grid",
   component: PixelGrid,
   tags: ["autodocs"],
   parameters: { layout: "fullscreen" },
+  decorators: [
+    effectStage({
+      title: "Pixel Grid",
+      subtitle: "A flickering field that follows your cursor.",
+    }),
+  ],
   argTypes: {
-    squareSize: { control: { type: "number" } },
-    gridGap: { control: { type: "number" } },
-    flickerChance: { control: { type: "range", min: 0, max: 1, step: 0.05 } },
-    maxOpacity: { control: { type: "range", min: 0, max: 1, step: 0.05 } },
-    interactive: { control: "boolean" },
-    interactionRadius: { control: { type: "number" } },
-    interactionStrength: {
-      control: { type: "range", min: 0, max: 1, step: 0.05 },
-    },
-    cursorReveal: { control: "inline-radio", options: ["hidden", "dim"] },
-    color: { control: "color" },
+    preset: presetSelect(presets, "Appearance"),
+    interactive: toggle("Behavior"),
+    cursorReveal: radio(["hidden", "dim"], "Behavior"),
   },
   args: {
-    squareSize: 4,
-    gridGap: 6,
-    flickerChance: 0.3,
-    maxOpacity: 0.3,
+    preset: "Default",
     interactive: false,
-    interactionRadius: 120,
-    interactionStrength: 1,
     cursorReveal: "hidden",
   },
+  render: renderPreset(presets, (cfg) => <PixelGrid {...cfg} />),
 };
 
 export default meta;
-type Story = StoryObj<PixelGridProps>;
+type Story = StoryObj<PlaygroundArgs>;
 
-const Stage = (args: PixelGridProps, label: string) => (
-  <div className="relative flex min-h-[420px] w-full items-center justify-center overflow-hidden bg-background">
-    <PixelGrid {...args} />
-    <p className="relative z-raised rounded-lg bg-background/70 px-4 py-2 text-sm font-medium text-foreground backdrop-blur">
-      {label}
-    </p>
-  </div>
-);
-
-// Automatic animated background — the whole field flickers on its own.
-export const Automatic: Story = {
-  args: { interactive: false },
-  render: (args) => Stage(args, "Automatic animated background"),
-};
-
-// Cursor mode: only squares within the radius animate, the rest hidden.
-export const CursorReveal: Story = {
-  args: { interactive: true, cursorReveal: "hidden" },
-  render: (args) => Stage(args, "Move your cursor across the grid"),
-};
-
-// Cursor mode with a static dim field outside the radius.
-export const CursorRevealDim: Story = {
-  args: { interactive: true, cursorReveal: "dim" },
-  render: (args) => Stage(args, "Move your cursor across the grid"),
-};
-
-export const CustomColor: Story = {
-  args: { color: "oklch(0.7 0.18 280)", maxOpacity: 0.5 },
-  render: (args) => Stage(args, "Custom color"),
-};
-
-export const Dense: Story = {
-  args: { squareSize: 2, gridGap: 2, flickerChance: 0.2, maxOpacity: 0.4 },
-  render: (args) => Stage(args, "Dense grid"),
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/presence-facepile.stories.tsx
+++ b/apps/storybook/src/stories/presence-facepile.stories.tsx
@@ -1,17 +1,7 @@
 import { PresenceFacepile } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { useEffect, useState } from "react";
-
-const meta = {
-  title: "Collaboration/PresenceFacepile",
-  component: PresenceFacepile,
-  tags: ["autodocs"],
-  parameters: { layout: "centered" },
-  args: { users: [] },
-} satisfies Meta<typeof PresenceFacepile>;
-
-export default meta;
-type Story = StoryObj<typeof meta>;
+import { hidden, range, select, toggle } from "../playground/argtypes";
+import { centered } from "../playground/stage";
 
 const users = [
   { id: "1", name: "Ana Reyes", status: "active" as const },
@@ -23,30 +13,27 @@ const users = [
   { id: "7", name: "Noa Levi", status: "active" as const },
 ];
 
-export const Default: Story = {
-  args: { users, max: 5 },
-};
-
-export const NoStatus: Story = {
-  args: { users, max: 6, showStatus: false },
-};
-
-export const Large: Story = {
-  args: { users, max: 4, size: "lg" },
-};
-
-export const LiveJoinLeave: Story = {
-  render: () => {
-    function Demo() {
-      const [count, setCount] = useState(3);
-      useEffect(() => {
-        const id = setInterval(() => {
-          setCount((c) => (c >= users.length ? 2 : c + 1));
-        }, 1400);
-        return () => clearInterval(id);
-      }, []);
-      return <PresenceFacepile users={users.slice(0, count)} max={5} />;
-    }
-    return <Demo />;
+const meta = {
+  title: "Collaboration/PresenceFacepile",
+  component: PresenceFacepile,
+  tags: ["autodocs"],
+  parameters: { layout: "centered" },
+  decorators: [centered()],
+  argTypes: {
+    size: select(["sm", "md", "lg"], "Appearance"),
+    max: range(1, 7, 1, "Behavior"),
+    showStatus: toggle("Appearance"),
+    users: hidden(),
   },
-};
+  args: {
+    size: "md",
+    max: 5,
+    showStatus: true,
+    users,
+  },
+} satisfies Meta<typeof PresenceFacepile>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/progress-fold-button.stories.tsx
+++ b/apps/storybook/src/stories/progress-fold-button.stories.tsx
@@ -1,96 +1,36 @@
-import {
-  ProgressFoldButton,
-  type ProgressFoldButtonProps,
-} from "@godui/components";
+import { ProgressFoldButton } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import * as React from "react";
+import { fn } from "storybook/test";
+import { action, range, select, text, toggle } from "../playground/argtypes";
+import { centered } from "../playground/stage";
 
 const meta = {
   title: "Buttons/Progress Fold Button",
   component: ProgressFoldButton,
   tags: ["autodocs"],
-  parameters: {
-    layout: "centered",
+  parameters: { layout: "centered" },
+  decorators: [centered()],
+  argTypes: {
+    children: text("Content"),
+    variant: select(["primary", "secondary"], "Appearance"),
+    size: select(["sm", "md", "lg"], "Appearance"),
+    status: select(["idle", "loading"], "State"),
+    progress: range(0, 100, 5, "State"),
+    disabled: toggle("State"),
+    onClick: action("click"),
+  },
+  args: {
+    children: "Submit",
+    variant: "primary",
+    size: "md",
+    status: "idle",
+    progress: 40,
+    disabled: false,
+    onClick: fn(),
   },
 } satisfies Meta<typeof ProgressFoldButton>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Primary: Story = {
-  args: {
-    children: "Submit",
-    variant: "primary",
-  } satisfies ProgressFoldButtonProps,
-};
-
-export const Secondary: Story = {
-  args: {
-    children: "Submit",
-    variant: "secondary",
-  } satisfies ProgressFoldButtonProps,
-};
-
-export const Disabled: Story = {
-  args: {
-    children: "Submit",
-    variant: "primary",
-    disabled: true,
-  } satisfies ProgressFoldButtonProps,
-};
-
-export const Sizes: Story = {
-  render: () => (
-    <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
-      <ProgressFoldButton size="sm">Small</ProgressFoldButton>
-      <ProgressFoldButton size="md">Medium</ProgressFoldButton>
-      <ProgressFoldButton size="lg">Large</ProgressFoldButton>
-    </div>
-  ),
-};
-
-// Indeterminate: click to fold open and loop the bar until clicked again.
-export const Indeterminate: Story = {
-  render: () => {
-    const [loading, setLoading] = React.useState(false);
-    return (
-      <ProgressFoldButton
-        status={loading ? "loading" : "idle"}
-        onClick={() => setLoading((v) => !v)}
-        style={{ minWidth: 160 }}
-      >
-        {loading ? "Working…" : "Start"}
-      </ProgressFoldButton>
-    );
-  },
-};
-
-// Determinate: click to run a progress ramp from 0 to 100, then reset.
-export const Determinate: Story = {
-  render: () => {
-    const [progress, setProgress] = React.useState<number | null>(null);
-
-    React.useEffect(() => {
-      if (progress == null) return;
-      if (progress >= 100) {
-        const id = setTimeout(() => setProgress(null), 600);
-        return () => clearTimeout(id);
-      }
-      const id = setTimeout(() => setProgress((p) => (p ?? 0) + 10), 250);
-      return () => clearTimeout(id);
-    }, [progress]);
-
-    return (
-      <ProgressFoldButton
-        status={progress == null ? "idle" : "loading"}
-        progress={progress ?? undefined}
-        onClick={() => {
-          if (progress == null) setProgress(0);
-        }}
-        style={{ minWidth: 160 }}
-      >
-        {progress == null ? "Upload" : `${progress}%`}
-      </ProgressFoldButton>
-    );
-  },
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/progressive-card-reveal.stories.tsx
+++ b/apps/storybook/src/stories/progressive-card-reveal.stories.tsx
@@ -1,18 +1,8 @@
 import { ProgressiveCardReveal } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import * as React from "react";
-
-const meta = {
-  title: "Layout/Progressive Card Reveal",
-  component: ProgressiveCardReveal,
-  tags: ["autodocs"],
-  parameters: {
-    layout: "centered",
-  },
-} satisfies Meta<typeof ProgressiveCardReveal>;
-
-export default meta;
-type Story = StoryObj<typeof meta>;
+import { hidden, range } from "../playground/argtypes";
+import { centered } from "../playground/stage";
 
 type Leg = {
   icon: string;
@@ -98,13 +88,17 @@ function ExpandedBody({ icon, label, distance, time }: Leg) {
 }
 
 function TravelDemo({
-  initialActive = 4,
+  activeIndex,
   maxDepth,
 }: {
-  initialActive?: number;
+  activeIndex: number;
   maxDepth?: number;
 }) {
-  const [active, setActive] = React.useState(initialActive);
+  const [active, setActive] = React.useState(activeIndex);
+
+  React.useEffect(() => {
+    setActive(activeIndex);
+  }, [activeIndex]);
 
   return (
     <ProgressiveCardReveal
@@ -127,37 +121,28 @@ function TravelDemo({
   );
 }
 
-export const Default: Story = {
-  args: { activeIndex: 4 },
-  render: () => <TravelDemo />,
-};
-
-export const CappedDepth: Story = {
-  args: { activeIndex: 0, maxDepth: 2 },
-  render: () => <TravelDemo initialActive={0} maxDepth={2} />,
-};
-
-export const FirstActive: Story = {
-  args: { activeIndex: 0 },
-  render: () => {
-    const [active, setActive] = React.useState(0);
-    return (
-      <ProgressiveCardReveal
-        activeIndex={active}
-        onActiveChange={setActive}
-        className="w-[420px]"
-      >
-        {legs.map((leg) => (
-          <ProgressiveCardReveal.Card key={leg.label}>
-            <ProgressiveCardReveal.CardCollapsed>
-              <CollapsedRow {...leg} />
-            </ProgressiveCardReveal.CardCollapsed>
-            <ProgressiveCardReveal.CardExpanded>
-              <ExpandedBody {...leg} />
-            </ProgressiveCardReveal.CardExpanded>
-          </ProgressiveCardReveal.Card>
-        ))}
-      </ProgressiveCardReveal>
-    );
+const meta = {
+  title: "Layout/Progressive Card Reveal",
+  component: ProgressiveCardReveal,
+  tags: ["autodocs"],
+  parameters: { layout: "centered" },
+  decorators: [centered()],
+  argTypes: {
+    children: hidden(),
+    onActiveChange: hidden(),
+    activeIndex: range(0, 4, 1, "State"),
+    maxDepth: range(1, 5, 1, "Behavior"),
   },
-};
+  args: {
+    activeIndex: 4,
+    maxDepth: 3,
+  },
+  render: ({ activeIndex, maxDepth }) => (
+    <TravelDemo activeIndex={activeIndex} maxDepth={maxDepth} />
+  ),
+} satisfies Meta<typeof ProgressiveCardReveal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/prompt-composer.stories.tsx
+++ b/apps/storybook/src/stories/prompt-composer.stories.tsx
@@ -1,68 +1,52 @@
 import { PromptComposer } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { useState } from "react";
+import { fn } from "storybook/test";
+import {
+  action,
+  hidden,
+  range,
+  select,
+  text,
+  toggle,
+} from "../playground/argtypes";
+import { padded } from "../playground/stage";
 
 const meta = {
   title: "AI/PromptComposer",
   component: PromptComposer,
   tags: ["autodocs"],
   parameters: { layout: "padded" },
+  decorators: [padded(576)],
+  argTypes: {
+    variant: select(["comfortable", "compact", "minimal"], "Appearance"),
+    placeholder: text("Content"),
+    maxRows: range(1, 16, 1, "Behavior"),
+    isStreaming: toggle("State"),
+    disabled: toggle("State"),
+    models: hidden(),
+    attachments: hidden(),
+    value: hidden(),
+    onSend: action("send"),
+    onStop: action("stop"),
+    onValueChange: action("valueChange"),
+    onModelChange: action("modelChange"),
+  },
+  args: {
+    variant: "comfortable",
+    placeholder: "Ask GodUI anything…",
+    maxRows: 8,
+    isStreaming: false,
+    disabled: false,
+    models: ["Opus 4.8", "Sonnet 4.6", "Haiku 4.5"],
+    model: "Opus 4.8",
+    onSend: fn(),
+    onStop: fn(),
+    onValueChange: fn(),
+    onModelChange: fn(),
+  },
 } satisfies Meta<typeof PromptComposer>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-  render: (args) => (
-    <div className="mx-auto max-w-xl">
-      <PromptComposer {...args} />
-    </div>
-  ),
-  args: { placeholder: "Ask GodUI anything…" },
-};
-
-export const WithModelPicker: Story = {
-  render: (args) => (
-    <div className="mx-auto max-w-xl">
-      <PromptComposer
-        {...args}
-        models={["Opus 4.8", "Sonnet 4.6", "Haiku 4.5"]}
-      />
-    </div>
-  ),
-};
-
-export const Streaming: Story = {
-  render: () => {
-    function Demo() {
-      const [streaming, setStreaming] = useState(false);
-      return (
-        <div className="mx-auto max-w-xl">
-          <PromptComposer
-            isStreaming={streaming}
-            onSend={() => setStreaming(true)}
-            onStop={() => setStreaming(false)}
-            placeholder="Type, then send to watch it switch to stop…"
-          />
-        </div>
-      );
-    }
-    return <Demo />;
-  },
-};
-
-export const Compact: Story = {
-  render: (args) => (
-    <div className="mx-auto max-w-xl">
-      <PromptComposer {...args} variant="compact" />
-    </div>
-  ),
-};
-
-export const Minimal: Story = {
-  render: (args) => (
-    <div className="mx-auto max-w-xl">
-      <PromptComposer {...args} variant="minimal" />
-    </div>
-  ),
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/prompt-suggestions.stories.tsx
+++ b/apps/storybook/src/stories/prompt-suggestions.stories.tsx
@@ -1,16 +1,8 @@
 import { PromptSuggestions } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-
-const meta = {
-  title: "AI/PromptSuggestions",
-  component: PromptSuggestions,
-  tags: ["autodocs"],
-  parameters: { layout: "padded" },
-  args: { suggestions: [] },
-} satisfies Meta<typeof PromptSuggestions>;
-
-export default meta;
-type Story = StoryObj<typeof meta>;
+import { fn } from "storybook/test";
+import { action, hidden, range, select, toggle } from "../playground/argtypes";
+import { padded } from "../playground/stage";
 
 function Icon({ d }: { d: string }) {
   return (
@@ -60,27 +52,29 @@ const suggestions = [
   },
 ];
 
-export const Grid: Story = {
-  render: (args) => (
-    <div className="mx-auto max-w-xl">
-      <PromptSuggestions {...args} suggestions={suggestions} />
-    </div>
-  ),
-  args: { variant: "grid" },
-};
+const meta = {
+  title: "AI/PromptSuggestions",
+  component: PromptSuggestions,
+  tags: ["autodocs"],
+  parameters: { layout: "padded" },
+  decorators: [padded(576)],
+  argTypes: {
+    variant: select(["grid", "chips", "list"], "Appearance"),
+    loading: toggle("State"),
+    skeletonCount: range(1, 8, 1, "Behavior"),
+    suggestions: hidden(),
+    onSelect: action("select"),
+  },
+  args: {
+    variant: "grid",
+    loading: false,
+    skeletonCount: 4,
+    suggestions,
+    onSelect: fn(),
+  },
+} satisfies Meta<typeof PromptSuggestions>;
 
-export const Chips: Story = {
-  render: () => (
-    <div className="mx-auto max-w-xl">
-      <PromptSuggestions variant="chips" suggestions={suggestions} />
-    </div>
-  ),
-};
+export default meta;
+type Story = StoryObj<typeof meta>;
 
-export const Loading: Story = {
-  render: () => (
-    <div className="mx-auto max-w-xl">
-      <PromptSuggestions suggestions={suggestions} loading skeletonCount={4} />
-    </div>
-  ),
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/reactions.stories.tsx
+++ b/apps/storybook/src/stories/reactions.stories.tsx
@@ -1,66 +1,40 @@
 import { type Reaction, Reactions } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { useState } from "react";
+import { fn } from "storybook/test";
+import { action, hidden } from "../playground/argtypes";
+import { centered } from "../playground/stage";
+
+const reactions: Reaction[] = [
+  {
+    emoji: "👍",
+    count: 4,
+    reacted: true,
+    users: ["You", "Ana", "Marco"],
+  },
+  { emoji: "🎉", count: 2, users: ["Priya", "Jules"] },
+  { emoji: "🚀", count: 1, users: ["Sam"] },
+];
 
 const meta = {
   title: "Collaboration/Reactions",
   component: Reactions,
   tags: ["autodocs"],
   parameters: { layout: "centered" },
-  args: { reactions: [] },
+  decorators: [centered()],
+  argTypes: {
+    reactions: hidden(),
+    options: hidden(),
+    onToggle: action("toggle"),
+    onAdd: action("add"),
+  },
+  args: {
+    reactions,
+    onToggle: fn(),
+    onAdd: fn(),
+  },
 } satisfies Meta<typeof Reactions>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-function InteractiveReactions({ initial }: { initial: Reaction[] }) {
-  const [reactions, setReactions] = useState<Reaction[]>(initial);
-
-  const toggle = (emoji: string) =>
-    setReactions((prev) =>
-      prev
-        .map((r) =>
-          r.emoji === emoji
-            ? {
-                ...r,
-                reacted: !r.reacted,
-                count: r.count + (r.reacted ? -1 : 1),
-              }
-            : r,
-        )
-        .filter((r) => r.count > 0),
-    );
-
-  const add = (emoji: string) =>
-    setReactions((prev) => {
-      const existing = prev.find((r) => r.emoji === emoji);
-      if (existing) {
-        toggle(emoji);
-        return prev;
-      }
-      return [...prev, { emoji, count: 1, reacted: true }];
-    });
-
-  return <Reactions reactions={reactions} onToggle={toggle} onAdd={add} />;
-}
-
-export const Default: Story = {
-  render: () => (
-    <InteractiveReactions
-      initial={[
-        {
-          emoji: "👍",
-          count: 4,
-          reacted: true,
-          users: ["You", "Ana", "Marco"],
-        },
-        { emoji: "🎉", count: 2, users: ["Priya", "Jules"] },
-        { emoji: "🚀", count: 1, users: ["Sam"] },
-      ]}
-    />
-  ),
-};
-
-export const Empty: Story = {
-  render: () => <InteractiveReactions initial={[]} />,
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/resizable-header.stories.tsx
+++ b/apps/storybook/src/stories/resizable-header.stories.tsx
@@ -1,5 +1,7 @@
 import { ResizableHeader } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+import { action, hidden, range, toggle } from "../playground/argtypes";
 
 const links = [
   { label: "Home", href: "/" },
@@ -22,7 +24,6 @@ const meta = {
   component: ResizableHeader,
   tags: ["autodocs"],
   parameters: { layout: "fullscreen" },
-  args: { links, activeHref: "/features", cta },
   decorators: [
     (Story) => (
       <div className="h-[150vh] bg-muted/30">
@@ -33,11 +34,26 @@ const meta = {
       </div>
     ),
   ],
+  argTypes: {
+    logo: hidden(),
+    links: hidden(),
+    cta: hidden(),
+    scrollRef: hidden(),
+    sticky: toggle("Behavior"),
+    scrollThreshold: range(0, 240, 10, "Behavior"),
+    onNavigate: action("navigate"),
+  },
+  args: {
+    links,
+    activeHref: "/features",
+    cta,
+    sticky: true,
+    scrollThreshold: 40,
+    onNavigate: fn(),
+  },
 } satisfies Meta<typeof ResizableHeader>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
-export const NoCta: Story = { args: { cta: undefined } };
-export const NonSticky: Story = { args: { sticky: false } };
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/scroll-progress.stories.tsx
+++ b/apps/storybook/src/stories/scroll-progress.stories.tsx
@@ -1,18 +1,9 @@
-import { ScrollProgress } from "@godui/components";
+import { ScrollProgress, type ScrollProgressProps } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import * as React from "react";
+import { range, select } from "../playground/argtypes";
 
-const meta = {
-  title: "Effects/Scroll Progress",
-  component: ScrollProgress,
-  tags: ["autodocs"],
-  parameters: { layout: "centered" },
-} satisfies Meta<typeof ScrollProgress>;
-
-export default meta;
-type Story = StoryObj<typeof meta>;
-
-function ScrollBox({ variant }: { variant: "bar" | "circle" }) {
+function ScrollBox(args: ScrollProgressProps) {
   const ref = React.useRef<HTMLDivElement>(null);
   return (
     <div
@@ -27,7 +18,7 @@ function ScrollBox({ variant }: { variant: "bar" | "circle" }) {
         border: "1px solid var(--border)",
       }}
     >
-      {variant === "bar" && <ScrollProgress container={ref} />}
+      <ScrollProgress {...args} container={ref} />
       <div style={{ padding: 24, display: "grid", gap: 16 }}>
         {Array.from({ length: 16 }).map((_, i) => (
           // biome-ignore lint/suspicious/noArrayIndexKey: static filler
@@ -36,17 +27,33 @@ function ScrollBox({ variant }: { variant: "bar" | "circle" }) {
           </p>
         ))}
       </div>
-      {variant === "circle" && (
-        <ScrollProgress
-          variant="circle"
-          container={ref}
-          showAfter={0.05}
-          position="bottom-left"
-        />
-      )}
     </div>
   );
 }
 
-export const Bar: Story = { render: () => <ScrollBox variant="bar" /> };
-export const Circle: Story = { render: () => <ScrollBox variant="circle" /> };
+const meta = {
+  title: "Effects/Scroll Progress",
+  component: ScrollProgress,
+  tags: ["autodocs"],
+  parameters: { layout: "centered" },
+  argTypes: {
+    variant: select(["bar", "circle"], "Appearance"),
+    position: select(["bottom-right", "bottom-left"], "Appearance"),
+    height: range(2, 12, 1, "Appearance"),
+    size: range(36, 72, 2, "Appearance"),
+    showAfter: range(0, 1, 0.05, "Behavior"),
+  },
+  args: {
+    variant: "bar",
+    position: "bottom-right",
+    height: 4,
+    size: 48,
+    showAfter: 0.05,
+  },
+  render: (args: ScrollProgressProps) => <ScrollBox {...args} />,
+} satisfies Meta<typeof ScrollProgress>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/scroll-reveal.stories.tsx
+++ b/apps/storybook/src/stories/scroll-reveal.stories.tsx
@@ -1,5 +1,6 @@
 import { ScrollReveal, type ScrollRevealProps } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { range, select, toggle } from "../playground/argtypes";
 
 const Block = ({ children }: { children: React.ReactNode }) => (
   <div className="flex h-40 w-80 items-center justify-center rounded-xl border border-border bg-card text-lg font-semibold text-foreground shadow-sm">
@@ -18,14 +19,29 @@ const meta = {
   component: ScrollReveal,
   tags: ["autodocs"],
   parameters: { layout: "fullscreen" },
-  args: { direction: "up", blur: true, once: true },
+  argTypes: {
+    direction: select(["up", "down", "left", "right"], "Behavior"),
+    distance: range(0, 120, 5, "Behavior"),
+    delay: range(0, 1, 0.05, "Behavior"),
+    blur: toggle("Appearance"),
+    once: toggle("Behavior"),
+    velocitySkew: toggle("Behavior"),
+  },
+  args: {
+    direction: "up",
+    distance: 40,
+    delay: 0,
+    blur: true,
+    once: true,
+    velocitySkew: false,
+  },
   render: (args: ScrollRevealProps) => (
     <div className="flex flex-col items-center gap-24 p-8">
       <Filler />
       <ScrollReveal {...args}>
         <Block>I reveal on scroll</Block>
       </ScrollReveal>
-      <ScrollReveal {...args} delay={0.1}>
+      <ScrollReveal {...args} delay={(args.delay ?? 0) + 0.1}>
         <Block>Staggered sibling</Block>
       </ScrollReveal>
       <Filler />
@@ -36,10 +52,4 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
-
-export const FromLeft: Story = { args: { direction: "left", distance: 80 } };
-
-export const NoBlur: Story = { args: { blur: false } };
-
-export const VelocitySkew: Story = { args: { velocitySkew: true } };
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/segmented-control.stories.tsx
+++ b/apps/storybook/src/stories/segmented-control.stories.tsx
@@ -1,5 +1,8 @@
 import { SegmentedControl } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+import { action, hidden, select } from "../playground/argtypes";
+import { centered } from "../playground/stage";
 
 const options = [
   { label: "Day", value: "day" },
@@ -12,13 +15,23 @@ const meta = {
   component: SegmentedControl,
   tags: ["autodocs"],
   parameters: { layout: "centered" },
-  args: { options },
+  decorators: [centered()],
+  argTypes: {
+    options: hidden(),
+    value: hidden(),
+    size: select(["sm", "md", "lg"], "Appearance"),
+    defaultValue: select(["day", "week", "month"], "State"),
+    onChange: action("change"),
+  },
+  args: {
+    options,
+    size: "md",
+    defaultValue: "day",
+    onChange: fn(),
+  },
 } satisfies Meta<typeof SegmentedControl>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
-export const Small: Story = { args: { size: "sm" } };
-export const Large: Story = { args: { size: "lg" } };
-export const DefaultSelection: Story = { args: { defaultValue: "week" } };
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/shimmer-button.stories.tsx
+++ b/apps/storybook/src/stories/shimmer-button.stories.tsx
@@ -1,78 +1,34 @@
-import { ShimmerButton, type ShimmerButtonProps } from "@godui/components";
+import { ShimmerButton } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+import { action, select, text, toggle } from "../playground/argtypes";
+import { centered } from "../playground/stage";
 
 const meta = {
   title: "Buttons/Shimmer Button",
   component: ShimmerButton,
   tags: ["autodocs"],
-  parameters: {
-    layout: "centered",
+  parameters: { layout: "centered" },
+  decorators: [centered()],
+  argTypes: {
+    children: text("Content"),
+    variant: select(["primary", "secondary", "outline"], "Appearance"),
+    size: select(["sm", "md", "lg"], "Appearance"),
+    shimmer: toggle("Appearance"),
+    disabled: toggle("State"),
+    onClick: action("click"),
+  },
+  args: {
+    children: "Shimmer",
+    variant: "primary",
+    size: "md",
+    shimmer: true,
+    disabled: false,
+    onClick: fn(),
   },
 } satisfies Meta<typeof ShimmerButton>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Primary: Story = {
-  args: {
-    children: "Shimmer",
-    variant: "primary",
-  } satisfies ShimmerButtonProps,
-};
-
-export const Secondary: Story = {
-  args: {
-    children: "Shimmer",
-    variant: "secondary",
-  } satisfies ShimmerButtonProps,
-};
-
-export const Outline: Story = {
-  args: {
-    children: "Shimmer",
-    variant: "outline",
-  } satisfies ShimmerButtonProps,
-};
-
-export const Disabled: Story = {
-  args: {
-    children: "Shimmer",
-    variant: "primary",
-    disabled: true,
-  } satisfies ShimmerButtonProps,
-};
-
-export const Sizes: Story = {
-  render: () => (
-    <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
-      <ShimmerButton size="sm">Small</ShimmerButton>
-      <ShimmerButton size="md">Medium</ShimmerButton>
-      <ShimmerButton size="lg">Large</ShimmerButton>
-    </div>
-  ),
-};
-
-export const WithoutShimmer: Story = {
-  args: {
-    children: "Shimmer",
-    variant: "primary",
-    shimmer: false,
-  } satisfies ShimmerButtonProps,
-};
-
-export const Variants: Story = {
-  render: () => (
-    <div
-      style={{
-        display: "flex",
-        flexWrap: "wrap",
-        alignItems: "center",
-        gap: 16,
-      }}
-    >
-      <ShimmerButton variant="primary">Primary</ShimmerButton>
-      <ShimmerButton variant="secondary">Secondary</ShimmerButton>
-      <ShimmerButton variant="outline">Outline</ShimmerButton>
-    </div>
-  ),
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/sidebar.stories.tsx
+++ b/apps/storybook/src/stories/sidebar.stories.tsx
@@ -1,5 +1,7 @@
 import { Sidebar, type SidebarItem } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+import { action, hidden, toggle } from "../playground/argtypes";
 
 const dot = (
   <span className="h-2 w-2 rounded-full bg-current" aria-hidden="true" />
@@ -25,7 +27,6 @@ const meta = {
   component: Sidebar,
   tags: ["autodocs"],
   parameters: { layout: "fullscreen" },
-  args: { items, activeId: "home", header: "GodUI" },
   decorators: [
     (Story) => (
       <div className="flex h-[420px] bg-muted/20">
@@ -36,13 +37,25 @@ const meta = {
       </div>
     ),
   ],
+  argTypes: {
+    items: hidden(),
+    header: hidden(),
+    footer: hidden(),
+    defaultCollapsed: toggle("State"),
+    expandOnHover: toggle("Behavior"),
+    onNavigate: action("navigate"),
+  },
+  args: {
+    items,
+    activeId: "home",
+    header: "GodUI",
+    defaultCollapsed: true,
+    expandOnHover: true,
+    onNavigate: fn(),
+  },
 } satisfies Meta<typeof Sidebar>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
-export const Expanded: Story = { args: { defaultCollapsed: false } };
-export const PinnedToggle: Story = {
-  args: { expandOnHover: false, defaultCollapsed: false },
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/source-citations.stories.tsx
+++ b/apps/storybook/src/stories/source-citations.stories.tsx
@@ -1,17 +1,7 @@
 import { SourceCitation, SourceList } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-
-const meta = {
-  title: "AI/SourceCitations",
-  component: SourceCitation,
-  subcomponents: { SourceList },
-  tags: ["autodocs"],
-  parameters: { layout: "padded" },
-  args: { index: 1, source: { title: "", url: "" } },
-} satisfies Meta<typeof SourceCitation>;
-
-export default meta;
-type Story = StoryObj<typeof meta>;
+import { hidden, range, toggle } from "../playground/argtypes";
+import { centered } from "../playground/stage";
 
 const sources = [
   {
@@ -36,25 +26,31 @@ const sources = [
   },
 ];
 
-export const InlineCitations: Story = {
-  render: () => (
-    <div className="mx-auto max-w-lg text-sm leading-7 text-foreground">
-      <p>
-        Modern design systems lean on OKLCH for consistent theming
-        <SourceCitation index={1} source={sources[0]} /> and Tailwind v4 for a
-        CSS-first config
-        <SourceCitation index={2} source={sources[1]} />. Motion is increasingly
-        treated as a first-class concern
-        <SourceCitation index={3} source={sources[3]} />.
-      </p>
+const meta = {
+  title: "AI/SourceCitations",
+  component: SourceList,
+  subcomponents: { SourceCitation },
+  tags: ["autodocs"],
+  parameters: { layout: "centered" },
+  decorators: [centered(384)],
+  argTypes: {
+    collapsible: toggle("Behavior"),
+    previewCount: range(1, 6, 1, "Behavior"),
+    sources: hidden(),
+  },
+  args: {
+    collapsible: true,
+    previewCount: 2,
+    sources,
+  },
+  render: (args) => (
+    <div className="w-full rounded-xl border border-border bg-card p-4">
+      <SourceList {...args} />
     </div>
   ),
-};
+} satisfies Meta<typeof SourceList>;
 
-export const SourcesList: Story = {
-  render: () => (
-    <div className="mx-auto max-w-md rounded-xl border border-border bg-card p-4">
-      <SourceList sources={sources} previewCount={2} />
-    </div>
-  ),
-};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/sparkles.stories.tsx
+++ b/apps/storybook/src/stories/sparkles.stories.tsx
@@ -1,5 +1,6 @@
-import { Sparkles } from "@godui/components";
+import { Sparkles, type SparklesProps } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { color, range } from "../playground/argtypes";
 
 const meta = {
   title: "Effects/Sparkles",
@@ -7,16 +8,17 @@ const meta = {
   tags: ["autodocs"],
   parameters: { layout: "centered" },
   argTypes: {
-    density: { control: { type: "range", min: 5, max: 100, step: 5 } },
-    speed: { control: { type: "range", min: 0.2, max: 3, step: 0.1 } },
+    color: color("Appearance"),
+    density: range(5, 100, 5, "Appearance"),
+    minSize: range(0.5, 3, 0.5, "Appearance"),
+    maxSize: range(1, 6, 0.5, "Appearance"),
+    speed: range(0.2, 3, 0.1, "Behavior"),
   },
-} satisfies Meta<typeof Sparkles>;
-
-export default meta;
-type Story = StoryObj<typeof meta>;
-
-export const Default: Story = {
-  render: (args) => (
+  args: {
+    density: 40,
+    speed: 1,
+  },
+  render: (args: SparklesProps) => (
     <Sparkles
       {...args}
       className="flex h-52 w-80 items-center justify-center rounded-2xl bg-card"
@@ -24,9 +26,9 @@ export const Default: Story = {
       <h2 className="text-4xl font-semibold text-foreground">Magic</h2>
     </Sparkles>
   ),
-};
+} satisfies Meta<typeof Sparkles>;
 
-export const Dense: Story = {
-  ...Default,
-  args: { density: 70 },
-};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/spotlight-card.stories.tsx
+++ b/apps/storybook/src/stories/spotlight-card.stories.tsx
@@ -1,35 +1,18 @@
 import { SpotlightCard, type SpotlightCardProps } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { color, range, toggle } from "../playground/argtypes";
 
 const meta = {
   title: "Effects/SpotlightCard",
   component: SpotlightCard,
   tags: ["autodocs"],
   parameters: { layout: "centered" },
+  argTypes: {
+    glowColor: color("Appearance"),
+    radius: range(100, 600, 10, "Appearance"),
+    border: toggle("Appearance"),
+  },
   args: { radius: 350, border: true },
-} satisfies Meta<typeof SpotlightCard>;
-
-export default meta;
-type Story = StoryObj<typeof meta>;
-
-function Check() {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={3}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className="size-3"
-      aria-hidden="true"
-    >
-      <path d="M20 6 9 17l-5-5" />
-    </svg>
-  );
-}
-
-export const Default: Story = {
   render: (args: SpotlightCardProps) => (
     <SpotlightCard {...args} className="max-w-sm p-8">
       <h3 className="text-lg font-semibold text-foreground">
@@ -40,134 +23,9 @@ export const Default: Story = {
       </p>
     </SpotlightCard>
   ),
-};
+} satisfies Meta<typeof SpotlightCard>;
 
-export const Border: Story = {
-  args: {
-    border: true,
-    radius: 300,
-    glowColor: "color-mix(in oklch, var(--primary) 60%, transparent)",
-  },
-  render: (args: SpotlightCardProps) => (
-    <SpotlightCard {...args} className="max-w-sm p-8">
-      <h3 className="text-lg font-semibold text-foreground">Trace the edge</h3>
-      <p className="mt-2 text-sm text-muted-foreground">
-        The border brightens where the pointer is closest, then fades behind it.
-      </p>
-    </SpotlightCard>
-  ),
-};
+export default meta;
+type Story = StoryObj<typeof meta>;
 
-const PLANS = [
-  {
-    name: "Hobby",
-    price: "$0",
-    period: "/mo",
-    features: ["1 project", "Community support", "1k events / mo"],
-    cta: "Start free",
-    featured: false,
-  },
-  {
-    name: "Pro",
-    price: "$24",
-    period: "/mo",
-    features: [
-      "Unlimited projects",
-      "Priority support",
-      "1M events / mo",
-      "SSO & audit logs",
-    ],
-    cta: "Start free trial",
-    featured: true,
-  },
-  {
-    name: "Enterprise",
-    price: "Custom",
-    period: "",
-    features: ["SLA guarantee", "Dedicated CSM", "On-prem option"],
-    cta: "Contact sales",
-    featured: false,
-  },
-];
-
-export const Pricing: Story = {
-  render: () => (
-    <div className="grid max-w-4xl items-stretch gap-6 sm:grid-cols-3">
-      {PLANS.map((plan) => (
-        <SpotlightCard
-          key={plan.name}
-          glowColor="color-mix(in oklch, var(--primary) 16%, transparent)"
-          radius={260}
-          className={`flex h-full flex-col p-7 ${
-            plan.featured
-              ? "bg-primary/[0.035] ring-1 ring-primary/40 shadow-[0_12px_40px_-16px_color-mix(in_oklch,var(--primary)_55%,transparent)] sm:-my-2 sm:scale-[1.02]"
-              : ""
-          }`}
-        >
-          <div className="flex h-6 items-center justify-between">
-            <h3 className="text-sm font-semibold uppercase tracking-wide text-foreground">
-              {plan.name}
-            </h3>
-            {plan.featured ? (
-              <span className="inline-flex rounded-full bg-primary px-2.5 py-0.5 text-xs font-medium text-primary-foreground">
-                Popular
-              </span>
-            ) : null}
-          </div>
-          <div className="mt-5 flex items-baseline gap-1">
-            <span className="text-4xl font-semibold tracking-tight tabular-nums text-foreground">
-              {plan.price}
-            </span>
-            {plan.period ? (
-              <span className="text-sm text-muted-foreground">
-                {plan.period}
-              </span>
-            ) : null}
-          </div>
-          <p className="mt-3 min-h-10 text-sm text-muted-foreground">
-            For teams shipping to production.
-          </p>
-          <ul className="mt-6 min-h-[8.5rem] space-y-3.5 border-t border-border pt-6">
-            {plan.features.map((f) => (
-              <li
-                key={f}
-                className="flex items-center gap-3 text-sm text-foreground"
-              >
-                <span className="flex size-[18px] shrink-0 items-center justify-center rounded-full bg-primary/15 text-primary">
-                  <Check />
-                </span>
-                {f}
-              </li>
-            ))}
-          </ul>
-          <div className="mt-auto pt-8">
-            <button
-              type="button"
-              className={`w-full rounded-lg py-2.5 text-sm font-semibold ${
-                plan.featured
-                  ? "bg-primary text-primary-foreground"
-                  : "border border-border text-foreground hover:bg-accent"
-              }`}
-            >
-              {plan.cta}
-            </button>
-          </div>
-        </SpotlightCard>
-      ))}
-    </div>
-  ),
-};
-
-export const CustomColor: Story = {
-  args: {
-    glowColor: "color-mix(in oklch, oklch(0.7 0.2 320) 50%, transparent)",
-  },
-  render: (args: SpotlightCardProps) => (
-    <SpotlightCard {...args} className="max-w-sm p-8">
-      <h3 className="text-lg font-semibold text-foreground">Custom glow</h3>
-      <p className="mt-2 text-sm text-muted-foreground">
-        Pass any CSS color through <code>glowColor</code>.
-      </p>
-    </SpotlightCard>
-  ),
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/stepper.stories.tsx
+++ b/apps/storybook/src/stories/stepper.stories.tsx
@@ -1,8 +1,9 @@
-import { Stepper } from "@godui/components";
+import { type Step, Stepper } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import * as React from "react";
+import { hidden, range, select } from "../playground/argtypes";
+import { padded } from "../playground/stage";
 
-const steps = [
+const steps: Step[] = [
   { label: "Account", description: "Email & password" },
   { label: "Profile", description: "Name & avatar" },
   { label: "Workspace", description: "Invite your team" },
@@ -14,51 +15,20 @@ const meta = {
   component: Stepper,
   tags: ["autodocs"],
   parameters: { layout: "padded" },
-  args: { steps, active: 1 },
-  decorators: [
-    (Story) => (
-      <div style={{ maxWidth: 640, margin: "0 auto" }}>
-        <Story />
-      </div>
-    ),
-  ],
+  decorators: [padded(640)],
+  argTypes: {
+    steps: hidden(),
+    active: range(0, 4, 1, "State"),
+    orientation: select(["horizontal", "vertical"], "Appearance"),
+  },
+  args: {
+    steps,
+    active: 1,
+    orientation: "horizontal",
+  },
 } satisfies Meta<typeof Stepper>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Horizontal: Story = { args: { active: 1 } };
-export const Vertical: Story = { args: { orientation: "vertical", active: 2 } };
-export const Complete: Story = { args: { active: 4 } };
-
-export const Interactive: Story = {
-  render: () => {
-    const [active, setActive] = React.useState(1);
-    return (
-      <div
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          gap: 32,
-          alignItems: "center",
-        }}
-      >
-        <Stepper steps={steps} active={active} />
-        <div style={{ display: "flex", gap: 12 }}>
-          <button
-            type="button"
-            onClick={() => setActive((s) => Math.max(0, s - 1))}
-          >
-            Back
-          </button>
-          <button
-            type="button"
-            onClick={() => setActive((s) => Math.min(steps.length, s + 1))}
-          >
-            Next
-          </button>
-        </div>
-      </div>
-    );
-  },
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/tab-bar.stories.tsx
+++ b/apps/storybook/src/stories/tab-bar.stories.tsx
@@ -1,5 +1,8 @@
 import { TabBar, type TabBarTab } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+import { action, hidden, select, toggle } from "../playground/argtypes";
+import { centered } from "../playground/stage";
 
 const icon = (d: string) => (
   <svg
@@ -47,11 +50,25 @@ const meta = {
   component: TabBar,
   tags: ["autodocs"],
   parameters: { layout: "centered" },
-  args: { tabs, defaultValue: "home" },
+  decorators: [centered()],
+  argTypes: {
+    tabs: hidden(),
+    value: hidden(),
+    defaultValue: select(["home", "search", "alerts", "profile"], "State"),
+    labelsOnActiveOnly: toggle("Appearance"),
+    safeArea: toggle("Appearance"),
+    onChange: action("change"),
+  },
+  args: {
+    tabs,
+    defaultValue: "home",
+    labelsOnActiveOnly: true,
+    safeArea: false,
+    onChange: fn(),
+  },
 } satisfies Meta<typeof TabBar>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
-export const AllLabels: Story = { args: { labelsOnActiveOnly: false } };
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/text-animate.stories.tsx
+++ b/apps/storybook/src/stories/text-animate.stories.tsx
@@ -1,12 +1,46 @@
-import { TextAnimate, type TextAnimateProps } from "@godui/components";
+import { TextAnimate } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { hidden, range, select, text, toggle } from "../playground/argtypes";
+import { centered } from "../playground/stage";
 
 const meta = {
   title: "Text/TextAnimate",
   component: TextAnimate,
   tags: ["autodocs"],
-  parameters: {
-    layout: "centered",
+  parameters: { layout: "centered" },
+  decorators: [centered()],
+  argTypes: {
+    children: text("Content"),
+    animation: select(
+      [
+        "fadeIn",
+        "blurIn",
+        "blurInUp",
+        "blurInDown",
+        "slideUp",
+        "slideDown",
+        "slideLeft",
+        "slideRight",
+        "scaleUp",
+        "scaleDown",
+      ],
+      "Appearance",
+    ),
+    by: select(["text", "word", "character", "line"], "Behavior"),
+    as: select(
+      ["span", "p", "div", "h1", "h2", "h3", "h4", "h5", "h6", "li", "section"],
+      "Appearance",
+    ),
+    delay: range(0, 2, 0.1, "Behavior"),
+    duration: range(0.1, 2, 0.1, "Behavior"),
+    stagger: range(0, 0.2, 0.01, "Behavior"),
+    startOnView: toggle("Behavior"),
+    once: toggle("Behavior"),
+    accessible: toggle("Behavior"),
+    viewportAmount: hidden(),
+    variants: hidden(),
+    segmentClassName: hidden(),
+    className: hidden(),
   },
   args: {
     children: "Animate your ideas into reality",
@@ -14,106 +48,10 @@ const meta = {
     by: "word",
     startOnView: false,
     className: "text-4xl font-semibold tracking-tight",
-  } satisfies TextAnimateProps,
+  },
 } satisfies Meta<typeof TextAnimate>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const FadeIn: Story = {
-  args: {
-    animation: "fadeIn",
-    by: "word",
-  },
-};
-
-export const BlurInUp: Story = {
-  args: {
-    animation: "blurInUp",
-    by: "word",
-    children: "Blur in from below",
-  },
-};
-
-export const CharacterSlideUp: Story = {
-  args: {
-    animation: "slideUp",
-    by: "character",
-    stagger: 0.03,
-    children: "Character by character",
-  },
-};
-
-export const ScaleUp: Story = {
-  args: {
-    animation: "scaleUp",
-    by: "word",
-    children: "Scale up with spring",
-  },
-};
-
-export const SlideLeft: Story = {
-  args: {
-    animation: "slideLeft",
-    by: "word",
-    children: "Slide from the right",
-  },
-};
-
-export const Heading: Story = {
-  args: {
-    as: "h1",
-    animation: "blurInUp",
-    by: "word",
-    children: "Hero headline",
-    className: "text-5xl font-bold tracking-tight",
-  },
-};
-
-export const InView: Story = {
-  args: {
-    animation: "fadeIn",
-    by: "word",
-    startOnView: true,
-    once: true,
-    children: "Scroll to reveal this text",
-  },
-  decorators: [
-    (Story) => (
-      <div style={{ height: "200vh", paddingTop: "80vh" }}>
-        <Story />
-      </div>
-    ),
-  ],
-};
-
-export const AllPresets: Story = {
-  render: () => (
-    <div className="flex max-w-2xl flex-col gap-8">
-      {(
-        [
-          "fadeIn",
-          "blurIn",
-          "blurInUp",
-          "blurInDown",
-          "slideUp",
-          "slideDown",
-          "slideLeft",
-          "slideRight",
-          "scaleUp",
-          "scaleDown",
-        ] as const
-      ).map((animation) => (
-        <TextAnimate
-          key={animation}
-          animation={animation}
-          by="word"
-          startOnView={false}
-          className="text-2xl font-medium"
-        >
-          {animation}
-        </TextAnimate>
-      ))}
-    </div>
-  ),
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/theme-toggle.stories.tsx
+++ b/apps/storybook/src/stories/theme-toggle.stories.tsx
@@ -1,18 +1,26 @@
 import { ThemeToggle } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+import { action, range } from "../playground/argtypes";
+import { centered } from "../playground/stage";
 
 const meta = {
   title: "Buttons/Theme Toggle",
   component: ThemeToggle,
   tags: ["autodocs"],
   parameters: { layout: "centered" },
+  decorators: [centered()],
+  argTypes: {
+    duration: range(200, 1200, 50, "Behavior"),
+    onThemeChange: action("themeChange"),
+  },
+  args: {
+    duration: 500,
+    onThemeChange: fn(),
+  },
 } satisfies Meta<typeof ThemeToggle>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
-
-export const SlowReveal: Story = {
-  args: { duration: 900 },
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/tilt-card.stories.tsx
+++ b/apps/storybook/src/stories/tilt-card.stories.tsx
@@ -1,21 +1,26 @@
 import { TiltCard } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { range, toggle } from "../playground/argtypes";
+import { centered } from "../playground/stage";
 
 const meta = {
   title: "Layout/Tilt Card",
   component: TiltCard,
   tags: ["autodocs"],
   parameters: { layout: "centered" },
+  decorators: [centered()],
   argTypes: {
-    maxTilt: { control: { type: "range", min: 0, max: 30, step: 1 } },
-    depth: { control: { type: "range", min: 0, max: 120, step: 5 } },
+    maxTilt: range(0, 30, 1, "Behavior"),
+    scale: range(1, 1.2, 0.01, "Behavior"),
+    depth: range(0, 120, 5, "Behavior"),
+    glare: toggle("Appearance"),
   },
-} satisfies Meta<typeof TiltCard>;
-
-export default meta;
-type Story = StoryObj<typeof meta>;
-
-export const Default: Story = {
+  args: {
+    maxTilt: 12,
+    scale: 1.04,
+    depth: 40,
+    glare: true,
+  },
   render: (args) => (
     <TiltCard {...args} className="w-72 p-6">
       <h3 className="text-lg font-semibold text-foreground">Tilt me</h3>
@@ -24,14 +29,9 @@ export const Default: Story = {
       </p>
     </TiltCard>
   ),
-};
+} satisfies Meta<typeof TiltCard>;
 
-export const StrongTilt: Story = {
-  ...Default,
-  args: { maxTilt: 22, depth: 70 },
-};
+export default meta;
+type Story = StoryObj<typeof meta>;
 
-export const NoGlare: Story = {
-  ...Default,
-  args: { glare: false },
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/toast.stories.tsx
+++ b/apps/storybook/src/stories/toast.stories.tsx
@@ -1,18 +1,26 @@
 import { ToastProvider, toast } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { range, select } from "../playground/argtypes";
 
 const meta = {
   title: "Overlays/Toast",
   component: ToastProvider,
   tags: ["autodocs"],
   parameters: { layout: "centered" },
+  argTypes: {
+    position: select(
+      ["top-left", "top-right", "bottom-left", "bottom-right"],
+      "Appearance",
+    ),
+    duration: range(1000, 10000, 500, "Behavior"),
+  },
   args: { position: "bottom-right", duration: 4000 },
 } satisfies Meta<typeof ToastProvider>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
+export const Playground: Story = {
   render: (args) => (
     <>
       <div className="flex flex-wrap gap-3">

--- a/apps/storybook/src/stories/topographic-drift.stories.tsx
+++ b/apps/storybook/src/stories/topographic-drift.stories.tsx
@@ -3,36 +3,49 @@ import {
   type TopographicDriftProps,
 } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  type PresetMap,
+  presetSelect,
+  renderPreset,
+} from "../playground/presets";
+import { effectStage } from "../playground/stage";
 
-const meta = {
+const presets = {
+  Calm: { lineCount: 9, noiseScale: 0.004, speed: 1, weight: 1 },
+  Dense: { lineCount: 16, noiseScale: 0.006, speed: 1, weight: 1 },
+  Sky: {
+    color: "#0ea5e9",
+    lineCount: 9,
+    noiseScale: 0.004,
+    speed: 1,
+    weight: 1.4,
+  },
+  Broad: { lineCount: 7, noiseScale: 0.0025, speed: 0.8, weight: 1.2 },
+} satisfies PresetMap<TopographicDriftProps>;
+
+type PlaygroundArgs = TopographicDriftProps & { preset: keyof typeof presets };
+
+const meta: Meta<PlaygroundArgs> = {
   title: "Backgrounds/Topographic Drift",
   component: TopographicDrift,
   tags: ["autodocs"],
   parameters: { layout: "fullscreen" },
   decorators: [
-    (Story) => (
-      <div className="relative flex min-h-[60vh] w-full items-center justify-center overflow-hidden bg-background">
-        <Story />
-        <div className="relative z-raised text-center">
-          <h1 className="font-semibold text-4xl tracking-tight">
-            Topographic Drift
-          </h1>
-          <p className="mt-2 text-muted-foreground">A living elevation map.</p>
-        </div>
-      </div>
-    ),
+    effectStage({
+      title: "Topographic Drift",
+      subtitle: "A living elevation map.",
+    }),
   ],
-} satisfies Meta<typeof TopographicDrift>;
+  argTypes: {
+    preset: presetSelect(presets, "Appearance"),
+  },
+  args: {
+    preset: "Calm",
+  },
+  render: renderPreset(presets, (cfg) => <TopographicDrift {...cfg} />),
+};
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<PlaygroundArgs>;
 
-export const Default: Story = { args: {} satisfies TopographicDriftProps };
-
-export const Dense: Story = {
-  args: { lineCount: 16, noiseScale: 0.006 } satisfies TopographicDriftProps,
-};
-
-export const Tinted: Story = {
-  args: { color: "#0ea5e9", weight: 1.4 } satisfies TopographicDriftProps,
-};
+export const Playground: Story = {};

--- a/apps/storybook/src/stories/warp-starfield.stories.tsx
+++ b/apps/storybook/src/stories/warp-starfield.stories.tsx
@@ -1,35 +1,45 @@
 import { WarpStarfield, type WarpStarfieldProps } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { toggle } from "../playground/argtypes";
+import {
+  type PresetMap,
+  presetSelect,
+  renderPreset,
+} from "../playground/presets";
+import { effectStage } from "../playground/stage";
 
-const meta = {
+const presets = {
+  Cruise: { starCount: 400, speed: 1, depth: 1.5, parallax: 30 },
+  Hyperspace: { starCount: 400, speed: 1.6, depth: 1.5, parallax: 30 },
+  Dense: { starCount: 700, speed: 0.7, depth: 1.5, parallax: 30 },
+  Deep: { starCount: 400, speed: 1, depth: 2.4, parallax: 45 },
+} satisfies PresetMap<WarpStarfieldProps>;
+
+type PlaygroundArgs = WarpStarfieldProps & { preset: keyof typeof presets };
+
+const meta: Meta<PlaygroundArgs> = {
   title: "Backgrounds/Warp Starfield",
   component: WarpStarfield,
   tags: ["autodocs"],
   parameters: { layout: "fullscreen" },
   decorators: [
-    (Story) => (
-      <div className="relative flex min-h-[60vh] w-full items-center justify-center overflow-hidden bg-background">
-        <Story />
-        <div className="relative z-raised text-center">
-          <h1 className="font-semibold text-4xl tracking-tight">
-            Warp Starfield
-          </h1>
-          <p className="mt-2 text-muted-foreground">Fly through the stars.</p>
-        </div>
-      </div>
-    ),
+    effectStage({
+      title: "Warp Starfield",
+      subtitle: "Fly through the stars.",
+    }),
   ],
-} satisfies Meta<typeof WarpStarfield>;
+  argTypes: {
+    preset: presetSelect(presets, "Appearance"),
+    warp: toggle("Behavior"),
+  },
+  args: {
+    preset: "Cruise",
+    warp: false,
+  },
+  render: renderPreset(presets, (cfg) => <WarpStarfield {...cfg} />),
+};
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<PlaygroundArgs>;
 
-export const Default: Story = { args: {} satisfies WarpStarfieldProps };
-
-export const Hyperspace: Story = {
-  args: { warp: true, speed: 1.6 } satisfies WarpStarfieldProps,
-};
-
-export const Dense: Story = {
-  args: { starCount: 700, speed: 0.7 } satisfies WarpStarfieldProps,
-};
+export const Playground: Story = {};


### PR DESCRIPTION
Reshapes the Storybook into a uniform "play with it" surface: every component now exposes a single interactive `Playground` story plus the autodocs Docs tab, replacing the previous 248 ad-hoc example stories across all 75 components. Adds shared `playground/` helpers — `argtypes` (grouped select/toggle/range/color/action/hidden builders), `stage` (centered/padded/effectStage/box framing decorators), and `presets` (curated preset selector for pure-visual components). Callbacks are wired to the Actions panel via `fn()`, visual/background components get tuned presets, and ref-based components rebuild their demo scene inside `render`. Also adds an external-link icon (ArrowUpRight) to the "Animated Icons" link in the docs header and mobile menu. Verified clean: tsc, biome, and a full Storybook build all pass, and the built index shows exactly 75 Docs + 75 Playground entries.