### PR TITLE
docs(readme): refresh og-image banner (cache-bust)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 
 <a href="https://godui.design">
-  <img src="https://raw.githubusercontent.com/LucasBassetti/godui/main/apps/docs/public/og-image.png" alt="GodUI — UI Collection for Modern Interfaces" width="100%" />
+  <img src="https://raw.githubusercontent.com/LucasBassetti/godui/main/apps/docs/public/og-image.png?v=2" alt="GodUI — UI Collection for Modern Interfaces" width="100%" />
 </a>
 
 <h1>GodUI</h1>


### PR DESCRIPTION
The README banner points to the raw og-image URL on `main`; since the file was replaced at the same path, GitHub's camo proxy keeps serving the stale cached image. This adds a `?v=2` cache-bust so the new banner renders. The image is already wrapped in a link to godui.design.