### PR TITLE
feat(docs): SSR GitHub stars + header/preview UI polish

### DIFF
--- a/apps/docs/src/app/docs/_components/github-stars.tsx
+++ b/apps/docs/src/app/docs/_components/github-stars.tsx
@@ -1,19 +1,10 @@
 "use client";
 
-import {
-  type ComponentProps,
-  useEffect,
-  useState,
-  useSyncExternalStore,
-} from "react";
+import type { ComponentProps } from "react";
+import { useGitHubStars } from "@/components/github-stars-provider";
 import { cn } from "@/lib/cn";
 
 const REPO = "LucasBassetti/godui";
-const CACHE_KEY = "godui:gh-stars";
-const CACHE_TTL = 60 * 60 * 1000; // 1h
-
-// No external store to subscribe to — the cache only changes via this component.
-const noopSubscribe = () => () => {};
 
 function GitHubIcon(props: ComponentProps<"svg">) {
   return (
@@ -37,71 +28,13 @@ function GitHubIcon(props: ComponentProps<"svg">) {
 }
 
 /**
- * GitHub badge linking to the repo, showing the live star count. The count is
- * fetched client-side and cached in localStorage (1h TTL) to avoid hitting the
- * GitHub API rate limit on every page load.
+ * GitHub badge linking to the repo, showing the star count. The count is fetched
+ * server-side (see `getGitHubStars`) and passed in as a prop so it renders in the
+ * initial HTML — no client-side pop-in or layout shift. The count is null only
+ * when the server fetch failed, in which case the badge shows just the icon.
  */
-function readCache(): { count: number; ts: number } | null {
-  if (typeof window === "undefined") return null;
-  try {
-    const cached = localStorage.getItem(CACHE_KEY);
-    return cached
-      ? (JSON.parse(cached) as { count: number; ts: number })
-      : null;
-  } catch {
-    return null; // malformed cache
-  }
-}
-
-// Fresh, valid cached count, or null. Used as the client snapshot.
-function readFreshCount(): number | null {
-  const cached = readCache();
-  return cached &&
-    Number.isFinite(cached.count) &&
-    Date.now() - cached.ts < CACHE_TTL
-    ? cached.count
-    : null;
-}
-
 export function GitHubStars({ className, ...props }: ComponentProps<"a">) {
-  // Read the cached count without a hydration mismatch: the server snapshot is
-  // null (matches SSR), then React swaps in the client snapshot after hydration.
-  // A previous render-seed + suppressHydrationWarning froze the value to the
-  // server's empty render whenever the cache was fresh — this avoids that.
-  const cached = useSyncExternalStore(
-    noopSubscribe,
-    readFreshCount,
-    () => null,
-  );
-  const [fetched, setFetched] = useState<number | null>(null);
-  const stars = fetched ?? cached;
-
-  useEffect(() => {
-    if (cached !== null) return; // fresh cache already shown
-
-    let active = true;
-    fetch(`https://api.github.com/repos/${REPO}`)
-      .then((res) => (res.ok ? res.json() : null))
-      .then((data) => {
-        if (!active || !data || typeof data.stargazers_count !== "number") {
-          return;
-        }
-        const count = data.stargazers_count as number;
-        setFetched(count);
-        localStorage.setItem(
-          CACHE_KEY,
-          JSON.stringify({ count, ts: Date.now() }),
-        );
-      })
-      .catch(() => {
-        // network error — keep whatever we have (cache or nothing)
-      });
-
-    return () => {
-      active = false;
-    };
-  }, [cached]);
-
+  const count = useGitHubStars();
   return (
     <a
       href={`https://github.com/${REPO}`}
@@ -115,8 +48,8 @@ export function GitHubStars({ className, ...props }: ComponentProps<"a">) {
       {...props}
     >
       <GitHubIcon className="size-4" />
-      {stars !== null ? (
-        <span className="tabular-nums">{stars.toLocaleString("en-US")}</span>
+      {count !== null ? (
+        <span className="tabular-nums">{count.toLocaleString("en-US")}</span>
       ) : null}
     </a>
   );

--- a/apps/docs/src/app/docs/_components/theme-toggle.tsx
+++ b/apps/docs/src/app/docs/_components/theme-toggle.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { motion, useAnimationControls, useReducedMotion } from "framer-motion";
 import { Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
 import type { ComponentProps } from "react";
@@ -7,25 +8,49 @@ import { cn } from "@/lib/cn";
 
 /**
  * Single-icon theme toggle: shows the active theme's icon and flips
- * light <-> dark on click. Works at every breakpoint. The icon swap is
- * driven by the `.dark` class (CSS), so there's no hydration flash.
+ * light <-> dark on click. Which glyph is visible is driven by the `.dark`
+ * class (CSS), so there's no hydration flash. The morph on click is a JS
+ * (framer-motion) spin + scale + fade — CSS transitions can't be used here
+ * because fumadocs runs next-themes with `disableTransitionOnChange`, which
+ * suppresses CSS transitions during the exact frame the theme class swaps.
  */
 export function ThemeToggle({ className, ...props }: ComponentProps<"button">) {
   const { resolvedTheme, setTheme } = useTheme();
+  const controls = useAnimationControls();
+  const reduceMotion = useReducedMotion();
+
+  const toggle = () => {
+    setTheme(resolvedTheme === "dark" ? "light" : "dark");
+    if (reduceMotion) return;
+    // Sun morphs into moon (and back): the new glyph spins + scales + fades in
+    // while the swap itself happens instantly under the cover of the animation.
+    controls.set({ rotate: -120, scale: 0.4, opacity: 0 });
+    void controls.start({
+      rotate: 0,
+      scale: 1,
+      opacity: 1,
+      transition: { duration: 0.45, ease: [0.16, 1, 0.3, 1] },
+    });
+  };
 
   return (
     <button
       type="button"
       aria-label="Toggle theme"
-      onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
+      onClick={toggle}
       className={cn(
-        "inline-flex size-9 items-center justify-center rounded-full text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground",
+        "inline-flex size-9 cursor-pointer items-center justify-center rounded-full text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground",
         className,
       )}
       {...props}
     >
-      <Sun className="size-4.5 dark:hidden" />
-      <Moon className="hidden size-4.5 dark:block" />
+      <motion.span
+        animate={controls}
+        className="inline-flex size-4.5 items-center justify-center"
+      >
+        <Sun className="size-4.5 dark:hidden" />
+        <Moon className="hidden size-4.5 dark:block" />
+      </motion.span>
     </button>
   );
 }

--- a/apps/docs/src/app/globals.css
+++ b/apps/docs/src/app/globals.css
@@ -511,11 +511,16 @@ figure.shiki div:has(> button[aria-label]) {
   border-radius: var(--radius-lg);
   border: 1px solid var(--color-fd-border);
   background: var(--color-fd-card);
-  overflow: hidden;
+  /* Scroll horizontally instead of crushing columns on narrow screens; still
+     clips the rounded corners (auto establishes a clipping context). */
+  overflow-x: auto;
 }
 
 .docs-table {
   width: 100%;
+  /* Floor the table width so columns stay readable on mobile — below this the
+     wrapper scrolls rather than wrapping the type column character-by-character. */
+  min-width: 40rem;
   border-collapse: collapse;
   font-variant-numeric: tabular-nums;
   font-size: 0.875rem;
@@ -615,6 +620,24 @@ figure.shiki div:has(> button[aria-label]) {
   );
   font-size: 0.875rem;
   text-wrap: pretty;
+}
+
+/* --- Focus outlines ---------------------------------------------------------
+   Fumadocs' code blocks are focusable (tabindex="-1") only so click-to-scroll
+   works; they're not in the tab order, so the outline the browser paints on
+   mouse-click is pure noise that lit up the whole card border. Drop it. */
+.shiki:focus,
+.shiki:focus-visible {
+  outline: none;
+}
+
+/* TOC ("On this page") links are full-width blocks, so the default UA outline
+   drew edge-to-edge lines across the column. Replace with a tidy rounded, inset
+   keyboard-focus ring — indicator kept for a11y, but it reads as intentional. */
+#nd-toc a:focus-visible {
+  outline: 2px solid var(--color-fd-ring);
+  outline-offset: -2px;
+  border-radius: 8px;
 }
 
 /* Copy button: pop the icon in when it swaps to the success check mark. */

--- a/apps/docs/src/app/hero-grid.tsx
+++ b/apps/docs/src/app/hero-grid.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+/**
+ * Dashed center-fade grid backdrop with a subtle pointer parallax. Split into
+ * its own client component so the home page itself can stay a server component
+ * (and fetch the star count server-side).
+ */
+export function HeroGrid() {
+  const gridRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // Subtle parallax: nudge the grid a few px toward the pointer.
+    const STRENGTH = 12; // max px offset in each axis
+    let frame = 0;
+
+    const handlePointerMove = (event: PointerEvent) => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => {
+        const x = (event.clientX / window.innerWidth - 0.5) * 2;
+        const y = (event.clientY / window.innerHeight - 0.5) * 2;
+        if (gridRef.current) {
+          gridRef.current.style.transform = `translate3d(${x * STRENGTH}px, ${y * STRENGTH}px, 0) scale(1.04)`;
+        }
+      });
+    };
+
+    window.addEventListener("pointermove", handlePointerMove);
+    return () => {
+      window.removeEventListener("pointermove", handlePointerMove);
+      cancelAnimationFrame(frame);
+    };
+  }, []);
+
+  return (
+    <div
+      ref={gridRef}
+      className="pointer-events-none absolute inset-0 z-0 transition-transform duration-300 ease-out [transition-property:transform] will-change-transform"
+      // Initial scale keeps the grid covering the viewport while it parallaxes.
+      style={{
+        backgroundImage: `
+          linear-gradient(to right, var(--color-fd-border) 1px, transparent 1px),
+          linear-gradient(to bottom, var(--color-fd-border) 1px, transparent 1px)
+        `,
+        backgroundSize: "20px 20px",
+        backgroundPosition: "0 0, 0 0",
+        maskImage: `
+          repeating-linear-gradient(to right, black 0px, black 3px, transparent 3px, transparent 8px),
+          repeating-linear-gradient(to bottom, black 0px, black 3px, transparent 3px, transparent 8px),
+          radial-gradient(ellipse 60% 60% at 50% 50%, #000 30%, transparent 70%)
+        `,
+        WebkitMaskImage: `
+          repeating-linear-gradient(to right, black 0px, black 3px, transparent 3px, transparent 8px),
+          repeating-linear-gradient(to bottom, black 0px, black 3px, transparent 3px, transparent 8px),
+          radial-gradient(ellipse 60% 60% at 50% 50%, #000 30%, transparent 70%)
+        `,
+        maskComposite: "intersect",
+        WebkitMaskComposite: "source-in",
+        transform: "translate3d(0, 0, 0) scale(1.04)",
+      }}
+    />
+  );
+}

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -3,7 +3,9 @@ import { GoogleAnalytics } from "@next/third-parties/google";
 import { RootProvider } from "fumadocs-ui/provider/next";
 import type { Metadata } from "next";
 import "./globals.css";
+import { GitHubStarsProvider } from "@/components/github-stars-provider";
 import { GodSearchDialog } from "@/components/search-dialog";
+import { getGitHubStars } from "@/lib/github-stars";
 import { AeoWidget } from "./aeo-widget";
 import { SiteStructuredData } from "./structured-data";
 
@@ -56,11 +58,13 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const stars = await getGitHubStars();
+
   return (
     <html
       lang="en"
@@ -77,7 +81,7 @@ export default function RootLayout({
           }}
           search={{ SearchDialog: GodSearchDialog }}
         >
-          {children}
+          <GitHubStarsProvider value={stars}>{children}</GitHubStarsProvider>
         </RootProvider>
         <AeoWidget />
       </body>

--- a/apps/docs/src/app/page.tsx
+++ b/apps/docs/src/app/page.tsx
@@ -1,9 +1,7 @@
-"use client";
-
 import { MagicButton } from "@godui/components";
 import Link from "next/link";
-import { useEffect, useRef } from "react";
 import { DocsHeader } from "./docs/_components/docs-header";
+import { HeroGrid } from "./hero-grid";
 
 const SITE_URL = "https://godui.design";
 
@@ -24,60 +22,9 @@ const structuredData = {
 };
 
 export default function Home() {
-  const gridRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    // Subtle parallax: nudge the grid a few px toward the pointer.
-    const STRENGTH = 12; // max px offset in each axis
-    let frame = 0;
-
-    const handlePointerMove = (event: PointerEvent) => {
-      cancelAnimationFrame(frame);
-      frame = requestAnimationFrame(() => {
-        const x = (event.clientX / window.innerWidth - 0.5) * 2;
-        const y = (event.clientY / window.innerHeight - 0.5) * 2;
-        if (gridRef.current) {
-          gridRef.current.style.transform = `translate3d(${x * STRENGTH}px, ${y * STRENGTH}px, 0) scale(1.04)`;
-        }
-      });
-    };
-
-    window.addEventListener("pointermove", handlePointerMove);
-    return () => {
-      window.removeEventListener("pointermove", handlePointerMove);
-      cancelAnimationFrame(frame);
-    };
-  }, []);
-
   return (
     <main className="relative flex min-h-svh flex-col">
-      {/* Dashed Center Fade Grid */}
-      <div
-        ref={gridRef}
-        className="pointer-events-none absolute inset-0 z-0 transition-transform duration-300 ease-out [transition-property:transform] will-change-transform"
-        // Initial scale keeps the grid covering the viewport while it parallaxes.
-        style={{
-          backgroundImage: `
-            linear-gradient(to right, var(--color-fd-border) 1px, transparent 1px),
-            linear-gradient(to bottom, var(--color-fd-border) 1px, transparent 1px)
-          `,
-          backgroundSize: "20px 20px",
-          backgroundPosition: "0 0, 0 0",
-          maskImage: `
-            repeating-linear-gradient(to right, black 0px, black 3px, transparent 3px, transparent 8px),
-            repeating-linear-gradient(to bottom, black 0px, black 3px, transparent 3px, transparent 8px),
-            radial-gradient(ellipse 60% 60% at 50% 50%, #000 30%, transparent 70%)
-          `,
-          WebkitMaskImage: `
-            repeating-linear-gradient(to right, black 0px, black 3px, transparent 3px, transparent 8px),
-            repeating-linear-gradient(to bottom, black 0px, black 3px, transparent 3px, transparent 8px),
-            radial-gradient(ellipse 60% 60% at 50% 50%, #000 30%, transparent 70%)
-          `,
-          maskComposite: "intersect",
-          WebkitMaskComposite: "source-in",
-          transform: "translate3d(0, 0, 0) scale(1.04)",
-        }}
-      />
+      <HeroGrid />
       <DocsHeader
         className="mx-auto w-full max-w-[90rem] border-transparent"
         showSidebarTrigger={false}

--- a/apps/docs/src/components/component-install.tsx
+++ b/apps/docs/src/components/component-install.tsx
@@ -215,7 +215,7 @@ export function ComponentInstall({
                 value={manager}
                 onChange={(value) => setManager(value as PackageManager)}
               />
-              <CopyButton value={cliCommand} />
+              <CopyButton value={cliCommand} className="rounded-md" />
             </div>
             <div className="flex items-center gap-3 px-4 py-2.5">
               <TerminalIcon />
@@ -260,7 +260,7 @@ export function ComponentInstall({
                           setManager(value as PackageManager)
                         }
                       />
-                      <CopyButton value={depsCommand} />
+                      <CopyButton value={depsCommand} className="rounded-md" />
                     </div>
                     <div className="flex items-center gap-3 px-4 py-2.5">
                       <TerminalIcon />

--- a/apps/docs/src/components/component-preview.tsx
+++ b/apps/docs/src/components/component-preview.tsx
@@ -59,42 +59,12 @@ function PlaygroundLink({ story }: { story: string }) {
       target="_blank"
       rel="noreferrer"
       title="Open the interactive playground in Storybook"
-      className="inline-flex h-8 items-center gap-1.5 rounded-md border border-fd-border bg-fd-card px-2.5 font-medium text-fd-muted-foreground text-xs transition-colors hover:border-fd-primary/45 hover:text-fd-primary"
+      // Hidden on mobile (no Storybook playground there); shown from sm up.
+      className="hidden h-8 items-center gap-1.5 rounded-[10px] border border-fd-border bg-fd-card px-2.5 font-medium text-fd-muted-foreground text-xs transition-colors hover:border-fd-primary/45 hover:text-fd-primary sm:inline-flex"
     >
       Playground
       <ExternalIcon />
     </a>
-  );
-}
-
-function PlayIcon() {
-  return (
-    <svg
-      aria-hidden="true"
-      viewBox="6.5 5 14 14"
-      className="size-3"
-      fill="currentColor"
-    >
-      <path d="M8 5v14l11-7z" />
-    </svg>
-  );
-}
-
-function CodeIcon() {
-  return (
-    <svg
-      aria-hidden="true"
-      viewBox="0 0 24 24"
-      className="size-3.5"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="m16 18 6-6-6-6" />
-      <path d="m8 6-6 6 6 6" />
-    </svg>
   );
 }
 
@@ -272,8 +242,8 @@ export function ComponentPreview({
       <div className="component-preview-bar flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
         <Segmented
           tabs={[
-            { value: "preview", label: "Preview", icon: <PlayIcon /> },
-            { value: "code", label: "Code", icon: <CodeIcon /> },
+            { value: "preview", label: "Preview" },
+            { value: "code", label: "Code" },
           ]}
           value={tab}
           onChange={setTab}
@@ -294,7 +264,7 @@ export function ComponentPreview({
               onClick={() => setReplayKey((key) => key + 1)}
               aria-label="Replay animation"
               title="Replay"
-              className="inline-flex size-8 items-center justify-center rounded-md border border-fd-border bg-fd-card text-fd-muted-foreground transition-colors hover:text-fd-foreground"
+              className="inline-flex size-8 items-center justify-center rounded-[10px] border border-fd-border bg-fd-card text-fd-muted-foreground transition-colors hover:text-fd-foreground"
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -313,7 +283,7 @@ export function ComponentPreview({
               </svg>
             </button>
           ) : (
-            <CopyButton value={formattedCode} />
+            <CopyButton value={formattedCode} className="rounded-[10px]" />
           )}
         </div>
       </div>

--- a/apps/docs/src/components/copy-button.tsx
+++ b/apps/docs/src/components/copy-button.tsx
@@ -23,7 +23,9 @@ export function CopyButton({ value, className }: CopyButtonProps) {
       aria-label={copied ? "Copied" : "Copy to clipboard"}
       onClick={onCopy}
       className={cn(
-        "inline-flex size-8 items-center justify-center rounded-md border border-fd-border bg-fd-card text-fd-muted-foreground transition-[color,border-color,background-color,transform] duration-150 hover:border-fd-primary/45 hover:text-fd-primary active:scale-[0.96]",
+        // Radius comes from the call site (cn has no tailwind-merge, so a base
+        // radius couldn't be overridden). Callers pass rounded-md / rounded-[10px].
+        "inline-flex size-8 items-center justify-center border border-fd-border bg-fd-card text-fd-muted-foreground transition-[color,border-color,background-color,transform] duration-150 hover:border-fd-primary/45 hover:text-fd-primary active:scale-[0.96]",
         className,
         copied &&
           "border-fd-success/45 text-fd-success hover:border-fd-success/45 hover:text-fd-success",

--- a/apps/docs/src/components/docs-tabs.tsx
+++ b/apps/docs/src/components/docs-tabs.tsx
@@ -123,7 +123,7 @@ export function Segmented({ tabs, value, onChange, className }: DocsTabsProps) {
         // Grid (not inline-flex) so every segment is an equal-width column —
         // a shrink-to-fit flex track sizes buttons to their content, which
         // makes the half-width thumb misalign with the wider tab.
-        "relative inline-grid rounded-[10px] border border-fd-border bg-[var(--muted)] p-[3px]",
+        "relative inline-grid h-8 rounded-[10px] border border-fd-border bg-[var(--muted)] p-[3px]",
         className,
       )}
       style={{
@@ -148,7 +148,10 @@ export function Segmented({ tabs, value, onChange, className }: DocsTabsProps) {
           type="button"
           onClick={() => onChange(tab.value)}
           className={cn(
-            "relative z-[1] inline-flex items-center justify-center gap-1.5 rounded-[7px] px-3 py-1 text-[13px] font-medium transition-colors",
+            // h-8 track (border-box) leaves a 24px inner area; symmetric
+            // py-[3px] + leading-[18px] centers the label vertically without
+            // depending on grid row-stretch behavior.
+            "relative z-[1] inline-flex items-center justify-center gap-1.5 rounded-[7px] px-3 py-[3px] text-[13px] leading-[18px] font-medium transition-colors",
             value === tab.value
               ? "text-[var(--foreground)]"
               : "text-[var(--muted-foreground)] hover:text-[var(--foreground)]",

--- a/apps/docs/src/components/github-stars-provider.tsx
+++ b/apps/docs/src/components/github-stars-provider.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { createContext, type ReactNode, useContext } from "react";
+
+/**
+ * Carries the server-fetched GitHub star count to the (client) header badges.
+ * The count is fetched once in the root layout (`getGitHubStars`) and provided
+ * here, so it's present during SSR — the badge renders the number in the initial
+ * HTML with no client fetch or layout shift. null means the fetch failed.
+ */
+const GitHubStarsContext = createContext<number | null>(null);
+
+export function GitHubStarsProvider({
+  value,
+  children,
+}: {
+  value: number | null;
+  children: ReactNode;
+}) {
+  return (
+    <GitHubStarsContext.Provider value={value}>
+      {children}
+    </GitHubStarsContext.Provider>
+  );
+}
+
+export function useGitHubStars(): number | null {
+  return useContext(GitHubStarsContext);
+}

--- a/apps/docs/src/components/mcp-install.tsx
+++ b/apps/docs/src/components/mcp-install.tsx
@@ -86,7 +86,7 @@ export function MCPInstall() {
                 value={manager}
                 onChange={(value) => setManager(value as PackageManager)}
               />
-              <CopyButton value={cliCommand} />
+              <CopyButton value={cliCommand} className="rounded-md" />
             </div>
             <div className="flex items-center gap-3 px-4 py-4">
               <TerminalIcon />

--- a/apps/docs/src/lib/github-stars.ts
+++ b/apps/docs/src/lib/github-stars.ts
@@ -1,0 +1,29 @@
+import { cache } from "react";
+
+const REPO = "LucasBassetti/godui";
+
+/**
+ * Server-side star count. Cached in Next's data cache for 1h so the value is
+ * baked into the initial HTML — no client fetch, no icon-then-number layout
+ * shift — while staying well under GitHub's unauthenticated rate limit
+ * (~1 request/hour). React `cache` dedupes it within a single render pass.
+ * Returns null on any failure; the badge then renders the icon alone.
+ */
+export const getGitHubStars = cache(async (): Promise<number | null> => {
+  try {
+    const res = await fetch(`https://api.github.com/repos/${REPO}`, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        "User-Agent": "godui-docs",
+      },
+      next: { revalidate: 3600 },
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { stargazers_count?: number };
+    return typeof data.stargazers_count === "number"
+      ? data.stargazers_count
+      : null;
+  } catch {
+    return null;
+  }
+});


### PR DESCRIPTION
Fetches the GitHub star count server-side (root layout, 1h revalidate) and passes it to the header badge via context, so the count renders in the initial HTML with no client fetch or icon-then-number layout shift (home page is now a Server Component with the pointer-parallax grid split into `HeroGrid`). The theme toggle now morphs sun↔moon on click via a framer-motion spin/scale/fade that survives fumadocs' `disableTransitionOnChange`, plus a pointer cursor. Preview bar polish: Playground hidden on mobile, Segmented tabs matched to the other controls in height (`h-8`), radius (`rounded-[10px]`) and vertical centering, Preview/Code icons dropped, and CopyButton radius scoped per call site. The Props table gets a min-width with horizontal scroll so it reads well on mobile. Focus outlines softened — the noisy mouse-focus outline on `tabindex="-1"` code blocks is removed and TOC links get a tidy rounded inset keyboard-focus ring.