### PR TITLE
feat(docs): play logo hover animation from the wordmark too

### DIFF
--- a/apps/docs/src/app/docs/_components/docs-header.tsx
+++ b/apps/docs/src/app/docs/_components/docs-header.tsx
@@ -62,7 +62,7 @@ export function DocsHeader({
       >
         <Link
           href="/"
-          className="inline-flex items-center gap-2 font-bold text-[0.9375rem] text-fd-foreground"
+          className="godui-hover-group inline-flex items-center gap-2 font-bold text-[0.9375rem] text-fd-foreground"
         >
           <GoduiLogo className="h-6 w-6" width={24} height={24} />
           GodUI

--- a/apps/docs/src/app/docs/_components/godui-logo.tsx
+++ b/apps/docs/src/app/docs/_components/godui-logo.tsx
@@ -41,7 +41,11 @@ export function GoduiLogo({ alt = "GodUI", ...props }: GoduiLogoProps) {
           filter: drop-shadow(0 3px 5px rgb(0 0 0 / 0.4));
           transition: offset-distance 1.1s cubic-bezier(.65,.05,.36,1);
         }
-        .godui-mark:hover .godui-dot { offset-distance: 100%; }
+        /* Animate on hover of the mark itself, OR of any ancestor tagged
+           .godui-hover-group (e.g. the header's logo+wordmark link). Inline
+           SVG <style> is document-scoped, so the ancestor selector resolves. */
+        .godui-mark:hover .godui-dot,
+        .godui-hover-group:hover .godui-dot { offset-distance: 100%; }
         @media (prefers-reduced-motion: reduce) {
           .godui-mark .godui-dot { transition: none; }
         }


### PR DESCRIPTION
The header link wraps both the logo mark and the "GodUI" wordmark. This tags that link with `.godui-hover-group` and animates the logo's dot on hover of the mark **or** that ancestor, so hovering the text plays the same dot-along-the-G animation. Works because inline SVG `<style>` is document-scoped, so the ancestor selector resolves.