### PR TITLE
feat(docs): mobile nav drawer on landing page

### DIFF
--- a/apps/docs/src/app/docs/_components/home-header.tsx
+++ b/apps/docs/src/app/docs/_components/home-header.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import type { ComponentProps } from "react";
+import { DocsHeader } from "./docs-header";
+
+/**
+ * DocsHeader preset for the landing page (full-bleed, transparent border, no
+ * scroll border). A dedicated client component so it can be passed as the
+ * DocsLayout `header` slot — plain server functions can't cross the client
+ * boundary DocsLayout sits behind.
+ */
+export function HomeHeader(props: ComponentProps<typeof DocsHeader>) {
+  return (
+    <DocsHeader
+      {...props}
+      className="mx-auto w-full max-w-[90rem] border-transparent"
+      showScrollBorder={false}
+    />
+  );
+}

--- a/apps/docs/src/app/page.tsx
+++ b/apps/docs/src/app/page.tsx
@@ -1,6 +1,12 @@
 import { MagicButton } from "@godui/components";
+import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import Link from "next/link";
-import { DocsHeader } from "./docs/_components/docs-header";
+import type { CSSProperties } from "react";
+import { baseOptions } from "@/lib/layout.shared";
+import { source } from "@/lib/source";
+import { HomeHeader } from "./docs/_components/home-header";
+import { MobileMenu } from "./docs/_components/mobile-menu";
+import { NullNavTitle } from "./docs/_components/null-nav-title";
 import { HeroGrid } from "./hero-grid";
 
 const SITE_URL = "https://godui.design";
@@ -21,79 +27,108 @@ const structuredData = {
   ],
 };
 
