### PR TITLE
feat(docs): parallax index grid background to mouse

### DIFF
--- a/apps/docs/src/app/page.tsx
+++ b/apps/docs/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { MagicButton } from "@godui/components";
 import { useRouter } from "next/navigation";
+import { useEffect, useRef } from "react";
 import { DocsHeader } from "./docs/_components/docs-header";
 
 const SITE_URL = "https://godui.design";
@@ -24,12 +25,38 @@ const structuredData = {
 
 export default function Home() {
   const router = useRouter();
+  const gridRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // Subtle parallax: nudge the grid a few px toward the pointer.
+    const STRENGTH = 12; // max px offset in each axis
+    let frame = 0;
+
+    const handlePointerMove = (event: PointerEvent) => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => {
+        const x = (event.clientX / window.innerWidth - 0.5) * 2;
+        const y = (event.clientY / window.innerHeight - 0.5) * 2;
+        if (gridRef.current) {
+          gridRef.current.style.transform = `translate3d(${x * STRENGTH}px, ${y * STRENGTH}px, 0) scale(1.04)`;
+        }
+      });
+    };
+
+    window.addEventListener("pointermove", handlePointerMove);
+    return () => {
+      window.removeEventListener("pointermove", handlePointerMove);
+      cancelAnimationFrame(frame);
+    };
+  }, []);
 
   return (
     <main className="relative flex min-h-svh flex-col">
       {/* Dashed Center Fade Grid */}
       <div
-        className="pointer-events-none absolute inset-0 z-0"
+        ref={gridRef}
+        className="pointer-events-none absolute inset-0 z-0 transition-transform duration-300 ease-out [transition-property:transform] will-change-transform"
+        // Initial scale keeps the grid covering the viewport while it parallaxes.
         style={{
           backgroundImage: `
             linear-gradient(to right, var(--color-fd-border) 1px, transparent 1px),
@@ -49,6 +76,7 @@ export default function Home() {
           `,
           maskComposite: "intersect",
           WebkitMaskComposite: "source-in",
+          transform: "translate3d(0, 0, 0) scale(1.04)",
         }}
       />
       <DocsHeader


### PR DESCRIPTION
Adds subtle pointer-driven parallax to the home page grid backdrop. A rAF-throttled `pointermove` listener nudges the grid up to 12px toward the cursor via GPU `translate3d`. A base `scale(1.04)` keeps the grid covering the viewport so the translate never exposes an edge, and an ease-out transition smooths the motion. Page stays click-through via `pointer-events-none`.