### PR TITLE
fix(components): keep HoldConfirmButton width stable while holding

### DIFF
--- a/packages/components/src/hold-confirm-button/hold-confirm-button.tsx
+++ b/packages/components/src/hold-confirm-button/hold-confirm-button.tsx
@@ -126,12 +126,13 @@ const HoldConfirmButton = React.forwardRef<
       if (event.key === " " || event.key === "Enter") cancel();
     };
 
-    const label =
-      status === "confirmed"
-        ? confirmedLabel
-        : status === "holding"
-          ? holdingLabel
-          : children;
+    // All label variants share one grid cell so the button sizes to the
+    // widest and never changes width as the status (and label) changes.
+    const labels: { key: HoldConfirmButtonStatus; node: React.ReactNode }[] = [
+      { key: "idle", node: children },
+      { key: "holding", node: holdingLabel },
+      { key: "confirmed", node: confirmedLabel },
+    ];
 
     return (
       <button
@@ -154,27 +155,38 @@ const HoldConfirmButton = React.forwardRef<
           style={{ scaleX: progress }}
           className={`absolute inset-0 origin-left ${fillClass[variant]}`}
         />
-        <span className="relative inline-flex items-center gap-2">
-          {status === "confirmed" && (
-            <svg
-              viewBox="0 0 24 24"
-              fill="none"
-              className="size-[1.15em]"
-              aria-hidden="true"
-            >
-              <motion.path
-                d="M5 12.5 10 17.5 19 7"
-                stroke="currentColor"
-                strokeWidth="2.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                initial={{ pathLength: 0 }}
-                animate={{ pathLength: 1 }}
-                transition={{ duration: 0.3 }}
-              />
-            </svg>
-          )}
-          <span className="whitespace-nowrap">{label}</span>
+        <span className="relative grid">
+          {labels.map(({ key, node }) => {
+            const active = status === key;
+            return (
+              <span
+                key={key}
+                aria-hidden={active ? undefined : "true"}
+                className={`col-start-1 row-start-1 inline-flex items-center justify-center gap-2 ${active ? "" : "invisible"}`}
+              >
+                {key === "confirmed" && (
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    className="size-[1.15em]"
+                    aria-hidden="true"
+                  >
+                    <motion.path
+                      d="M5 12.5 10 17.5 19 7"
+                      stroke="currentColor"
+                      strokeWidth="2.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      initial={{ pathLength: 0 }}
+                      animate={active ? { pathLength: 1 } : { pathLength: 0 }}
+                      transition={{ duration: 0.3 }}
+                    />
+                  </svg>
+                )}
+                <span className="whitespace-nowrap">{node}</span>
+              </span>
+            );
+          })}
         </span>
       </button>
     );


### PR DESCRIPTION
Stack all label variants (idle / holding / confirmed) in a single CSS grid cell so `HoldConfirmButton` sizes to its widest label once. The button no longer changes width when the status and its label swap during a hold. Inactive variants stay laid out but `invisible`, and the confirmed checkmark path only animates when active.