### PR TITLE
fix(docs): render World Map & Text Animate index previews

### DIFF
--- a/apps/docs/src/components/card-previews/previews/text-animate.tsx
+++ b/apps/docs/src/components/card-previews/previews/text-animate.tsx
@@ -8,7 +8,7 @@ export default function TextAnimatePreview() {
       {[0, 1, 2].map((i) => (
         <div
           key={i}
-          className={`h-3 ${widths[i]} translate-y-1 rounded bg-[var(--muted-foreground)]/20 opacity-0 blur-[1px] transition-all duration-300 group-hover:translate-y-0 group-hover:opacity-100 group-hover:blur-0`}
+          className={`h-3 ${widths[i]} translate-y-1 rounded bg-[var(--muted-foreground)]/25 opacity-40 blur-[1px] transition-all duration-300 group-hover:translate-y-0 group-hover:bg-primary/60 group-hover:opacity-100 group-hover:blur-0`}
           style={{ transitionDelay: `${i * 120}ms` }}
         />
       ))}

--- a/apps/docs/src/components/card-previews/previews/world-map.tsx
+++ b/apps/docs/src/components/card-previews/previews/world-map.tsx
@@ -1,14 +1,59 @@
 "use client";
 
+const CONTINENTS = [
+  "M28 32 Q40 24 48 34 Q50 44 42 48 Q34 46 30 40 Z",
+  "M40 54 Q48 56 46 66 Q42 76 36 70 Q34 60 40 54 Z",
+  "M76 30 Q86 26 90 34 Q94 48 86 62 Q80 74 76 62 Q74 46 76 30 Z",
+  "M104 26 Q132 20 150 30 Q154 40 142 44 Q118 46 106 40 Q100 32 104 26 Z",
+  "M132 60 Q146 56 150 66 Q148 74 138 72 Q128 68 132 60 Z",
+];
+
 export default function WorldMapPreview() {
   return (
-    <div className="relative h-24 w-44 overflow-hidden rounded-lg [background:radial-gradient(circle,color-mix(in_oklch,var(--muted-foreground)_25%,transparent)_1px,transparent_1px)] [background-size:8px_8px]">
+    <div className="relative h-24 w-44 overflow-hidden rounded-lg bg-[var(--muted)]/30">
       <svg
         viewBox="0 0 176 96"
         className="absolute inset-0 size-full"
         aria-hidden="true"
       >
         <title>World map</title>
+        <defs>
+          <pattern
+            id="wm-dots"
+            width="4"
+            height="4"
+            patternUnits="userSpaceOnUse"
+          >
+            <circle
+              cx="1"
+              cy="1"
+              r="0.9"
+              fill="var(--muted-foreground)"
+              fillOpacity={0.55}
+            />
+          </pattern>
+          <clipPath id="wm-land">
+            {CONTINENTS.map((d) => (
+              <path key={d} d={d} />
+            ))}
+          </clipPath>
+        </defs>
+        {/* Dotted continents. */}
+        <rect
+          width="176"
+          height="96"
+          fill="url(#wm-dots)"
+          clipPath="url(#wm-land)"
+        />
+        {/* Muted base arc, always visible. */}
+        <path
+          d="M 40 64 Q 88 16 136 56"
+          fill="none"
+          stroke="color-mix(in oklch, var(--muted-foreground) 30%, transparent)"
+          strokeWidth="2"
+          strokeLinecap="round"
+        />
+        {/* Primary arc draws on hover. */}
         <path
           d="M 40 64 Q 88 16 136 56"
           fill="none"


### PR DESCRIPTION
Both component-index preview cards on `/docs/components` were invisible at rest because they only revealed on hover, breaking the shared *muted base at rest → accent on hover* convention the sibling previews follow.

## Fixes
- **Text Animate** (`previews/text-animate.tsx`): bars no longer start at `opacity-0` (which rendered nothing at rest). They now render faded + blurred at rest and sharpen/lift to `primary` on hover — reading as an entrance reveal.
- **World Map** (`previews/world-map.tsx`): previously only two pins showed at rest (the arc was fully hidden until hover, and there was no map). Added dotted continent silhouettes (a dot `pattern` clipped to landmasses, matching the real `dotted-map` component) plus an always-visible muted base arc, so the card reads as a map with two pins. The `primary` arc still draws over it on hover.

## Notes
- Config-only convention, no component/runtime changes — docs preview cards only.
- `biome check` clean on both files.