### PR TITLE
feat(docs): add Static Effects nav section for non-animated backgrounds

### DIFF
--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -114,11 +114,7 @@
     "components/effects/terminal",
     "---Backgrounds---",
     "components/backgrounds/blueprint-grid",
-    "components/backgrounds/decorative-background",
-    "components/backgrounds/effect-background",
     "components/backgrounds/flow-field",
-    "components/backgrounds/geometric-background",
-    "components/backgrounds/gradient-background",
     "components/backgrounds/light-rays",
     "components/backgrounds/liquid-metaballs",
     "components/backgrounds/pixel-grid",
@@ -126,6 +122,11 @@
     "components/backgrounds/warp-starfield",
     "---Glass---",
     "components/glass/liquid-glass-card",
-    "components/glass/liquid-glass-lens"
+    "components/glass/liquid-glass-lens",
+    "---Static Effects---",
+    "components/backgrounds/decorative-background",
+    "components/backgrounds/effect-background",
+    "components/backgrounds/geometric-background",
+    "components/backgrounds/gradient-background"
   ]
 }

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -71,7 +71,7 @@ export default async function RootLayout({
       suppressHydrationWarning
       className={`${GeistSans.variable} ${GeistMono.variable}`}
     >
-      <body className={GeistSans.className}>
+      <body className={GeistSans.className} suppressHydrationWarning>
         <SiteStructuredData />
         <RootProvider
           theme={{


### PR DESCRIPTION
Adds a new **Static Effects** section as the last sidenav group, moving the four non-animated background pages (decorative, effect, geometric, gradient) out of Backgrounds. Page files and URLs are unchanged — only the nav grouping in `meta.json` moved. Also adds `suppressHydrationWarning` to `<body>` to silence a browser-extension (Grammarly) attribute-mismatch hydration warning.