### PR TITLE
feat(docs): full-bleed background previews + page-only search dialog

### DIFF
--- a/apps/docs/content/docs/components/backgrounds/blueprint-grid.mdx
+++ b/apps/docs/content/docs/components/backgrounds/blueprint-grid.mdx
@@ -11,6 +11,7 @@ ruled `lines`, a `dots` matrix, or a floor-fading `perspective` grid. Pure CSS.
 Drop it as the first child of a `relative overflow-hidden` container.
 
 <ComponentPreview
+  fullWidth
   story="backgrounds-blueprint-grid"
   code={`import { BlueprintGrid } from "@/components/godui/blueprint-grid";
 
@@ -26,7 +27,7 @@ export function BlueprintGridDemo() {
   );
 }`}
 >
-  <div className="relative flex h-[360px] w-full items-center justify-center overflow-hidden rounded-xl border border-border bg-background">
+  <div className="relative flex w-full flex-1 items-center justify-center overflow-hidden bg-background">
     <BlueprintGrid />
     <div className="relative z-raised text-center">
       <h2 className="font-semibold text-3xl tracking-tight">Built with precision</h2>
@@ -59,6 +60,7 @@ content at `z-raised`+. Color defaults to `--color-border`. The sweep hides unde
 ### Dots
 
 <ComponentPreview
+  fullWidth
   code={`import { BlueprintGrid } from "@/components/godui/blueprint-grid";
 
 export function BlueprintGridDots() {
@@ -69,7 +71,7 @@ export function BlueprintGridDots() {
   );
 }`}
 >
-  <div className="relative h-[300px] w-full overflow-hidden rounded-xl border border-border bg-background">
+  <div className="relative w-full flex-1 overflow-hidden bg-background">
     <BlueprintGrid variant="dots" />
   </div>
 </ComponentPreview>
