### PR TITLE
fix(docs): render Text Animate main preview in production

### DIFF
--- a/apps/docs/content/docs/components/text/text-animate.mdx
+++ b/apps/docs/content/docs/components/text/text-animate.mdx
@@ -5,6 +5,8 @@ description: Staggered entrance animations for headlines and copy, split by word
 
 import { TextAnimate } from "@godui/components";
 
+`TextAnimate` splits text into words, characters, or lines and staggers each fragment through an entrance animation.
+
 <ComponentPreview
   code={`import { TextAnimate } from "@/components/godui/text-animate";
 


### PR DESCRIPTION
## Problem

The Text Animate page's top preview rendered an empty canvas in production (worked in local dev). The other previews on the page were fine.

## Root cause

The first `<ComponentPreview>` in the MDX body carries a large multi-line template literal in its `code` prop. As the **first body node**, that tripped the production MDX compiler into dropping the live preview's text **children** — so `TextAnimate` received empty content and animated an empty span. The bug is build-time (present in the SSR HTML), not animation- or hydration-related; dev's MDX path tolerated it.

## Fix

Add a short lead-in paragraph before the first preview so it is no longer the first body node. Verified against a production build (`next build` + `next start`): all six previews, including the main one, now render their text.