### PR TITLE
feat(docs): slide the preview desktop/mobile toggle like the tabs

### DIFF
--- a/apps/docs/src/app/docs/_components/godui-logo.tsx
+++ b/apps/docs/src/app/docs/_components/godui-logo.tsx
@@ -43,7 +43,8 @@ export function GoduiLogo({ alt = "GodUI", ...props }: GoduiLogoProps) {
         }
         /* Animate on hover of the mark itself, OR of any ancestor tagged
            .godui-hover-group (e.g. the header's logo+wordmark link). Inline
-           SVG <style> is document-scoped, so the ancestor selector resolves. */
+           SVG style elements are document-scoped, so the ancestor selector
+           resolves. */
         .godui-mark:hover .godui-dot,
         .godui-hover-group:hover .godui-dot { offset-distance: 100%; }
         @media (prefers-reduced-motion: reduce) {

--- a/apps/docs/src/components/component-preview.tsx
+++ b/apps/docs/src/components/component-preview.tsx
@@ -79,12 +79,30 @@ function ViewToggle({
     { value: "desktop", label: "Desktop view", Icon: Monitor },
     { value: "mobile", label: "Mobile view", Icon: Smartphone },
   ];
+  const activeIndex = Math.max(
+    0,
+    options.findIndex((opt) => opt.value === view),
+  );
 
   return (
     // bg-fd-muted is aliased to muted-foreground in the GodUI theme (renders as a
     // heavy block), so use the real --muted track + raised --card active segment,
     // matching <Segmented>.
-    <div className="hidden h-8 items-center rounded-[10px] border border-fd-border bg-[var(--muted)] p-[3px] md:inline-flex">
+    <div
+      className="relative hidden h-8 rounded-[10px] border border-fd-border bg-[var(--muted)] p-[3px] md:inline-grid"
+      style={{
+        gridTemplateColumns: `repeat(${options.length}, minmax(0, 1fr))`,
+      }}
+    >
+      {/* Floating thumb that slides under the active segment, matching <Segmented>. */}
+      <span
+        aria-hidden="true"
+        className="absolute inset-y-[3px] left-[3px] rounded-[6px] bg-[var(--card)] shadow-sm transition-transform duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none"
+        style={{
+          width: `calc((100% - 6px) / ${options.length})`,
+          transform: `translateX(${activeIndex * 100}%)`,
+        }}
+      />
       {options.map(({ value, label, Icon }) => {
         const active = view === value;
         return (
@@ -96,9 +114,9 @@ function ViewToggle({
             aria-pressed={active}
             title={label}
             className={cn(
-              "inline-flex size-6 items-center justify-center rounded-[6px] transition-colors",
+              "relative z-[1] inline-flex size-6 items-center justify-center rounded-[6px] transition-colors",
               active
-                ? "bg-[var(--card)] text-[var(--foreground)] shadow-sm"
+                ? "text-[var(--foreground)]"
                 : "text-[var(--muted-foreground)] hover:text-[var(--foreground)]",
             )}
           >


### PR DESCRIPTION
The ComponentPreview desktop/mobile `ViewToggle` now animates with a floating thumb that slides under the active segment, matching the sibling Preview/Code `Segmented` control in the same toolbar. Also fixes a hydration mismatch in `GoduiLogo`: a CSS comment contained the literal text `<style>`, which the server serialized raw while the client escaped it (`<\73 tyle>`) — that mismatch triggered a full client re-render, which in turn surfaced the "script tag while rendering React component" warning from the JSON-LD `<script>`. Removing the tag from the comment resolves both.