@@ -77,6 +79,7 @@ export function BlueprintGridDots() {
 ### Perspective
 
 <ComponentPreview
+  fullWidth
   code={`import { BlueprintGrid } from "@/components/godui/blueprint-grid";
 
 export function BlueprintGridPerspective() {
@@ -87,7 +90,7 @@ export function BlueprintGridPerspective() {
   );
 }`}
 >
-  <div className="relative h-[300px] w-full overflow-hidden rounded-xl border border-border bg-background">
+  <div className="relative w-full flex-1 overflow-hidden bg-background">
     <BlueprintGrid variant="perspective" color="#6366f1" />
   </div>
 </ComponentPreview>

--- a/apps/docs/content/docs/components/backgrounds/flow-field.mdx
+++ b/apps/docs/content/docs/components/backgrounds/flow-field.mdx
@@ -11,6 +11,7 @@ themed background, so drop it as the first child of a `relative` container and
 let your content sit above it.
 
 <ComponentPreview
+  fullWidth
   story="backgrounds-flow-field"
   code={`import { FlowField } from "@/components/godui/flow-field";
 
@@ -26,7 +27,7 @@ export function FlowFieldDemo() {
   );
 }`}
 >
-  <div className="relative flex h-[360px] w-full items-center justify-center overflow-hidden rounded-xl border border-border">
+  <div className="relative flex w-full flex-1 items-center justify-center overflow-hidden">
     <FlowField />
     <div className="relative z-raised text-center">
       <h2 className="font-semibold text-3xl tracking-tight">Generative by default</h2>
@@ -63,6 +64,7 @@ trails in `color` (default `--color-primary`); both track light/dark. Caps DPR a
 Lower `fade` for longer, silkier streaks.
 
 <ComponentPreview
+  fullWidth
   code={`import { FlowField } from "@/components/godui/flow-field";
 
 export function FlowFieldLong() {
@@ -73,7 +75,7 @@ export function FlowFieldLong() {
   );
 }`}
 >
-  <div className="relative h-[320px] w-full overflow-hidden rounded-xl border border-border">
+  <div className="relative w-full flex-1 overflow-hidden">
     <FlowField fade={0.02} speed={1.2} />
   </div>
 </ComponentPreview>

--- a/apps/docs/content/docs/components/backgrounds/light-rays.mdx
+++ b/apps/docs/content/docs/components/backgrounds/light-rays.mdx
@@ -11,6 +11,7 @@ the spotlight-from-the-heavens hero. Pure CSS. Drop it as the first child of a
 `relative overflow-hidden` container.
 
 <ComponentPreview
+  fullWidth
   story="backgrounds-light-rays"
   code={`import { LightRays } from "@/components/godui/light-rays";
 
@@ -26,7 +27,7 @@ export function LightRaysDemo() {
   );
 }`}
 >
-  <div className="relative flex h-[360px] w-full items-center justify-center overflow-hidden rounded-xl border border-border bg-background">
+  <div className="relative flex w-full flex-1 items-center justify-center overflow-hidden bg-background">
     <LightRays />
     <div className="relative z-raised text-center">
       <h2 className="font-semibold text-3xl tracking-tight">Step into the light</h2>
@@ -59,6 +60,7 @@ content at `z-raised`+. Color defaults to `--color-primary`. The sweep stops und
 ### Warm
 
 <ComponentPreview
+  fullWidth
   code={`import { LightRays } from "@/components/godui/light-rays";
 
 export function LightRaysWarm() {
@@ -69,7 +71,7 @@ export function LightRaysWarm() {
   );
 }`}
 >
-  <div className="relative h-[320px] w-full overflow-hidden rounded-xl border border-border bg-background">
+  <div className="relative w-full flex-1 overflow-hidden bg-background">
     <LightRays color="#f59e0b" rayCount={18} intensity={0.7} />
   </div>
 </ComponentPreview>

--- a/apps/docs/content/docs/components/backgrounds/liquid-metaballs.mdx
+++ b/apps/docs/content/docs/components/backgrounds/liquid-metaballs.mdx
@@ -11,6 +11,7 @@ cursor and merges with the rest. Playful and organic. Drop it as the first child
 of a `relative` container.
 
 <ComponentPreview
+  fullWidth
   story="backgrounds-liquid-metaballs"
   code={`import { LiquidMetaballs } from "@/components/godui/liquid-metaballs";
 
@@ -26,7 +27,7 @@ export function LiquidMetaballsDemo() {
   );
 }`}
 >
-  <div className="relative flex h-[360px] w-full items-center justify-center overflow-hidden rounded-xl border border-border bg-background">
+  <div className="relative flex w-full flex-1 items-center justify-center overflow-hidden bg-background">
     <LiquidMetaballs />
     <div className="relative z-raised text-center">
       <h2 className="font-semibold text-3xl tracking-tight">Fluid by nature</h2>
@@ -62,6 +63,7 @@ coexist safely. Pauses off-screen and on hidden tabs; freezes under
 Raise `gooeyness` and `blobCount`.
 
 <ComponentPreview
+  fullWidth
   code={`import { LiquidMetaballs } from "@/components/godui/liquid-metaballs";
 
 export function LiquidMetaballsGooey() {
@@ -72,7 +74,7 @@ export function LiquidMetaballsGooey() {
   );
 }`}
 >
-  <div className="relative h-[320px] w-full overflow-hidden rounded-xl border border-border bg-background">
+  <div className="relative w-full flex-1 overflow-hidden bg-background">
     <LiquidMetaballs gooeyness={24} blobCount={9} />
   </div>
 </ComponentPreview>

--- a/apps/docs/content/docs/components/backgrounds/pixel-grid.mdx
+++ b/apps/docs/content/docs/components/backgrounds/pixel-grid.mdx
@@ -15,6 +15,7 @@ color defaults to the `--color-foreground` theme token and re-resolves on theme
 change, so it tracks light and dark automatically.
 
 <ComponentPreview
+  fullWidth
   story="backgrounds-pixel-grid"
   code={`import { PixelGrid } from "@/components/godui/pixel-grid";
 
@@ -26,7 +27,7 @@ export function PixelGridDemo() {
   );
 }`}
 >
-  <div className="relative min-h-[320px] w-full overflow-hidden rounded-xl border border-border bg-background">
+  <div className="relative w-full flex-1 overflow-hidden bg-background">
     <PixelGrid interactive={false} />
   </div>
 </ComponentPreview>
@@ -59,6 +60,7 @@ animate. With the default `cursorReveal="hidden"`, the rest stay invisible — a
 spotlight that follows the pointer.
 
 <ComponentPreview
+  fullWidth
   code={`import { PixelGrid } from "@/components/godui/pixel-grid";
 
 export function PixelGridCursor() {
@@ -70,7 +72,7 @@ export function PixelGridCursor() {
   );
 }`}
 >
-  <div className="relative flex min-h-[240px] w-full items-center justify-center overflow-hidden rounded-xl border border-border bg-background">
+  <div className="relative flex w-full flex-1 items-center justify-center overflow-hidden bg-background">
     <PixelGrid interactive />
     <p className="relative z-10 text-sm font-medium text-foreground">Move your cursor across the grid</p>
   </div>
@@ -82,6 +84,7 @@ export function PixelGridCursor() {
 opacity, so the cursor lights up an already-present grid.
 
 <ComponentPreview
+  fullWidth
   code={`import { PixelGrid } from "@/components/godui/pixel-grid";
 
 export function PixelGridCursorDim() {
@@ -93,7 +96,7 @@ export function PixelGridCursorDim() {
   );
 }`}
 >
-  <div className="relative flex min-h-[240px] w-full items-center justify-center overflow-hidden rounded-xl border border-border bg-background">
+  <div className="relative flex w-full flex-1 items-center justify-center overflow-hidden bg-background">
     <PixelGrid interactive cursorReveal="dim" />
     <p className="relative z-10 text-sm font-medium text-foreground">Move your cursor across the grid</p>
   </div>
@@ -104,6 +107,7 @@ export function PixelGridCursorDim() {
 Pass any CSS color string to `color` to override the theme token.
 
 <ComponentPreview
+  fullWidth
   code={`import { PixelGrid } from "@/components/godui/pixel-grid";
 
 export function PixelGridColored() {
@@ -114,7 +118,7 @@ export function PixelGridColored() {
   );
 }`}
 >
-  <div className="relative min-h-[240px] w-full overflow-hidden rounded-xl border border-border bg-background">
+  <div className="relative w-full flex-1 overflow-hidden bg-background">
     <PixelGrid interactive={false} color="oklch(0.7 0.18 280)" maxOpacity={0.5} />
   </div>
 </ComponentPreview>
@@ -124,6 +128,7 @@ export function PixelGridColored() {
 Smaller `squareSize` and `gridGap` pack the field tighter.
 
 <ComponentPreview
+  fullWidth
   code={`import { PixelGrid } from "@/components/godui/pixel-grid";
 
 export function PixelGridDense() {
@@ -134,7 +139,7 @@ export function PixelGridDense() {
   );
 }`}
 >
-  <div className="relative min-h-[240px] w-full overflow-hidden rounded-xl border border-border bg-background">
+  <div className="relative w-full flex-1 overflow-hidden bg-background">
     <PixelGrid interactive={false} squareSize={2} gridGap={2} flickerChance={0.2} maxOpacity={0.4} />
   </div>
 </ComponentPreview>

--- a/apps/docs/content/docs/components/backgrounds/topographic-drift.mdx
+++ b/apps/docs/content/docs/components/backgrounds/topographic-drift.mdx
@@ -10,6 +10,7 @@ beneath them evolves. Editorial, cartographic, and calm — drawn with marching
 squares on one Canvas. Drop it as the first child of a `relative` container.
 
 <ComponentPreview
+  fullWidth
   story="backgrounds-topographic-drift"
   code={`import { TopographicDrift } from "@/components/godui/topographic-drift";
 
@@ -25,7 +26,7 @@ export function TopographicDriftDemo() {
   );
 }`}
 >
-  <div className="relative flex h-[360px] w-full items-center justify-center overflow-hidden rounded-xl border border-border bg-background">
+  <div className="relative flex w-full flex-1 items-center justify-center overflow-hidden bg-background">
     <TopographicDrift />
     <div className="relative z-raised text-center">
       <h2 className="font-semibold text-3xl tracking-tight">Chart the unknown</h2>
@@ -61,6 +62,7 @@ at 2, pauses off-screen and on hidden tabs, and renders a static map under
 More levels, finer terrain.
 
 <ComponentPreview
+  fullWidth
   code={`import { TopographicDrift } from "@/components/godui/topographic-drift";
 
 export function TopographicDriftDense() {
@@ -71,7 +73,7 @@ export function TopographicDriftDense() {
   );
 }`}
 >
-  <div className="relative h-[320px] w-full overflow-hidden rounded-xl border border-border bg-background">
+  <div className="relative w-full flex-1 overflow-hidden bg-background">
     <TopographicDrift lineCount={16} noiseScale={0.006} />
   </div>
 </ComponentPreview>

--- a/apps/docs/content/docs/components/backgrounds/warp-starfield.mdx
+++ b/apps/docs/content/docs/components/backgrounds/warp-starfield.mdx
@@ -10,6 +10,7 @@ field for parallax. Flip on `warp` for a hyperspace jump where the stars stretch
 into streaks. Drop it as the first child of a `relative` container.
 
 <ComponentPreview
+  fullWidth
   story="backgrounds-warp-starfield"
   code={`import { WarpStarfield } from "@/components/godui/warp-starfield";
 
@@ -25,7 +26,7 @@ export function WarpStarfieldDemo() {
   );
 }`}
 >
-  <div className="relative flex h-[360px] w-full items-center justify-center overflow-hidden rounded-xl border border-border bg-background">
+  <div className="relative flex w-full flex-1 items-center justify-center overflow-hidden bg-background">
     <WarpStarfield />
     <div className="relative z-raised text-center">
       <h2 className="font-semibold text-3xl tracking-tight">Reach the stars</h2>
@@ -59,6 +60,7 @@ tabs, and renders a static frame under `prefers-reduced-motion`.
 ### Hyperspace
 
 <ComponentPreview
+  fullWidth
   code={`import { WarpStarfield } from "@/components/godui/warp-starfield";
 
 export function WarpStarfieldHyperspace() {
@@ -69,7 +71,7 @@ export function WarpStarfieldHyperspace() {
   );
 }`}
 >
-  <div className="relative h-[320px] w-full overflow-hidden rounded-xl border border-border bg-background">
+  <div className="relative w-full flex-1 overflow-hidden bg-background">
     <WarpStarfield warp speed={1.6} />
   </div>
 </ComponentPreview>

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { GoogleAnalytics } from "@next/third-parties/google";
 import { RootProvider } from "fumadocs-ui/provider/next";
 import type { Metadata } from "next";
 import "./globals.css";
+import { GodSearchDialog } from "@/components/search-dialog";
 import { AeoWidget } from "./aeo-widget";
 import { SiteStructuredData } from "./structured-data";
 
@@ -74,6 +75,7 @@ export default function RootLayout({
             enableSystem: true,
             enabled: true,
           }}
+          search={{ SearchDialog: GodSearchDialog }}
         >
           {children}
         </RootProvider>

--- a/apps/docs/src/components/background-showcase.tsx
+++ b/apps/docs/src/components/background-showcase.tsx
@@ -14,8 +14,14 @@ import {
   gradientBackgroundPresets,
   gradientBackgroundVariants,
 } from "@godui/components";
-import { type ComponentType, type CSSProperties, useState } from "react";
+import {
+  type ComponentType,
+  type CSSProperties,
+  useMemo,
+  useState,
+} from "react";
 import { ComponentInstall } from "@/components/component-install";
+import { ComponentPreview } from "@/components/component-preview";
 import { cn } from "@/lib/cn";
 
 type Key = "gradient" | "geometric" | "decorative" | "effect";
@@ -60,11 +66,32 @@ const SETS: Record<
   },
 };
 
+/** Serialize a preset's CSSProperties into the usage snippet for the Code tab. */
+function buildCode(set: (typeof SETS)[Key], preset: CSSProperties) {
+  const style = Object.entries(preset)
+    .map(([key, value]) => `          ${key}: ${JSON.stringify(value)},`)
+    .join("\n");
+  return `import { ${set.component} } from "@/components/godui/${set.name}";
+
+export function ${set.component}Demo() {
+  return (
+    <div className="relative h-[360px] w-full overflow-hidden rounded-xl border border-border">
+      <${set.component}
+        style={{
+${style}
+        }}
+      />
+    </div>
+  );
+}`;
+}
+
 export function BackgroundShowcase({ component }: { component: Key }) {
   const set = SETS[component];
   const [selected, setSelected] = useState(set.variants[0]);
   const preset = set.presets[selected];
   const Bg = set.Component;
+  const code = useMemo(() => buildCode(set, preset), [set, preset]);
 
   // Geometric grids/dashes look like flat colour in a tiny swatch (you only see
   // one cell). Render them into a larger, scaled-down box so several tiles show.
@@ -100,13 +127,13 @@ export function BackgroundShowcase({ component }: { component: Key }) {
         ))}
       </div>
 
-      {/* live preview */}
-      <div className="relative flex min-h-[320px] w-full items-center justify-center overflow-hidden rounded-xl border border-fd-border">
-        <Bg style={preset} />
-        <span className="relative z-10 rounded-md bg-fd-background/70 px-3 py-1 text-sm backdrop-blur">
-          {selected}
-        </span>
-      </div>
+      {/* live preview — the selected variant drives both the canvas and the
+          Code tab, full-bleed inside the preview box */}
+      <ComponentPreview fullWidth className="my-0!" code={code}>
+        <div className="relative w-full flex-1 overflow-hidden">
+          <Bg style={preset} />
+        </div>
+      </ComponentPreview>
 
       {/* install — same tabbed pattern as every component, with the selected
           variant baked into the command + Manual source */}

--- a/apps/docs/src/components/search-dialog.tsx
+++ b/apps/docs/src/components/search-dialog.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useDocsSearch } from "fumadocs-core/search/client";
+import { fetchClient } from "fumadocs-core/search/client/fetch";
+import {
+  SearchDialog,
+  SearchDialogClose,
+  SearchDialogContent,
+  SearchDialogHeader,
+  SearchDialogIcon,
+  SearchDialogInput,
+  SearchDialogList,
+  SearchDialogListItem,
+  SearchDialogOverlay,
+  type SharedProps,
+} from "fumadocs-ui/components/dialog/search";
+import {
+  BarChart3,
+  Bot,
+  CornerDownLeft,
+  FileText,
+  Film,
+  GlassWater,
+  Image,
+  Layers,
+  LayoutGrid,
+  type LucideIcon,
+  MousePointerClick,
+  Navigation,
+  Rocket,
+  Sparkles,
+  TextCursorInput,
+  Type,
+  Users,
+} from "lucide-react";
+import { Fragment, type ReactNode, useMemo } from "react";
+import meta from "../../content/docs/meta.json";
+
+// Per-section icon, picked to echo each section's idea.
+const ICON_BY_SECTION: Record<string, LucideIcon> = {
+  "Getting Started": Rocket,
+  "Motion Guidelines": Film,
+  Buttons: MousePointerClick,
+  Inputs: TextCursorInput,
+  Navigation: Navigation,
+  Overlays: Layers,
+  Layout: LayoutGrid,
+  Text: Type,
+  AI: Bot,
+  Collaboration: Users,
+  Visualizations: BarChart3,
+  Effects: Sparkles,
+  Backgrounds: Image,
+  Glass: GlassWater,
+};
+
+// Search results arrive as a string with the matched span wrapped in
+// `<mark>…</mark>`; render those as highlighted text instead of literal tags.
+function renderTitle(content: ReactNode): ReactNode {
+  if (typeof content !== "string") return content;
+  return content.split(/(<mark>.*?<\/mark>)/g).map((part, i) => {
+    const match = /^<mark>(.*?)<\/mark>$/.exec(part);
+    const key = `${i}-${part}`;
+    return match ? (
+      <span key={key} className="text-fd-primary">
+        {match[1]}
+      </span>
+    ) : (
+      <Fragment key={key}>{part}</Fragment>
+    );
+  });
+}
+
+// Map every doc URL to its section label, derived from the `---Section---`
+// separators in meta.json (single source of truth for the nav grouping).
+const SECTION_BY_URL: Record<string, string> = (() => {
+  const map: Record<string, string> = {};
+  let section = "";
+  for (const entry of meta.pages) {
+    const heading = /^---(.+)---$/.exec(entry);
+    if (heading) {
+      section = heading[1].trim();
+      continue;
+    }
+    const slug = entry.replace(/^\/+|\/+$/g, "");
+    map[slug === "index" ? "/docs" : `/docs/${slug}`] = section;
+  }
+  return map;
+})();
+
+export function GodSearchDialog(props: SharedProps) {
+  const { search, setSearch, query } = useDocsSearch({
+    client: fetchClient({}),
+  });
+
+  // Pages only — drop heading/text matches so each result is a single doc row.
+  const items = useMemo(() => {
+    if (!query.data || query.data === "empty") return null;
+    return query.data.filter((item) => item.type === "page");
+  }, [query.data]);
+
+  return (
+    <SearchDialog
+      search={search}
+      onSearchChange={setSearch}
+      isLoading={query.isLoading}
+      {...props}
+    >
+      <SearchDialogOverlay />
+      <SearchDialogContent>
+        <SearchDialogHeader>
+          <SearchDialogIcon />
+          <SearchDialogInput />
+          <SearchDialogClose />
+        </SearchDialogHeader>
+        <SearchDialogList
+          items={items}
+          Item={({ item, onClick }) => {
+            const section =
+              item.type === "page"
+                ? (SECTION_BY_URL[item.url] ?? "Docs")
+                : "Docs";
+            const Icon = ICON_BY_SECTION[section] ?? FileText;
+            return (
+              <SearchDialogListItem
+                item={item}
+                onClick={onClick}
+                className="group flex items-center gap-3 px-3 py-2.5"
+              >
+                <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-fd-primary/10 text-fd-primary">
+                  <Icon className="size-4" />
+                </span>
+                <span className="flex min-w-0 flex-col">
+                  <span className="truncate font-medium text-fd-popover-foreground">
+                    {item.type === "action"
+                      ? item.node
+                      : renderTitle(item.content)}
+                  </span>
+                  <span className="truncate text-fd-muted-foreground text-xs">
+                    in {section}
+                  </span>
+                </span>
+                <CornerDownLeft className="ms-auto size-4 shrink-0 text-fd-muted-foreground/40 transition-colors group-aria-selected:text-fd-muted-foreground" />
+              </SearchDialogListItem>
+            );
+          }}
+        />
+      </SearchDialogContent>
+    </SearchDialog>
+  );
+}
+
+export default GodSearchDialog;


### PR DESCRIPTION
Make every background component preview fill the preview box edge-to-edge instead of sitting inside an inner card — the animated backgrounds use `fullWidth` + `flex-1` children, and the pattern showcases (decorative/effect/geometric/gradient) now render inside a `ComponentPreview` whose Code tab tracks the selected variant. Also replaces the docs search dialog with a custom page-only result list: one row per page with a per-section icon, the page title with the matched span highlighted, and an "in <Section>" subtitle derived from the meta.json nav groups.