### PR TITLE
fix(storybook): resolve manager assets under /design-system subpath

### DIFF
--- a/apps/storybook/.storybook/manager-head.html
+++ b/apps/storybook/.storybook/manager-head.html
@@ -1,0 +1,1 @@
+<base href="/design-system/" />


### PR DESCRIPTION
Storybook is deployed as static files at `godui.design/design-system/`, but Vercel strips the trailing slash (`/design-system/` → `/design-system`), so the manager's relative `./sb-manager` bundle imports resolved against root and 404'd. That left the preview iframe stuck on an infinite spinner in production while the sidebar still rendered, and it only reproduced on prod since local dev proxies a live Storybook server. This adds `apps/storybook/.storybook/manager-head.html` with `<base href="/design-system/">` so the manager's relative imports resolve correctly regardless of trailing slash. Verified in headless Chromium against a prod-style no-slash serve: zero 404s and the preview iframe loads (vs. 4 manager-bundle 404s before).