### PR TITLE
fix(storybook): serve at root for standalone Vercel deploy (godui-storybook.vercel.app)

### DIFF
--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -7,10 +7,6 @@ const config: StorybookConfig = {
     name: "@storybook/react-vite",
     options: {},
   },
-  async viteFinal(viteConfig) {
-    viteConfig.base = "/design-system/";
-    return viteConfig;
-  },
 };
 
 export default config;

--- a/apps/storybook/.storybook/manager-head.html
+++ b/apps/storybook/.storybook/manager-head.html
@@ -1,1 +1,0 @@
-<base href="/design-system/" />

--- a/apps/storybook/.storybook/manager-head.html
+++ b/apps/storybook/.storybook/manager-head.html
@@ -1,9 +1,1 @@
-<!--
-  Storybook is served under the /design-system/ subpath in production.
-  Vercel strips the trailing slash (/design-system/ -> /design-system), so the
-  manager's relative bundle imports (./sb-manager/*) would otherwise resolve
-  against the site root and 404, leaving the preview iframe stuck loading.
-  This <base> pins all relative manager URLs to the subpath regardless of the
-  trailing slash. Do not remove.
--->
 <base href="/design-system/" />


### PR DESCRIPTION
godui-storybook.vercel.app serves Storybook at the domain **root**, but the build targeted the `/design-system/` subpath (Vite `base` + a manager `<base>` tag from #54/#55). So every manager bundle and preview asset resolved to `/design-system/*` and 404'd, leaving the preview stuck loading forever.

This PR reverts the #54/#55 `<base>` tag and drops the Vite `base` override. Storybook then emits relative asset paths (`./sb-manager`, `./assets`) that resolve correctly at the root deploy. Verified locally with a headless browser served at root: manager loads, preview iframe renders, and the loading spinner clears for both stories and docs.