### PR TITLE
chore(storybook): document manager <base> tag and force prod redeploy

### DIFF
--- a/apps/storybook/.storybook/manager-head.html
+++ b/apps/storybook/.storybook/manager-head.html
@@ -1,1 +1,9 @@
+<!--
+  Storybook is served under the /design-system/ subpath in production.
+  Vercel strips the trailing slash (/design-system/ -> /design-system), so the
+  manager's relative bundle imports (./sb-manager/*) would otherwise resolve
+  against the site root and 404, leaving the preview iframe stuck loading.
+  This <base> pins all relative manager URLs to the subpath regardless of the
+  trailing slash. Do not remove.
+-->
 <base href="/design-system/" />


### PR DESCRIPTION
PR #54's trailing-slash fix is correct — the storybook build emits the `<base href="/design-system/">` tag on both turbo cache miss and hit, and the standalone godui-storybook deploy already serves it. But godui.design/design-system is still serving a stale pre-fix build: its edge-cache `age` never resets, so the new build was never promoted to that path. Merging this forces a fresh docs production deploy so the fix actually ships, and adds a comment explaining why the `<base>` tag must not be removed. After merge, verify with `curl -s https://godui.design/design-system | grep '<base'`; if it's still stale, the docs Vercel project needs a manual redeploy with build cache disabled.