+// Full-bleed single-column grid (zero-width sidebar/toc columns) so the hero
+// spans the viewport, while still rendering inside DocsLayout — that's what
+// gives the landing page the exact same mobile nav drawer as the docs pages.
+const homeLayoutStyle = {
+  gridTemplate: `"sidebar header"
+"sidebar main" 1fr / 0 minmax(0, 1fr)`,
+} as CSSProperties;
+
 export default function Home() {
   return (
-    <main className="relative flex min-h-svh flex-col">
-      <HeroGrid />
-      <DocsHeader
-        className="mx-auto w-full max-w-[90rem] border-transparent"
-        showSidebarTrigger={false}
-        showScrollBorder={false}
-      />
-      <section className="relative z-10 flex flex-1 flex-col items-center justify-center gap-8 px-4 text-center">
-        <a
-          href="https://github.com/LucasBassetti/godui"
-          target="_blank"
-          rel="noreferrer noopener"
-          className="inline-flex items-center gap-2 rounded-full border bg-fd-card px-3 py-1 font-medium text-fd-muted-foreground text-xs transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
-        >
-          <span className="relative flex size-2">
-            <span className="absolute inline-flex size-full animate-ping rounded-full bg-fd-primary opacity-75" />
-            <span className="relative inline-flex size-2 rounded-full bg-fd-primary" />
-          </span>
-          Actively building — star us on GitHub
-        </a>
-        <h1 className="max-w-3xl text-balance font-semibold text-4xl text-fd-foreground tracking-tight sm:text-5xl md:text-6xl">
-          UI Collection for Modern Interfaces
-        </h1>
-        <p className="max-w-md text-balance text-fd-muted-foreground text-sm sm:text-base">
-          An open-source collection of beautifully crafted motion components
-          built with{" "}
-          <span className="font-semibold text-fd-foreground">React</span>,{" "}
-          <span className="font-semibold text-fd-foreground">TypeScript</span>,{" "}
-          <span className="font-semibold text-fd-foreground">Tailwind CSS</span>
-          , <span className="font-semibold text-fd-foreground">Motion</span>,
-          and{" "}
-          <span className="font-semibold text-fd-foreground">shadcn/ui</span>.
-        </p>
-        <div className="flex flex-col items-center gap-3 sm:flex-row">
-          <Link href="/docs/components" className="inline-block">
-            <MagicButton size="lg" tabIndex={-1}>
-              Browse Components
-            </MagicButton>
-          </Link>
-          <a
-            href="https://github.com/LucasBassetti/godui"
-            target="_blank"
-            rel="noreferrer noopener"
-            className="inline-block"
-          >
-            <MagicButton
-              size="lg"
-              variant="secondary"
-              rainbow={false}
-              tabIndex={-1}
+    <>
+      <DocsLayout
+        tree={source.getPageTree()}
+        {...baseOptions()}
+        // Desktop sidebar hidden (md:hidden); the mobile drawer is fixed-position
+        // and unaffected, so the landing keeps a clean full-bleed hero on desktop
+        // while sharing the docs drawer on mobile.
+        sidebar={{ collapsible: false, className: "md:hidden" }}
+        links={[{ type: "custom", on: "menu", children: <MobileMenu /> }]}
+        containerProps={{ className: "min-h-svh", style: homeLayoutStyle }}
+        slots={{
+          header: HomeHeader,
+          navTitle: NullNavTitle,
+          searchTrigger: false,
+        }}
+      >
+        <main className="relative flex min-h-svh flex-col [grid-area:main]">
+          <HeroGrid />
+          <section className="relative z-10 flex flex-1 flex-col items-center justify-center gap-8 px-4 text-center">
+            <a
+              href="https://github.com/LucasBassetti/godui"
+              target="_blank"
+              rel="noreferrer noopener"
+              className="inline-flex items-center gap-2 rounded-full border bg-fd-card px-3 py-1 font-medium text-fd-muted-foreground text-xs transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
             >
-              <span className="inline-flex items-center gap-2">
-                <svg
-                  viewBox="0 0 24 24"
-                  className="size-4"
-                  fill="currentColor"
-                  aria-hidden="true"
-                >
-                  <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
-                </svg>
-                Star on GitHub
+              <span className="relative flex size-2">
+                <span className="absolute inline-flex size-full animate-ping rounded-full bg-fd-primary opacity-75" />
+                <span className="relative inline-flex size-2 rounded-full bg-fd-primary" />
               </span>
-            </MagicButton>
-          </a>
-        </div>
-      </section>
+              Actively building — star us on GitHub
+            </a>
+            <h1 className="max-w-3xl text-balance font-semibold text-4xl text-fd-foreground tracking-tight sm:text-5xl md:text-6xl">
+              UI Collection for Modern Interfaces
+            </h1>
+            <p className="max-w-md text-balance text-fd-muted-foreground text-sm sm:text-base">
+              An open-source collection of beautifully crafted motion components
+              built with{" "}
+              <span className="font-semibold text-fd-foreground">React</span>,{" "}
+              <span className="font-semibold text-fd-foreground">
+                TypeScript
+              </span>
+              ,{" "}
+              <span className="font-semibold text-fd-foreground">
+                Tailwind CSS
+              </span>
+              , <span className="font-semibold text-fd-foreground">Motion</span>
+              , and{" "}
+              <span className="font-semibold text-fd-foreground">
+                shadcn/ui
+              </span>
+              .
+            </p>
+            <div className="flex flex-col items-center gap-4 sm:flex-row sm:gap-5">
+              <Link href="/docs/components" className="inline-block">
+                <MagicButton size="lg" tabIndex={-1}>
+                  Browse Components
+                </MagicButton>
+              </Link>
+              <a
+                href="https://github.com/LucasBassetti/godui"
+                target="_blank"
+                rel="noreferrer noopener"
+                className="inline-block"
+              >
+                <MagicButton
+                  size="lg"
+                  variant="secondary"
+                  rainbow={false}
+                  tabIndex={-1}
+                >
+                  <span className="inline-flex items-center gap-2">
+                    <svg
+                      viewBox="0 0 24 24"
+                      className="size-4"
+                      fill="currentColor"
+                      aria-hidden="true"
+                    >
+                      <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+                    </svg>
+                    Star on GitHub
+                  </span>
+                </MagicButton>
+              </a>
+            </div>
+          </section>
+        </main>
+      </DocsLayout>
       <script
         type="application/ld+json"
         // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD requires raw script injection.
         dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
       />
-    </main>
+    </>
   );
 }


### PR DESCRIPTION
The landing page now renders inside the same `DocsLayout` as the docs pages, so its mobile hamburger opens the exact same slide-in navigation drawer — Menu links plus the full component page tree — instead of having no mobile nav at all. A zero-width sidebar/toc grid keeps the hero full-bleed and the desktop sidebar hidden, while the fixed-position drawer is unaffected. A small `HomeHeader` client component supplies the landing-styled `DocsHeader` as the layout header slot. Also bumps the spacing between the two hero CTA buttons.