### PR TITLE
docs(guidelines): source logos on principles, served-principle badge on patterns

### DIFF
--- a/apps/docs/src/components/motion-guidelines/motion-card.tsx
+++ b/apps/docs/src/components/motion-guidelines/motion-card.tsx
@@ -3,12 +3,17 @@
 import { useReducedMotion } from "framer-motion";
 import { type ComponentType, type ReactNode, useState } from "react";
 import { cn } from "@/lib/cn";
+import { type MotionOrigin, OriginLogos } from "./origin-logos";
 
 export type GalleryItem = {
   slug: string;
   title: string;
   description: string;
   Demo: ComponentType;
+  /** Source canon behind the principle (patterns omit this). */
+  origins?: MotionOrigin[];
+  /** For patterns: the principle this recipe serves (principles omit this). */
+  serves?: string;
 };
 
 const CARD = cn(
@@ -68,7 +73,7 @@ export function TapToPlay({
 }
 
 export function MotionCard({ item }: { item: GalleryItem }) {
-  const { title, description, Demo } = item;
+  const { title, description, Demo, origins, serves } = item;
 
   return (
     <article aria-label={`${title} — motion guideline`} className={CARD}>
@@ -77,7 +82,15 @@ export function MotionCard({ item }: { item: GalleryItem }) {
       </div>
 
       <div className="flex flex-1 flex-col p-5">
-        <h3 className="font-semibold text-base text-foreground">{title}</h3>
+        <div className="flex items-start justify-between gap-3">
+          <h3 className="font-semibold text-base text-foreground">{title}</h3>
+          {origins && origins.length > 0 && <OriginLogos origins={origins} />}
+          {serves && (
+            <span className="inline-flex shrink-0 items-center self-center whitespace-nowrap rounded-full border border-border bg-muted/50 px-2.5 py-0 font-medium text-[11px] leading-4 text-muted-foreground">
+              {serves}
+            </span>
+          )}
+        </div>
         <p className="mt-1.5 text-muted-foreground text-sm leading-relaxed">
           {description}
         </p>

--- a/apps/docs/src/components/motion-guidelines/motion-gallery.tsx
+++ b/apps/docs/src/components/motion-guidelines/motion-gallery.tsx
@@ -1,58 +1,15 @@
 "use client";
 
-import { Search } from "lucide-react";
-import { useId, useMemo, useState } from "react";
 import { type GalleryItem, MotionCard } from "./motion-card";
 
-export function MotionGallery({
-  items,
-  placeholder = "Search…",
-}: {
-  items: GalleryItem[];
-  placeholder?: string;
-}) {
-  const [query, setQuery] = useState("");
-  const inputId = useId();
-
-  const results = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    if (!q) return items;
-    return items.filter(
-      (item) =>
-        item.title.toLowerCase().includes(q) ||
-        item.description.toLowerCase().includes(q),
-    );
-  }, [items, query]);
-
+export function MotionGallery({ items }: { items: GalleryItem[] }) {
   return (
     <div className="not-prose mt-6">
-      <div className="relative max-w-sm">
-        <Search
-          aria-hidden
-          className="-translate-y-1/2 pointer-events-none absolute top-1/2 left-3 size-4 text-muted-foreground"
-        />
-        <input
-          id={inputId}
-          type="search"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          placeholder={placeholder}
-          aria-label={placeholder}
-          className="h-10 w-full rounded-lg border border-border bg-card pr-3 pl-9 text-foreground text-sm placeholder:text-muted-foreground focus-visible:border-foreground/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
-        />
+      <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
+        {items.map((item) => (
+          <MotionCard key={item.slug} item={item} />
+        ))}
       </div>
-
-      {results.length > 0 ? (
-        <div className="mt-6 grid grid-cols-1 gap-5 sm:grid-cols-2">
-          {results.map((item) => (
-            <MotionCard key={item.slug} item={item} />
-          ))}
-        </div>
-      ) : (
-        <p className="mt-10 text-center text-muted-foreground text-sm">
-          No results match “{query.trim()}”.
-        </p>
-      )}
     </div>
   );
 }

--- a/apps/docs/src/components/motion-guidelines/motion-patterns.tsx
+++ b/apps/docs/src/components/motion-guidelines/motion-patterns.tsx
@@ -4,5 +4,5 @@ import { MotionGallery } from "./motion-gallery";
 import { PATTERNS } from "./pattern-demos";
 
 export function MotionPatterns() {
-  return <MotionGallery items={PATTERNS} placeholder="Search patterns…" />;
+  return <MotionGallery items={PATTERNS} />;
 }

--- a/apps/docs/src/components/motion-guidelines/motion-principles.tsx
+++ b/apps/docs/src/components/motion-guidelines/motion-principles.tsx
@@ -4,5 +4,5 @@ import { MotionGallery } from "./motion-gallery";
 import { PRINCIPLES } from "./principle-demos";
 
 export function MotionPrinciples() {
-  return <MotionGallery items={PRINCIPLES} placeholder="Search principles…" />;
+  return <MotionGallery items={PRINCIPLES} />;
 }

--- a/apps/docs/src/components/motion-guidelines/origin-logos.tsx
+++ b/apps/docs/src/components/motion-guidelines/origin-logos.tsx
@@ -1,0 +1,66 @@
+import type { ComponentType, SVGProps } from "react";
+
+/** Where a motion principle traces back to. The first origin on a card is the
+ * strongest source; the rest are where the principle is shared. */
+export type MotionOrigin = "disney" | "apple" | "material";
+
+type LogoProps = SVGProps<SVGSVGElement>;
+
+function AppleLogo(props: LogoProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" role="img" {...props}>
+      <title>Apple</title>
+      <path d="M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.546 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.065 2.09-.987 3.935-.987 1.831 0 2.35.987 3.96.948 1.637-.026 2.676-1.48 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.415-.039-.013-3.182-1.221-3.22-4.857-.026-3.04 2.48-4.494 2.597-4.559-1.429-2.09-3.623-2.324-4.39-2.376-2-.156-3.675 1.09-4.61 1.09zM15.53 3.83c.843-1.012 1.4-2.427 1.245-3.83-1.207.052-2.662.805-3.532 1.818-.78.896-1.454 2.338-1.273 3.714 1.338.104 2.715-.688 3.559-1.701" />
+    </svg>
+  );
+}
+
+function MaterialLogo(props: LogoProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" role="img" {...props}>
+      <title>Material Design</title>
+      <path d="M11.9998 23.9997c-1.6545 0-3.218-.309-4.691-.927-1.4544-.6364-2.7269-1.4909-3.8179-2.5639-1.073-1.0905-1.9274-2.3634-2.5634-3.8179C.3085 15.2179 0 13.6545 0 12c0-1.6725.309-3.2364.927-4.6909.6365-1.4545 1.491-2.718 2.564-3.791C4.5818 2.4278 5.8543 1.5733 7.3087.9548c1.473-.6365 3.0365-.9545 4.691-.9545 1.673 0 3.2364.318 4.6909.955 1.4544.618 2.7179 1.4725 3.7909 2.563 1.091 1.073 1.945 2.3364 2.5634 3.7909C23.6815 8.7641 24 10.3275 24 12c0 1.655-.3185 3.218-.955 4.6909-.618 1.4545-1.4724 2.7274-2.5634 3.818-1.073 1.0729-2.3365 1.9274-3.791 2.5639-1.455.618-3.0179.927-4.6909.927zm-7.6364-5.8633V5.8636A9.4843 9.4843 0 0 0 2.755 8.7001C2.373 9.7365 2.1825 10.8365 2.1825 12s.1905 2.2725.5724 3.3274a9.5713 9.5713 0 0 0 1.609 2.809zm1.5-13.7727H18.163a9.4848 9.4848 0 0 0-2.836-1.609c-1.0549-.382-2.1639-.5725-3.3273-.5725-1.1635 0-2.2725.1905-3.327.5725a9.5713 9.5713 0 0 0-2.8094 1.609Zm6.1364 10.3637 4.1179-8.1818H7.9088Zm1.091 2.727h4.3633V8.7276Zm-6.5454 0h4.3634L6.5454 8.7276Zm8.7813 3.791c1.0545-.382 2-.918 2.836-1.609H5.8628a9.5713 9.5713 0 0 0 2.8094 1.609c1.0545.3819 2.1635.5724 3.327.5724 1.0543 0 2.1823-.1579 3.3274-.5725zm4.3089-3.109a9.5713 9.5713 0 0 0 1.609-2.809c.382-1.055.5724-2.164.5724-3.3274 0-1.1635-.1905-2.2635-.5724-3.3-.382-1.055-.918-1.9999-1.609-2.8364Z" />
+    </svg>
+  );
+}
+
+/** Disney has no clean single-color wordmark glyph, so the classic Mickey-ears
+ * silhouette stands in — instantly readable and rendered from three circles. */
+function DisneyLogo(props: LogoProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" role="img" {...props}>
+      <title>Disney</title>
+      <circle cx="5.5" cy="6" r="3.6" />
+      <circle cx="18.5" cy="6" r="3.6" />
+      <circle cx="12" cy="14" r="7" />
+    </svg>
+  );
+}
+
+const ORIGIN: Record<
+  MotionOrigin,
+  { label: string; Logo: ComponentType<LogoProps> }
+> = {
+  disney: { label: "Disney's 12 Principles", Logo: DisneyLogo },
+  apple: { label: "Apple HIG", Logo: AppleLogo },
+  material: { label: "Material 3", Logo: MaterialLogo },
+};
+
+/** Row of source logos shown to the right of a principle's title. */
+export function OriginLogos({ origins }: { origins: MotionOrigin[] }) {
+  return (
+    <div className="flex shrink-0 items-center gap-2 pt-1">
+      {origins.map((origin) => {
+        const { label, Logo } = ORIGIN[origin];
+        return (
+          <Logo
+            key={origin}
+            role="img"
+            aria-label={label}
+            className="size-3.5 text-muted-foreground/70"
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/docs/src/components/motion-guidelines/pattern-demos.tsx
+++ b/apps/docs/src/components/motion-guidelines/pattern-demos.tsx
@@ -318,78 +318,86 @@ export const PATTERNS: GalleryItem[] = [
   {
     slug: "enter",
     title: "Enter",
-    description:
-      "Bring an element in with a gentle fade-up on a soft spring. Serves Clarity.",
+    description: "Bring an element in with a gentle fade-up on a soft spring.",
+    serves: "Clarity",
     Demo: EnterDemo,
   },
   {
     slug: "exit",
     title: "Exit",
     description:
-      "Send it out the way it came, but faster — exits should never linger. Serves Continuity.",
+      "Send it out the way it came, but faster — exits should never linger.",
+    serves: "Continuity",
     Demo: ExitDemo,
   },
   {
     slug: "spring-pop",
     title: "Spring Pop",
-    description:
-      "Scale and fade together for menus, popovers, and tooltips. Serves Spatial Awareness.",
+    description: "Scale and fade together for menus, popovers, and tooltips.",
+    serves: "Spatial Awareness",
     Demo: SpringPopDemo,
   },
   {
     slug: "spring-height",
     title: "Spring Height",
     description:
-      "Animate height to auto for accordions, fading opacity alongside. Serves Continuity.",
+      "Animate height to auto for accordions, fading opacity alongside.",
+    serves: "Continuity",
     Demo: SpringHeightDemo,
   },
   {
     slug: "hover-lift",
     title: "Hover Lift",
     description:
-      "A small lift and shadow on hover gives cards and tiles weight. Serves Feedback.",
+      "A small lift and shadow on hover gives cards and tiles weight.",
+    serves: "Feedback",
     Demo: HoverLiftDemo,
   },
   {
     slug: "stagger-reveal",
     title: "Stagger Reveal",
     description:
-      "Cascade children with a shared stagger so a list reads as one wave. Serves Rhythm.",
+      "Cascade children with a shared stagger so a list reads as one wave.",
+    serves: "Rhythm",
     Demo: StaggerRevealDemo,
   },
   {
     slug: "backdrop-fade",
     title: "Backdrop Fade",
-    description:
-      "Fade the scrim independently from the content's spring. Serves Hierarchy.",
+    description: "Fade the scrim independently from the content's spring.",
+    serves: "Hierarchy",
     Demo: BackdropFadeDemo,
   },
   {
     slug: "shared-layout-morph",
     title: "Shared-Layout Morph",
     description:
-      "One surface morphs between two states instead of teleporting. Serves Continuity.",
+      "One surface morphs between two states instead of teleporting.",
+    serves: "Continuity",
     Demo: SharedLayoutMorphDemo,
   },
   {
     slug: "press-feedback",
     title: "Press Feedback",
     description:
-      "A quick scale-down confirms the press before anything else happens. Serves Feedback.",
+      "A quick scale-down confirms the press before anything else happens.",
+    serves: "Feedback",
     Demo: PressFeedbackDemo,
   },
   {
     slug: "loop",
     title: "Loop",
     description:
-      "A seamless marquee: duplicate the track and translate by half. Serves Restraint.",
+      "A seamless marquee: duplicate the track and translate by half.",
+    serves: "Restraint",
     Demo: LoopDemo,
   },
   {
     slug: "reduced-motion-fallback",
     title: "Reduced-Motion Fallback",
     description:
-      "Under prefers-reduced-motion, swap transforms for a plain opacity cross-fade — usability preserved. Serves Accessibility.",
+      "Under prefers-reduced-motion, swap transforms for a plain opacity cross-fade — usability preserved.",
+    serves: "Accessibility",
     Demo: ReducedMotionFallbackDemo,
   },
 ];

--- a/apps/docs/src/components/motion-guidelines/principle-demos.tsx
+++ b/apps/docs/src/components/motion-guidelines/principle-demos.tsx
@@ -337,6 +337,7 @@ export const PRINCIPLES: GalleryItem[] = [
     title: "Clarity",
     description:
       "Every motion should clarify what changed and why. One focal change at a time, never noise.",
+    origins: ["material", "apple"],
     Demo: ClarityDemo,
   },
   {
@@ -344,6 +345,7 @@ export const PRINCIPLES: GalleryItem[] = [
     title: "Continuity",
     description:
       "Objects move along visible paths instead of teleporting, so the eye never loses the thread.",
+    origins: ["apple", "material"],
     Demo: ContinuityDemo,
   },
   {
@@ -351,6 +353,7 @@ export const PRINCIPLES: GalleryItem[] = [
     title: "Hierarchy",
     description:
       "Sequence and emphasis tell you what matters first. The primary element leads; the rest follow.",
+    origins: ["material", "apple"],
     Demo: HierarchyDemo,
   },
   {
@@ -358,6 +361,7 @@ export const PRINCIPLES: GalleryItem[] = [
     title: "Spatial Awareness",
     description:
       "Elements enter and exit from where they live, reinforcing a stable mental model of the layout.",
+    origins: ["apple", "material"],
     Demo: SpatialAwarenessDemo,
   },
   {
@@ -365,6 +369,7 @@ export const PRINCIPLES: GalleryItem[] = [
     title: "Feedback",
     description:
       "The interface answers every input immediately, confirming the action landed before anything else.",
+    origins: ["apple", "material"],
     Demo: FeedbackDemo,
   },
   {
@@ -372,6 +377,7 @@ export const PRINCIPLES: GalleryItem[] = [
     title: "Timing & Easing",
     description:
       "The curve is the character. Natural motion accelerates and settles; it rarely moves at a constant speed.",
+    origins: ["disney", "material"],
     Demo: TimingEasingDemo,
   },
   {
@@ -379,6 +385,7 @@ export const PRINCIPLES: GalleryItem[] = [
     title: "Anticipation",
     description:
       "A subtle wind-up before a move primes the eye and makes the action feel intentional, not abrupt.",
+    origins: ["disney"],
     Demo: AnticipationDemo,
   },
   {
@@ -386,6 +393,7 @@ export const PRINCIPLES: GalleryItem[] = [
     title: "Follow Through",
     description:
       "Motion doesn't stop on a dime. Trailing elements keep going and settle, giving weight and life.",
+    origins: ["disney"],
     Demo: FollowThroughDemo,
   },
   {
@@ -393,6 +401,7 @@ export const PRINCIPLES: GalleryItem[] = [
     title: "Rhythm",
     description:
       "Consistent stagger and cadence turn many moving parts into one coordinated, legible gesture.",
+    origins: ["disney", "material"],
     Demo: RhythmDemo,
   },
   {
@@ -400,6 +409,7 @@ export const PRINCIPLES: GalleryItem[] = [
     title: "Restraint",
     description:
       "The best motion is felt, not noticed. When in doubt, do less — subtle beats flashy every time.",
+    origins: ["apple"],
     Demo: RestraintDemo,
   },
   {
@@ -407,6 +417,7 @@ export const PRINCIPLES: GalleryItem[] = [
     title: "Performance",
     description:
       "Animate only transform and opacity so motion stays at a buttery 60fps, and keep springs interruptible.",
+    origins: ["material"],
     Demo: PerformanceDemo,
   },
   {
@@ -414,6 +425,7 @@ export const PRINCIPLES: GalleryItem[] = [
     title: "Accessibility",
     description:
       "Honor prefers-reduced-motion: drop transforms, keep a subtle opacity change, and the interface still reads.",
+    origins: ["apple", "material"],
     Demo: AccessibilityDemo,
   },
 ];


### PR DESCRIPTION
Adds provenance to the Motion Guidelines docs. Each **Motion Principle** card now shows source logos (Apple HIG, Material 3, Disney) to the right of its title, tagging where the principle traces to. Each **Motion Pattern** card gets a small badge showing the principle it serves, and the redundant "Serves X." clause is dropped from pattern descriptions. The search input is removed from both galleries. New `origin-logos.tsx` holds the inline brand-logo components and the `MotionOrigin` type.