### PR TITLE
docs: reorder preview toolbar + GodUI GitHub links in demos

### DIFF
--- a/apps/docs/content/docs/components/ai/source-citations.mdx
+++ b/apps/docs/content/docs/components/ai/source-citations.mdx
@@ -13,7 +13,7 @@ import { SourceCitationsDemo } from "@/components/demos/source-citations-demo";
 } from "@/components/godui/source-citations";
 
 const sources = [
-  { title: "OKLCH in CSS", url: "https://evilmartians.com/chronicles/oklch-in-css", snippet: "A perceptual color space." },
+  { title: "GodUI", url: "https://github.com/LucasBassetti/godui", snippet: "Motion components for modern interfaces." },
   { title: "Tailwind v4", url: "https://tailwindcss.com/blog/tailwindcss-v4" },
 ];
 

--- a/apps/docs/content/docs/components/buttons/magnetic-button.mdx
+++ b/apps/docs/content/docs/components/buttons/magnetic-button.mdx
@@ -18,7 +18,18 @@ export function MagneticButtonDemo() {
         Get started
         <ArrowRight className="size-4" strokeWidth={2.5} />
       </MagneticButton>
-      <MagneticButton variant="outline" size="lg" range={36}>
+      <MagneticButton
+        variant="outline"
+        size="lg"
+        range={36}
+        onClick={() =>
+          window.open(
+            "https://github.com/LucasBassetti/godui",
+            "_blank",
+            "noopener,noreferrer",
+          )
+        }
+      >
         <Star className="size-4" strokeWidth={2.5} />
         Star on GitHub
       </MagneticButton>

--- a/apps/docs/src/components/component-preview.tsx
+++ b/apps/docs/src/components/component-preview.tsx
@@ -254,10 +254,10 @@ export function ComponentPreview({
           </span>
         ) : null}
         <div className="ms-auto flex items-center gap-2">
-          {story ? <PlaygroundLink story={story} /> : null}
           {tab === "preview" ? (
             <ViewToggle view={view} onChange={setView} />
           ) : null}
+          {story ? <PlaygroundLink story={story} /> : null}
           {tab === "preview" ? (
             <button
               type="button"

--- a/apps/docs/src/components/demos/magnetic-button-demo.tsx
+++ b/apps/docs/src/components/demos/magnetic-button-demo.tsx
@@ -11,7 +11,18 @@ export function MagneticButtonDemo() {
           Get started
           <ArrowRight className="size-4" strokeWidth={2.5} />
         </MagneticButton>
-        <MagneticButton variant="outline" size="lg" range={36}>
+        <MagneticButton
+          variant="outline"
+          size="lg"
+          range={36}
+          onClick={() =>
+            window.open(
+              "https://github.com/LucasBassetti/godui",
+              "_blank",
+              "noopener,noreferrer",
+            )
+          }
+        >
           <Star className="size-4" strokeWidth={2.5} />
           Star on GitHub
         </MagneticButton>

--- a/apps/docs/src/components/demos/source-citations-demo.tsx
+++ b/apps/docs/src/components/demos/source-citations-demo.tsx
@@ -4,10 +4,10 @@ import { SourceCitation, SourceList } from "@godui/components";
 
 const sources = [
   {
-    title: "OKLCH in CSS: why we moved",
-    url: "https://evilmartians.com/chronicles/oklch-in-css",
+    title: "GodUI — motion components for modern interfaces",
+    url: "https://github.com/LucasBassetti/godui",
     snippet:
-      "OKLCH keeps perceived lightness consistent across hues, which makes it ideal for design tokens and dark mode.",
+      "Beautifully crafted motion components with OKLCH theming, built for perceptually uniform design tokens and dark mode.",
   },
   {
     title: "Tailwind CSS v4 release notes",


### PR DESCRIPTION
Moves the Storybook Playground link to sit after the desktop/mobile view toggle in `ComponentPreview`. Wires the MagneticButton "Star on GitHub" demo to open the GodUI repo, and makes GodUI the first source in the SourceCitations demo. Mirrored MDX code samples are kept in sync.