### PR TITLE
fix(docs): sharpen orbit-carousel Learn legends + softer menu/beam shadows

### DIFF
--- a/.agents/skills/godui-learn-article/SKILL.md
+++ b/.agents/skills/godui-learn-article/SKILL.md
@@ -193,9 +193,37 @@ export function MyScene() {
   on dark surfaces). Leave faces blank when the shape alone carries the point. Explanation
   lives in the legend, the mono captions, and the prose — not on the shape. Real component
   labels are fine (and expected) only in the `Result` panel, since that's the live product.
-- **Label with a grounded legend, not floating tags.** Put a bottom legend row (tone
-  swatch + name + one-liner per element). Floating absolutely-positioned tags read as
-  broken — avoid them.
+- **Legend swatches MUST match the diagram (color + shape).** This is the #1 legend bug.
+  Every bottom-legend entry names a **concrete piece the reader can see** in the scene —
+  not an abstract CSS concept with no visual counterpart.
+
+  | Rule | Pass | Fail |
+  |------|------|------|
+  | **Color** | Swatch fill/border/opacity appears on that diagram piece | Opacity-only ramps (`/30` vs `/60` vs solid) that never appear as distinct pieces; `primary` / white / black that aren't on the diagram |
+  | **Shape** | Swatch silhouette matches the piece | Same `h-1.5 w-8 rounded-full` pill for a card, a pointer, a dashed frame, and a hairline |
+  | **Meaning** | Name = visible piece (Viewport, Tile, Active plate, Pointer) | Temporal labels (Pan / Settle / Flick) or CSS props (Perspective / Tilt) with no matching cue |
+
+  **Shape vocabulary** (pick the one that matches the piece):
+  - **Circle / dot** — pointer, avatar, orb, status, thumb
+  - **Plate** (`rounded-md` / `rounded-xl` / card border) — cards, panels, tiles
+  - **Pill / bar** — only when the diagram itself uses a pill/bar (token label, progress fill, dock bus)
+  - **Dashed rect / ring** — clip viewport, dashed guide, idle/ghost outline
+  - **Hairline** — separator, connector, threshold, SVG stroke
+  - **Diamond / isometric** — caret, or a tile that *reads* diamond because of `rotateX`/`rotateZ` (draw the swatch with the same transform + fill)
+
+  Prefer a local `LegendSwatch({ kind })` helper (or full shape classes on `swatch`) over always wrapping `item.swatch` in `h-1.5 w-8 rounded-full`. If two legend items would get identical swatches, either differentiate shapes or merge the items.
+
+  **If a concept isn't visible, make it visible first** — then swatch it. Example: a
+  `perspective` / overflow clip that has no border → add a dashed viewport outline on
+  the diagram, then use a matching dashed-frame swatch. Do **not** invent a circle or
+  dotted pill that doesn't exist in the scene (classic 3D Marquee failure).
+
+  Temporal / motion phases (drag → settle → fling) need a **visible cue** for each
+  phase (pointer dot, active plate, ghost outline at overshoot) — or rename the legend
+  to the pieces that are actually drawn.
+- **Label with a grounded legend, not floating tags.** Put a bottom legend row (swatch
+  + name + one-liner per element). Floating absolutely-positioned tags read as
+  broken — avoid them. Align legend column count with the number of pieces.
 - **3D exploded views (only when they help):** center a
   `[transform-style:preserve-3d]` stage in a fixed-size box (`[perspective:1000px]`),
   separate plates along `translateZ`. Works for stacked rectangular layers (Magic
@@ -209,6 +237,8 @@ Reference scenes (technique patterns, not templates to clone):
 - `layer-reveal.tsx` — isometric explode + legend (rectangular layers). Text-free plates.
 - `gooey-layers.tsx` — same open silhouette, split by layer (blob | control | both). Uses a `+` glyph, no words.
 - `mask-twin-labels.tsx` / `slide-anatomy.tsx` — canonical **token-bar** stand-ins for a label (`h-2 w-12 rounded-full bg-[var(--foreground)]/30`, light on dark).
+- `orbit-carousel-orbit.tsx` — motion legend with shape-matched pieces (pointer · active plate · flick ghost), not opacity pills.
+- `three-d-marquee-anatomy.tsx` — viewport dashed frame + isometric tile swatch matching the clipped diamond grid.
 - `rainbow-sweep.tsx` — the one colored scene (gradient), reuses `animate-magic-rainbow`.
 - `push-physics.tsx` — looping rest→hover→press cycle. NOTE: its face still reads "Push me" — that predates the no-copy rule; do **not** copy that, blank the face or use a token bar instead.
 
@@ -275,6 +305,9 @@ running on a non-3000 port — grep the log). Confirm:
 - Right TOC lists the article headings.
 - Scenes auto-play on scroll-in; **replay re-runs** each; reduced-motion shows the
   resolved state.
+- **Every legend swatch maps to a visible diagram piece** (same color + shape). Cover
+  anatomy *and* motion/lifecycle cards — not just anatomy. No orphan circles/pills for
+  CSS concepts that aren't drawn.
 - Component with no learn page shows **no** tabs.
 
 Headless screenshot without installing Playwright (chromium is cached):
@@ -312,3 +345,9 @@ drive CDP over the built-in global `WebSocket` (Node ≥20): click
 - **Don't animate layout/paint props** even though docs scenes aren't CI-gated.
 - **Live component import** works in docs (`@godui/components`); the docs `index.mdx`
   already imports components the same way.
+- **Legend ≠ opacity pills.** Never default every legend entry to
+  `h-1.5 w-8 rounded-full` with only `--foreground` opacity changes. Shape-match the
+  piece (plate / dot / dashed frame / hairline / isometric tile). If the concept isn't
+  on the diagram, draw the cue first (e.g. dashed viewport), then swatch it.
+- **Prose / legend / diagram stay in sync.** Same piece count; same names; Result
+  geometry matches anatomy when the article is teaching structure.

--- a/apps/docs/src/components/learn/accordion-anatomy.tsx
+++ b/apps/docs/src/components/learn/accordion-anatomy.tsx
@@ -15,23 +15,43 @@ const CSS = `
 .aa-static .aa-row { opacity: 1; animation: none; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "trigger" | "chevron" | "panel";
+}[] = [
   {
     name: "Trigger",
     desc: "button, aria-expanded + aria-controls",
-    swatch: "bg-[var(--muted)]",
+    kind: "trigger",
   },
   {
     name: "Chevron",
     desc: "group-data-[open=true]:rotate-180, 250ms ease",
-    swatch: "bg-[var(--foreground)]/50",
+    kind: "chevron",
   },
   {
     name: "Panel",
     desc: "role=region, mounted only while open",
-    swatch: "bg-[var(--foreground)]/30",
+    kind: "panel",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "trigger") {
+    return (
+      <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "chevron") {
+    return (
+      <span className="size-2 border-[var(--foreground)]/50 border-r-2 border-b-2 [transform:rotate(45deg)]" />
+    );
+  }
+  return (
+    <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/30 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 function Chevron({ open }: { open: boolean }) {
   return (
@@ -96,9 +116,7 @@ export function AccordionAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/accordion-height.tsx
+++ b/apps/docs/src/components/learn/accordion-height.tsx
@@ -28,18 +28,33 @@ const CSS = `
 .ah-static .ah-chevron { animation: none; transform: rotate(180deg); }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "panel" | "chevron";
+}[] = [
   {
     name: "Panel",
     desc: "height + opacity, spring stiffness 500 · damping 40",
-    swatch: "bg-[var(--foreground)]/30",
+    kind: "panel",
   },
   {
     name: "Chevron",
     desc: "transform: rotate, plain 250ms ease — no spring",
-    swatch: "bg-[var(--foreground)]/60",
+    kind: "chevron",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "chevron") {
+    return (
+      <span className="size-2 border-[var(--foreground)]/60 border-r-2 border-b-2 [transform:rotate(45deg)]" />
+    );
+  }
+  return (
+    <span className="h-3 w-7 rounded-md bg-[var(--foreground)]/30 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function AccordionHeight() {
   return (
@@ -88,9 +103,7 @@ export function AccordionHeight() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/agent-flow-anatomy.tsx
+++ b/apps/docs/src/components/learn/agent-flow-anatomy.tsx
@@ -75,23 +75,43 @@ const CSS = `
 .afa-static .afa-packet { animation: none; opacity: 0.85; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "node" | "edge" | "packet";
+}[] = [
   {
     name: "Node card",
     desc: "absolute (x, y) centre, size measured live",
-    swatch: "border-2 border-[var(--foreground)]/50 bg-transparent",
+    kind: "node",
   },
   {
     name: "Edge path",
     desc: "quadratic curve, right-centre → left-centre",
-    swatch: "bg-[var(--foreground)]/40",
+    kind: "edge",
   },
   {
     name: "Packet",
     desc: "gradient beam that rides the curve",
-    swatch: "bg-[var(--foreground)]",
+    kind: "packet",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "node") {
+    return (
+      <span className="h-3.5 w-6 rounded-md border border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "edge") {
+    return (
+      <span className="h-0.5 w-8 rounded-full bg-[var(--foreground)]/40 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="size-2.5 rounded-full bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 function Card({ x, y, delay }: { x: number; y: number; delay: string }) {
   return (
@@ -171,9 +191,7 @@ export function AgentFlowAnatomy() {
           <dl className="grid w-full max-w-[400px] grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/agent-flow-packet.tsx
+++ b/apps/docs/src/components/learn/agent-flow-packet.tsx
@@ -230,7 +230,7 @@ export function AgentFlowPacket() {
 
           <dl className="grid w-full max-w-[420px] grid-cols-2 gap-4 border-fd-border border-t pt-5">
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--primary)] ring-1 ring-fd-border ring-inset" />
+              <span className="size-3.5 rounded-lg border border-[var(--primary)] bg-[var(--primary)] ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Trace / light
               </dt>
@@ -239,7 +239,7 @@ export function AgentFlowPacket() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--primary)]/50 ring-1 ring-fd-border ring-inset" />
+              <span className="size-2.5 rounded-full bg-[var(--primary)] ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Beam
               </dt>

--- a/apps/docs/src/components/learn/agent-timeline-anatomy.tsx
+++ b/apps/docs/src/components/learn/agent-timeline-anatomy.tsx
@@ -67,23 +67,43 @@ function Connector({ fill }: { fill: string }) {
   );
 }
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "ring" | "connector" | "body";
+}[] = [
   {
     name: "Ring",
     desc: "border-color + fill keyed by status",
-    swatch: "border-2 border-[var(--foreground)] bg-transparent",
+    kind: "ring",
   },
   {
     name: "Connector",
     desc: "scaleY 0 → 0.5 → 1, spring 320/32/0.9",
-    swatch: "bg-[var(--foreground)]",
+    kind: "connector",
   },
   {
     name: "Body",
     desc: "height + opacity, collapsible per step",
-    swatch: "bg-[var(--foreground)]/30",
+    kind: "body",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "ring") {
+    return (
+      <span className="size-3 rounded-full border-2 border-[var(--foreground)] bg-transparent ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "connector") {
+    return (
+      <span className="h-3.5 w-0.5 rounded-full bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-3.5 w-6 rounded-md border border-fd-border bg-[var(--muted)]/40 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function AgentTimelineAnatomy() {
   return (
@@ -158,7 +178,7 @@ export function AgentTimelineAnatomy() {
           <dl className="mt-3 grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span className={`size-3 rounded-full ${item.swatch}`} />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/agent-timeline-expand.tsx
+++ b/apps/docs/src/components/learn/agent-timeline-expand.tsx
@@ -35,18 +35,33 @@ const CSS = `
 .ate-static .ate-title   { animation: none; opacity: 1; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "body" | "chevron";
+}[] = [
   {
     name: "Body",
     desc: "scaleY + opacity, spring 320/32/0.9",
-    swatch: "bg-[var(--foreground)]/30",
+    kind: "body",
   },
   {
     name: "Chevron",
     desc: "rotate 0 → 90deg, independent curve",
-    swatch: "bg-[var(--foreground)]/60",
+    kind: "chevron",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "chevron") {
+    return (
+      <span className="size-2 border-fd-muted-foreground border-r-2 border-b-2 [transform:rotate(-45deg)]" />
+    );
+  }
+  return (
+    <span className="h-3 w-7 rounded-lg border border-fd-border bg-[var(--muted)]/40 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function AgentTimelineExpand() {
   return (
@@ -98,9 +113,7 @@ export function AgentTimelineExpand() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/agent-timeline-rail.tsx
+++ b/apps/docs/src/components/learn/agent-timeline-rail.tsx
@@ -38,23 +38,45 @@ const CSS = `
 .atr-static .atr-ping-el { animation: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "pending" | "running" | "success";
+}[] = [
   {
     name: "Pending",
     desc: "hollow ring, dot",
-    swatch: "border-2 border-fd-border bg-transparent",
+    kind: "pending",
   },
   {
     name: "Running",
     desc: "spinner + ping, half fill",
-    swatch: "border-2 border-[var(--primary)] bg-[var(--primary)]/10",
+    kind: "running",
   },
   {
     name: "Success",
     desc: "solid ring, check, full fill",
-    swatch: "border-2 border-[var(--primary)] bg-[var(--primary)]",
+    kind: "success",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "pending") {
+    return (
+      <span className="relative flex size-3 items-center justify-center rounded-full border-2 border-fd-border bg-[var(--background)]">
+        <span className="size-1 rounded-full bg-fd-muted-foreground" />
+      </span>
+    );
+  }
+  if (kind === "running") {
+    return (
+      <span className="size-3 rounded-full border-2 border-[var(--primary)] bg-[var(--primary)]/10" />
+    );
+  }
+  return (
+    <span className="size-3 rounded-full border-2 border-[var(--primary)] bg-[var(--primary)]" />
+  );
+}
 
 export function AgentTimelineRail() {
   return (
@@ -110,7 +132,7 @@ export function AgentTimelineRail() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span className={`size-3 rounded-full ${item.swatch}`} />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/animated-beam-anatomy.tsx
+++ b/apps/docs/src/components/learn/animated-beam-anatomy.tsx
@@ -39,19 +39,35 @@ const LEGEND = [
   {
     name: "From",
     desc: "fromRef center, +startXOffset/startYOffset",
-    swatch: "bg-[var(--muted)]",
+    kind: "from",
   },
   {
     name: "To",
     desc: "toRef center, +endXOffset/endYOffset",
-    swatch: "bg-[var(--card)] ring-1 ring-fd-border ring-inset",
+    kind: "to",
   },
   {
     name: "Path",
     desc: "M start Q (mid, mid − curvature) end",
-    swatch: "bg-transparent ring-1 ring-[var(--foreground)]/50 ring-inset",
+    kind: "path",
   },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "from") {
+    return (
+      <span className="size-3 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "to") {
+    return (
+      <span className="size-3 rounded-full border border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-0.5 w-8 rounded-full bg-[var(--foreground)]/55 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function AnimatedBeamAnatomy() {
   return (
@@ -116,9 +132,7 @@ export function AnimatedBeamAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/animated-beam-gradient.tsx
+++ b/apps/docs/src/components/learn/animated-beam-gradient.tsx
@@ -51,19 +51,35 @@ const LEGEND = [
   {
     name: "Gradient",
     desc: "x1/x2 tween 10%→110%, linear, 3s, infinite",
-    swatch: "bg-[var(--primary)]",
+    kind: "gradient",
   },
   {
     name: "Path",
     desc: "static, pathOpacity 0.2 — never redrawn for this",
-    swatch: "bg-transparent ring-1 ring-[var(--foreground)]/40 ring-inset",
+    kind: "path",
   },
   {
     name: "Reverse",
     desc: "flips the array: 90%→−10% instead",
-    swatch: "bg-[var(--primary)]/40",
+    kind: "reverse",
   },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "gradient") {
+    return (
+      <span className="size-3.5 rounded-full bg-[var(--primary)] blur-[2px] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "path") {
+    return (
+      <span className="h-0.5 w-8 rounded-full bg-[var(--foreground)]/20 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="size-3 rounded-full bg-[var(--primary)]/40 ring-1 ring-fd-border ring-inset [transform:scaleX(-1)]" />
+  );
+}
 
 export function AnimatedBeamGradient() {
   return (
@@ -156,9 +172,7 @@ export function AnimatedBeamGradient() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/animated-beam-measure.tsx
+++ b/apps/docs/src/components/learn/animated-beam-measure.tsx
@@ -51,19 +51,35 @@ const LEGEND = [
   {
     name: "From node",
     desc: "container/window resize moves it",
-    swatch: "bg-[var(--muted)]",
+    kind: "from",
   },
   {
     name: "Path",
     desc: "d re-derived from live rects, every measure",
-    swatch: "bg-transparent ring-1 ring-[var(--foreground)]/50 ring-inset",
+    kind: "path",
   },
   {
     name: "ResizeObserver",
     desc: "+ window resize listener trigger update()",
-    swatch: "bg-[var(--foreground)]",
+    kind: "observer",
   },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "from") {
+    return (
+      <span className="size-3 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "path") {
+    return (
+      <span className="h-0.5 w-8 rounded-full bg-[var(--foreground)]/55 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-3 w-6 rounded-md border border-dashed border-[var(--foreground)]/25 bg-transparent ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function AnimatedBeamMeasure() {
   return (
@@ -127,9 +143,7 @@ export function AnimatedBeamMeasure() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/animated-testimonials-anatomy.tsx
+++ b/apps/docs/src/components/learn/animated-testimonials-anatomy.tsx
@@ -28,18 +28,29 @@ const PLATES: {
   { o: 1, y: "0px", s: 1, r: "0deg", z: 3, d: "180ms" },
 ];
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: { name: string; desc: string; kind: "active" | "inactive" }[] = [
   {
     name: "Active",
     desc: "scale 1 · rotate 0 · zIndex highest",
-    swatch: "bg-[var(--foreground)]/60",
+    kind: "active",
   },
   {
     name: "Inactive",
     desc: "opacity 0.5 · scale 0.92 · keeps its rotate seed",
-    swatch: "bg-[var(--muted)]",
+    kind: "inactive",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "active") {
+    return (
+      <span className="h-4 w-6 rounded-md border border-fd-border bg-[var(--card)] shadow-sm" />
+    );
+  }
+  return (
+    <span className="h-4 w-6 rounded-md border border-fd-border bg-[var(--card)] opacity-50 shadow-sm" />
+  );
+}
 
 export function AnimatedTestimonialsAnatomy() {
   return (
@@ -77,9 +88,7 @@ export function AnimatedTestimonialsAnatomy() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/animated-testimonials-stack.tsx
+++ b/apps/docs/src/components/learn/animated-testimonials-stack.tsx
@@ -28,18 +28,33 @@ const PLATES: { r: string; delay: string }[] = [
   { r: "-3deg", delay: "-3s" },
 ];
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "active" | "seed";
+}[] = [
   {
     name: "Spring",
     desc: "stiffness 320 · damping 32 · mass 0.9",
-    swatch: "bg-[var(--foreground)]/30",
+    kind: "active",
   },
   {
     name: "Rotate seed",
     desc: "random -8°..8°, fixed once per item via useMemo",
-    swatch: "bg-[var(--foreground)]/60",
+    kind: "seed",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "seed") {
+    return (
+      <span className="h-4 w-5 rounded-2xl border border-border bg-[var(--card)] opacity-50 [transform:rotate(-8deg)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-4 w-5 rounded-2xl border border-border bg-[var(--card)] shadow-sm ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function AnimatedTestimonialsStack() {
   return (
@@ -72,9 +87,7 @@ export function AnimatedTestimonialsStack() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/animated-testimonials-words.tsx
+++ b/apps/docs/src/components/learn/animated-testimonials-words.tsx
@@ -22,18 +22,37 @@ const CSS = `
 .tw-static .tw-word { animation: none; opacity: 1; filter: none; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "word" | "stagger";
+}[] = [
   {
     name: "Per-word entrance",
     desc: "blur 6px → 0 · y 6px → 0 · opacity 0 → 1",
-    swatch: "bg-[var(--foreground)]/30",
+    kind: "word",
   },
   {
     name: "Stagger",
     desc: "delay: 0.02 × word index",
-    swatch: "bg-[var(--foreground)]/60",
+    kind: "stagger",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "stagger") {
+    return (
+      <span className="flex items-center gap-0.5">
+        <span className="h-2 w-3 rounded-full bg-[var(--foreground)]/30 ring-1 ring-fd-border ring-inset" />
+        <span className="h-2 w-4 rounded-full bg-[var(--foreground)]/30 ring-1 ring-fd-border ring-inset" />
+        <span className="h-2 w-2.5 rounded-full bg-[var(--foreground)]/30 ring-1 ring-fd-border ring-inset" />
+      </span>
+    );
+  }
+  return (
+    <span className="h-2 w-8 rounded-full bg-[var(--foreground)]/30 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function AnimatedTestimonialsWords() {
   return (
@@ -71,9 +90,7 @@ export function AnimatedTestimonialsWords() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/animated-tooltip-anatomy.tsx
+++ b/apps/docs/src/components/learn/animated-tooltip-anatomy.tsx
@@ -19,23 +19,43 @@ function Bar({ w, tone }: { w: string; tone: string }) {
   return <span className={`h-2 rounded-full ${w} ${tone}`} />;
 }
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "trigger" | "panel" | "caret";
+}[] = [
   {
     name: "trigger",
     desc: "always mounted — hover/focus flips `open`",
-    swatch: "bg-[var(--muted)]",
+    kind: "trigger",
   },
   {
     name: "panel",
     desc: "role=tooltip, only in the DOM while open",
-    swatch: "bg-[var(--foreground)]",
+    kind: "panel",
   },
   {
     name: "caret",
     desc: "2px square rotated 45°, same fill as the panel",
-    swatch: "bg-[var(--foreground)]",
+    kind: "caret",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "trigger") {
+    return (
+      <span className="size-3 rounded-full border border-border bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "caret") {
+    return (
+      <span className="size-2.5 rotate-45 bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-3.5 w-7 rounded-md bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function AnimatedTooltipAnatomy() {
   return (
@@ -75,9 +95,7 @@ export function AnimatedTooltipAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium font-mono text-[12px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/animated-tooltip-spring.tsx
+++ b/apps/docs/src/components/learn/animated-tooltip-spring.tsx
@@ -21,23 +21,43 @@ const CSS = `
 .ats-static .ats-panel { animation: none; opacity: 1; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "panel" | "overshoot" | "trigger";
+}[] = [
   {
-    name: "opacity",
-    desc: "0 → 1, tied to the same spring",
-    swatch: "bg-[var(--foreground)]/30",
+    name: "Tooltip panel",
+    desc: "opacity 0 → 1, tied to the same spring",
+    kind: "panel",
   },
   {
-    name: "scale",
-    desc: "0.85 → 1, overshoots to ~1.09 first",
-    swatch: "bg-[var(--foreground)]/60",
+    name: "Overshoot",
+    desc: "scale 0.85 → 1, overshoots to ~1.09 first",
+    kind: "overshoot",
   },
   {
-    name: "y",
+    name: "Trigger",
     desc: "8px → 0, settles a beat after scale peaks",
-    swatch: "bg-[var(--foreground)]",
+    kind: "trigger",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "trigger") {
+    return (
+      <span className="size-3 rounded-full border border-border bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "overshoot") {
+    return (
+      <span className="h-3.5 w-8 rounded-lg bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-3 w-7 rounded-lg bg-[var(--foreground)]/80 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function AnimatedTooltipSpring() {
   return (
@@ -67,9 +87,7 @@ export function AnimatedTooltipSpring() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/animated-tooltip-tilt.tsx
+++ b/apps/docs/src/components/learn/animated-tooltip-tilt.tsx
@@ -27,23 +27,46 @@ const CSS = `
 .att-static .att-panel { animation: none; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "pointer" | "rotate" | "translate";
+}[] = [
   {
-    name: "pointer x",
+    name: "Pointer",
     desc: "clientX − trigger center, raw px",
-    swatch: "bg-[var(--foreground)]/40",
+    kind: "pointer",
   },
   {
-    name: "rotate",
+    name: "Rotate",
     desc: "useTransform [-60,60] → [-14,14]",
-    swatch: "bg-[var(--foreground)]/70",
+    kind: "rotate",
   },
   {
-    name: "translateX",
+    name: "TranslateX",
     desc: "useTransform [-60,60] → [-12,12]",
-    swatch: "bg-[var(--foreground)]",
+    kind: "translate",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "pointer") {
+    return (
+      <span className="size-2 rounded-full bg-[var(--foreground)]/50 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "rotate") {
+    return (
+      <span className="h-3 w-6 rounded-lg bg-[var(--foreground)] [transform:rotate(8deg)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="relative h-3 w-7">
+      <span className="absolute inset-y-0 left-0 w-5 rounded-lg bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
+      <span className="absolute inset-y-1 left-3 w-3 rounded-lg bg-[var(--foreground)]/70 ring-1 ring-fd-border ring-inset" />
+    </span>
+  );
+}
 
 export function AnimatedTooltipTilt() {
   return (
@@ -81,9 +104,7 @@ export function AnimatedTooltipTilt() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/app-showcase-anatomy.tsx
+++ b/apps/docs/src/components/learn/app-showcase-anatomy.tsx
@@ -24,23 +24,43 @@ const CSS = `
 .asa-static .asa-panel { opacity: 1; animation: none; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "shell" | "screen" | "notch";
+}[] = [
   {
     name: "Shell",
     desc: "radius = width × 0.17, holds the padding",
-    swatch: "bg-[var(--muted)]",
+    kind: "shell",
   },
   {
     name: "Screen",
     desc: "radius = width × 0.13, inset by width × 0.035",
-    swatch: "bg-[var(--foreground)]/25",
+    kind: "screen",
   },
   {
     name: "Notch",
     desc: "width × 0.3, top-centered on the screen",
-    swatch: "bg-[var(--foreground)]/60",
+    kind: "notch",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "notch") {
+    return (
+      <span className="h-1.5 w-5 rounded-full bg-[var(--foreground)]/60 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "shell") {
+    return (
+      <span className="h-4 w-3 rounded-md bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-3.5 w-5 rounded-md bg-[var(--foreground)]/25 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function AppShowcaseAnatomy() {
   return (
@@ -117,9 +137,7 @@ export function AppShowcaseAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/app-showcase-loop.tsx
+++ b/apps/docs/src/components/learn/app-showcase-loop.tsx
@@ -17,18 +17,36 @@ const CSS = `
 .asl-static .asl-track { animation: none; transform: translateY(-22%); }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "duplicate" | "wrap";
+}[] = [
   {
     name: "Duplicate copy",
     desc: "same screenshot rendered twice, 200% track height",
-    swatch: "bg-[var(--foreground)]/25",
+    kind: "duplicate",
   },
   {
     name: "Seamless wrap",
     desc: "translateY 0 → -50%, linear — one copy's height, no seam",
-    swatch: "bg-[var(--foreground)]/60",
+    kind: "wrap",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "duplicate") {
+    return (
+      <span className="flex h-3 w-5 flex-col justify-between">
+        <span className="h-1 w-full rounded-sm bg-[var(--foreground)]/25" />
+        <span className="h-1 w-full rounded-sm bg-[var(--foreground)]/25" />
+      </span>
+    );
+  }
+  return (
+    <span className="h-4 w-3 rounded-md border border-fd-border bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 function TrackContent() {
   return (
@@ -73,9 +91,7 @@ export function AppShowcaseLoop() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/app-showcase-scroll.tsx
+++ b/apps/docs/src/components/learn/app-showcase-scroll.tsx
@@ -25,18 +25,37 @@ const CSS = `
 .ashs-static .ashs-screen { animation: none; transform: translateY(-22%); }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "entrance" | "pan";
+}[] = [
   {
     name: "Entrance",
     desc: "opacity + y + rotateX, one whileInView spring",
-    swatch: "bg-[var(--foreground)]/30",
+    kind: "entrance",
   },
   {
     name: "Scroll pan",
     desc: "y: 0% → -45%, driven by scrollYProgress",
-    swatch: "bg-[var(--foreground)]/60",
+    kind: "pan",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "entrance") {
+    return (
+      <span className="h-4 w-3 rounded-md border border-fd-border bg-[var(--muted)] [transform:rotateX(12deg)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="flex h-4 w-3 flex-col gap-0.5 overflow-hidden rounded-md border border-fd-border bg-[var(--foreground)]/10 ring-1 ring-fd-border ring-inset">
+      <span className="h-1 w-full shrink-0 rounded-sm bg-[var(--foreground)]/25" />
+      <span className="h-1 w-full shrink-0 rounded-sm bg-[var(--foreground)]/15" />
+      <span className="h-1 w-full shrink-0 rounded-sm bg-[var(--foreground)]/25" />
+    </span>
+  );
+}
 
 export function AppShowcaseScroll() {
   return (
@@ -74,9 +93,7 @@ export function AppShowcaseScroll() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/aurora-text-lifecycle.tsx
+++ b/apps/docs/src/components/learn/aurora-text-lifecycle.tsx
@@ -91,7 +91,7 @@ export function AuroraTextLifecycle() {
 
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[linear-gradient(90deg,#ff2d55,#ffd60a,#0a84ff)] ring-1 ring-fd-border ring-inset" />
+              <span className="h-3 w-7 rounded-xl bg-[linear-gradient(135deg,#ff2d55,#ffd60a,#0a84ff)] ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Playing
               </dt>
@@ -100,7 +100,7 @@ export function AuroraTextLifecycle() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[linear-gradient(90deg,#ff2d55,#ffd60a,#0a84ff)] opacity-35 ring-1 ring-fd-border ring-inset" />
+              <span className="h-3 w-7 rounded-xl bg-[linear-gradient(135deg,#ff2d55,#ffd60a,#0a84ff)] opacity-35 ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Paused
               </dt>

--- a/apps/docs/src/components/learn/aurora-text-sweep.tsx
+++ b/apps/docs/src/components/learn/aurora-text-sweep.tsx
@@ -65,7 +65,7 @@ export function AuroraTextSweep() {
 
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[linear-gradient(90deg,#ff2d55,#ffd60a,#0a84ff,#bf5af2)] ring-1 ring-fd-border ring-inset" />
+              <span className="h-3 w-8 rounded-xl bg-[linear-gradient(135deg,#ff2d55,#ffd60a,#0a84ff,#bf5af2)] ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Gradient
               </dt>
@@ -74,7 +74,7 @@ export function AuroraTextSweep() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full border-2 border-[var(--foreground)]/40 bg-transparent ring-1 ring-fd-border ring-inset" />
+              <span className="h-3 w-8 rounded-xl border-2 border-[var(--foreground)]/40 bg-transparent ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Position
               </dt>

--- a/apps/docs/src/components/learn/avatar-group-anatomy.tsx
+++ b/apps/docs/src/components/learn/avatar-group-anatomy.tsx
@@ -19,18 +19,29 @@ const CSS = `
 .aga-static .aga-avatar { opacity: 1; animation: none; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: { name: string; desc: string; kind: "avatar" | "chip" }[] = [
   {
     name: "Avatar",
     desc: "marginLeft: -12px (except the first), zIndex: i",
-    swatch: "bg-[var(--muted)]",
+    kind: "avatar",
   },
   {
     name: "+N chip",
     desc: "same row, same negative margin, one extra item",
-    swatch: "bg-[var(--foreground)]/30",
+    kind: "chip",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "avatar") {
+    return (
+      <span className="size-3 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="size-3 rounded-full bg-[var(--foreground)]/30 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function AvatarGroupAnatomy() {
   return (
@@ -75,9 +86,7 @@ export function AvatarGroupAnatomy() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/avatar-group-spread.tsx
+++ b/apps/docs/src/components/learn/avatar-group-spread.tsx
@@ -34,18 +34,37 @@ const CSS = `
 .ags-static .ags-lift { animation: none; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "spread" | "lift";
+}[] = [
   {
     name: "Group spread",
     desc: "marginLeft -12 → 4, stiffness 520 · damping 32",
-    swatch: "bg-[var(--muted)]",
+    kind: "spread",
   },
   {
     name: "Avatar lift",
     desc: "y: -6, scale: 1.06 on the hovered avatar only",
-    swatch: "bg-[var(--foreground)]/60",
+    kind: "lift",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "spread") {
+    return (
+      <span className="relative h-3 w-7">
+        <span className="absolute inset-y-0 left-0 size-3 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+        <span className="absolute inset-y-0 left-2 size-3 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+        <span className="absolute inset-y-0 left-4 size-3 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+      </span>
+    );
+  }
+  return (
+    <span className="relative size-3 rounded-full bg-[var(--muted)] ring-2 ring-background ring-inset [transform:translateY(-2px)_scale(1.06)]" />
+  );
+}
 
 export function AvatarGroupSpread() {
   return (
@@ -90,9 +109,7 @@ export function AvatarGroupSpread() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/beam-draw-anatomy.tsx
+++ b/apps/docs/src/components/learn/beam-draw-anatomy.tsx
@@ -35,19 +35,35 @@ const LEGEND = [
   {
     name: "Origin",
     desc: "shared left endpoint at (0, 200) on the 1000×400 viewBox",
-    swatch: "bg-[var(--muted)]",
+    kind: "origin",
   },
   {
     name: "Fan paths",
     desc: "DEFAULT_PATHS — four cubics ending at y 40 / 150 / 250 / 360",
-    swatch: "bg-transparent ring-1 ring-[var(--foreground)]/50 ring-inset",
+    kind: "path",
   },
   {
     name: "Ends",
     desc: "right-edge destinations; token bars stand in for node labels",
-    swatch: "bg-[var(--card)] ring-1 ring-fd-border ring-inset",
+    kind: "end",
   },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "origin") {
+    return (
+      <span className="size-3.5 rounded-lg border border-fd-border bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "path") {
+    return (
+      <span className="h-0.5 w-8 rounded-full bg-[var(--foreground)]/55 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-3 w-5 rounded-md border border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function BeamDrawAnatomy() {
   return (
@@ -114,9 +130,7 @@ export function BeamDrawAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/beam-draw-scroll.tsx
+++ b/apps/docs/src/components/learn/beam-draw-scroll.tsx
@@ -40,19 +40,37 @@ const LEGEND = [
   {
     name: "Dead zone",
     desc: "scrollYProgress < 0.1 → pathLength stays 0",
-    swatch: "bg-[var(--muted)]",
+    kind: "dead",
   },
   {
     name: "Active window",
     desc: "useTransform([0.1, 0.8], [0, 1])",
-    swatch: "bg-[var(--foreground)]/35",
+    kind: "active",
   },
   {
     name: "pathLength",
     desc: "SVG stroke fill fraction — 0 empty, 1 complete",
-    swatch: "bg-transparent ring-1 ring-[var(--foreground)]/50 ring-inset",
+    kind: "path",
   },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "dead") {
+    return (
+      <span className="relative h-3 w-10 overflow-hidden rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset">
+        <span className="absolute inset-y-0 left-[10%] w-[70%] rounded-full bg-[var(--muted)]" />
+      </span>
+    );
+  }
+  if (kind === "active") {
+    return (
+      <span className="relative h-3 w-10 overflow-hidden rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset">
+        <span className="absolute inset-y-0 left-[15%] w-[55%] rounded-full bg-[var(--foreground)]/30" />
+      </span>
+    );
+  }
+  return <span className="h-0.5 w-8 rounded-full bg-[var(--foreground)]/70" />;
+}
 
 export function BeamDrawScroll() {
   return (
@@ -111,9 +129,7 @@ export function BeamDrawScroll() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/beam-draw-spring.tsx
+++ b/apps/docs/src/components/learn/beam-draw-spring.tsx
@@ -52,19 +52,35 @@ const LEGEND = [
   {
     name: "Raw map",
     desc: "useTransform alone — hard edges at 0.1 / 0.8",
-    swatch: "bg-[var(--muted)]",
+    kind: "raw",
   },
   {
     name: "Spring",
     desc: "useSpring({ stiffness: 320, damping: 32, mass: 0.9 })",
-    swatch: "bg-[var(--foreground)]/40",
+    kind: "spring",
   },
   {
     name: "Glow",
     desc: "drop-shadow with color-mix(primary 50%, transparent)",
-    swatch: "bg-[var(--primary)]/50",
+    kind: "glow",
   },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "raw") {
+    return (
+      <span className="h-0.5 w-8 rounded-full bg-[var(--foreground)]/65 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "spring") {
+    return (
+      <span className="h-0.5 w-8 rounded-full bg-[var(--primary)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="size-3 rounded-full bg-[var(--primary)]/50 blur-[2px] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 function PathRow({
   className,
@@ -127,9 +143,7 @@ export function BeamDrawSpring() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/bento-grid-anatomy.tsx
+++ b/apps/docs/src/components/learn/bento-grid-anatomy.tsx
@@ -14,23 +14,43 @@ const CSS = `
 .bga-static .bga-cell { opacity: 1; animation: none; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "col" | "row" | "cell";
+}[] = [
   {
     name: "colSpan cell",
     desc: "spans 2 of 3 grid columns",
-    swatch: "bg-[var(--card)]",
+    kind: "col",
   },
   {
     name: "rowSpan cell",
     desc: "auto-flow drops it into the next open column, spanning 2 rows",
-    swatch: "bg-[var(--muted)]",
+    kind: "row",
   },
   {
     name: "default cell",
     desc: "1×1, fills whatever's left",
-    swatch: "bg-[var(--card)]",
+    kind: "cell",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "col") {
+    return (
+      <span className="h-3 w-8 rounded-md border border-fd-border bg-[var(--card)] shadow-sm" />
+    );
+  }
+  if (kind === "row") {
+    return (
+      <span className="h-5 w-3 rounded-md border border-fd-border bg-[var(--muted)]" />
+    );
+  }
+  return (
+    <span className="size-3.5 rounded-md border border-fd-border bg-[var(--card)] shadow-sm" />
+  );
+}
 
 export function BentoGridAnatomy() {
   return (
@@ -52,9 +72,7 @@ export function BentoGridAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/bento-grid-glow.tsx
+++ b/apps/docs/src/components/learn/bento-grid-glow.tsx
@@ -25,18 +25,33 @@ const CSS = `
 .bgg-static .bgg-glow { animation: none; opacity: 0; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "lift" | "spotlight";
+}[] = [
   {
     name: "Lift",
     desc: "translate -4px, 300ms cubic-bezier(0.3,0.7,0.4,1)",
-    swatch: "bg-[var(--card)]",
+    kind: "lift",
   },
   {
     name: "Spotlight",
     desc: "radial-gradient at --x/--y, opacity 0→1",
-    swatch: "bg-[var(--foreground)]/40",
+    kind: "spotlight",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "lift") {
+    return (
+      <span className="h-3 w-7 rounded-xl border border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="size-3.5 rounded-full bg-[var(--foreground)]/25 blur-[2px] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function BentoGridGlow() {
   return (
@@ -58,9 +73,7 @@ export function BentoGridGlow() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/bento-grid-stagger.tsx
+++ b/apps/docs/src/components/learn/bento-grid-stagger.tsx
@@ -18,18 +18,37 @@ const CSS = `
 .bgs-static .bgs-cell { opacity: 1; animation: none; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "stagger" | "spring";
+}[] = [
   {
     name: "staggerChildren",
     desc: "0.08s between each card's start",
-    swatch: "bg-[var(--foreground)]/30",
+    kind: "stagger",
   },
   {
     name: "Item spring",
     desc: "stiffness 320 · damping 32 · mass 0.9",
-    swatch: "bg-[var(--foreground)]",
+    kind: "spring",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "stagger") {
+    return (
+      <span className="flex gap-0.5">
+        <span className="h-2.5 w-2 rounded-md border border-fd-border bg-[var(--card)] opacity-40 ring-1 ring-fd-border ring-inset" />
+        <span className="h-2.5 w-2 rounded-md border border-fd-border bg-[var(--card)] opacity-70 ring-1 ring-fd-border ring-inset" />
+        <span className="h-2.5 w-2 rounded-md border border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+      </span>
+    );
+  }
+  return (
+    <span className="h-3 w-5 rounded-xl border border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function BentoGridStagger() {
   return (
@@ -61,9 +80,7 @@ export function BentoGridStagger() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/blueprint-grid-anatomy.tsx
+++ b/apps/docs/src/components/learn/blueprint-grid-anatomy.tsx
@@ -52,7 +52,10 @@ export function BlueprintGridAnatomy() {
           </div>
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span
+                className="h-3.5 w-5 rounded-md border border-fd-border ring-1 ring-fd-border ring-inset [background-image:linear-gradient(to_right,var(--border)_1px,transparent_1px),linear-gradient(to_bottom,var(--border)_1px,transparent_1px)] [background-size:6px_6px]"
+                aria-hidden="true"
+              />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Lines
               </dt>
@@ -61,7 +64,10 @@ export function BlueprintGridAnatomy() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span
+                className="h-3.5 w-5 rounded-md border border-fd-border ring-1 ring-fd-border ring-inset [background-image:radial-gradient(var(--border)_1px,transparent_1.5px)] [background-size:5px_5px]"
+                aria-hidden="true"
+              />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Dots
               </dt>

--- a/apps/docs/src/components/learn/blueprint-grid-perspective.tsx
+++ b/apps/docs/src/components/learn/blueprint-grid-perspective.tsx
@@ -50,7 +50,14 @@ export function BlueprintGridPerspective() {
           </div>
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span
+                className="h-3 w-8 rounded-sm ring-1 ring-fd-border ring-inset [transform:rotateX(72deg)]"
+                style={{
+                  backgroundImage:
+                    "linear-gradient(to right, var(--border) 1px, transparent 1px), linear-gradient(to bottom, var(--border) 1px, transparent 1px)",
+                  backgroundSize: "6px 6px",
+                }}
+              />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Tilt
               </dt>
@@ -59,7 +66,13 @@ export function BlueprintGridPerspective() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span
+                className="h-3 w-8 rounded-sm ring-1 ring-fd-border ring-inset"
+                style={{
+                  backgroundImage:
+                    "linear-gradient(to top, var(--foreground)/35 20%, transparent 95%)",
+                }}
+              />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Fade
               </dt>
@@ -68,7 +81,7 @@ export function BlueprintGridPerspective() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span className="h-3 w-8 rounded-2xl border border-dashed border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Note
               </dt>

--- a/apps/docs/src/components/learn/blueprint-grid-sweep.tsx
+++ b/apps/docs/src/components/learn/blueprint-grid-sweep.tsx
@@ -60,7 +60,7 @@ export function BlueprintGridSweep() {
           </div>
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span className="h-3 w-5 origin-center rotate-[25deg] bg-[linear-gradient(90deg,transparent,rgba(255,255,255,0.35),transparent)] blur-[1px] ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Sweep
               </dt>
@@ -69,7 +69,13 @@ export function BlueprintGridSweep() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span
+                className="size-4 rounded-full ring-1 ring-fd-border ring-inset"
+                style={{
+                  background:
+                    "radial-gradient(circle, rgba(0,0,0,0.25) 0%, transparent 70%)",
+                }}
+              />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Spotlight
               </dt>

--- a/apps/docs/src/components/learn/border-beam-anatomy.tsx
+++ b/apps/docs/src/components/learn/border-beam-anatomy.tsx
@@ -36,19 +36,35 @@ const LEGEND = [
   {
     name: "Mask ring",
     desc: "mask-intersect: padding-box + border-box — only the border shows",
-    swatch: "bg-transparent ring-2 ring-[var(--foreground)]/40 ring-inset",
+    kind: "mask",
   },
   {
     name: "Beam square",
     desc: "aspect-square, size px — longer streak when size grows",
-    swatch: "bg-[var(--foreground)]/45",
+    kind: "beam",
   },
   {
     name: "Host",
     desc: "absolute inset-0, rounded-[inherit], pointer-events-none",
-    swatch: "bg-[var(--muted)]",
+    kind: "host",
   },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "mask") {
+    return (
+      <span className="h-3.5 w-5 rounded-md bg-transparent ring-2 ring-[var(--foreground)]/40 ring-inset" />
+    );
+  }
+  if (kind === "beam") {
+    return (
+      <span className="size-2.5 rounded-sm bg-[var(--foreground)]/50 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-3.5 w-5 rounded-md bg-[var(--muted)]/40 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function BorderBeamAnatomy() {
   return (
@@ -87,9 +103,7 @@ export function BorderBeamAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/border-beam-path.tsx
+++ b/apps/docs/src/components/learn/border-beam-path.tsx
@@ -35,19 +35,32 @@ const LEGEND = [
   {
     name: "Clockwise",
     desc: "offsetDistance [initialOffset%, 100 + initialOffset%]",
-    swatch: "bg-[var(--foreground)]/50",
+    kind: "cw",
   },
   {
     name: "Reverse",
     desc: "swaps to [100 − initial%, −initial%] — still linear forward",
-    swatch: "bg-[var(--muted)] ring-1 ring-[var(--foreground)]/30 ring-inset",
+    kind: "ccw",
   },
   {
     name: "Loop",
     desc: "repeat: Infinity, ease: linear, duration (default 6s)",
-    swatch: "bg-transparent ring-1 ring-fd-border ring-inset",
+    kind: "loop",
   },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "loop") {
+    return (
+      <span className="size-3 rounded-md border border-fd-border bg-transparent ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span
+      className={`size-2.5 rounded-sm bg-[var(--foreground)]/55 ring-1 ring-fd-border ring-inset ${kind === "ccw" ? "[transform:rotate(180deg)]" : ""}`}
+    />
+  );
+}
 
 function Track({ beamClass }: { beamClass: string }) {
   return (
@@ -86,9 +99,7 @@ export function BorderBeamPath() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/border-beam-rainbow.tsx
+++ b/apps/docs/src/components/learn/border-beam-rainbow.tsx
@@ -41,20 +41,35 @@ const LEGEND = [
   {
     name: "Rainbow",
     desc: "RAINBOW_BEAM — same hue order as MagicButton, trails to transparent",
-    swatch:
-      "bg-[linear-gradient(90deg,var(--rainbow-1),var(--rainbow-5),var(--rainbow-3),var(--rainbow-4))]",
+    kind: "rainbow",
   },
   {
     name: "Two-color",
     desc: "from-(--color-from) via-(--color-to) to-transparent",
-    swatch: "bg-[linear-gradient(90deg,var(--chart-1),var(--chart-5))]",
+    kind: "twoColor",
   },
   {
     name: "Glow echo",
     desc: "second square: opacity-60 blur-md, same animate/transition",
-    swatch: "bg-[var(--foreground)]/25 blur-[2px]",
+    kind: "glow",
   },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "rainbow") {
+    return (
+      <span className="size-2.5 rounded-sm bg-[linear-gradient(90deg,var(--rainbow-1),var(--rainbow-5),var(--rainbow-3),var(--rainbow-4))] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "twoColor") {
+    return (
+      <span className="size-2.5 rounded-sm bg-[linear-gradient(90deg,var(--chart-1),var(--chart-5))] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="size-3 rounded-sm bg-[var(--foreground)]/25 blur-[2px] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function BorderBeamRainbow() {
   return (
@@ -99,9 +114,7 @@ export function BorderBeamRainbow() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/card-swap-anatomy.tsx
+++ b/apps/docs/src/components/learn/card-swap-anatomy.tsx
@@ -30,18 +30,29 @@ function plateStyle(rank: number): CSSProperties {
   } as CSSProperties;
 }
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: { name: string; desc: string; kind: "front" | "back" }[] = [
   {
     name: "rank 0 (front)",
     desc: "x 0 · y 0 · scale 1 · rotate 0°",
-    swatch: "bg-[var(--card)]",
+    kind: "front",
   },
   {
     name: "rank 1–3 (back)",
     desc: "each step: +22px x, −28px y, −0.06 scale, −2.5°",
-    swatch: "bg-[var(--muted)]",
+    kind: "back",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "front") {
+    return (
+      <span className="h-4 w-6 rounded-md border border-fd-border bg-[var(--card)] shadow-sm" />
+    );
+  }
+  return (
+    <span className="h-4 w-6 rounded-md border border-fd-border bg-[var(--card)] opacity-70 shadow-sm" />
+  );
+}
 
 export function CardSwapAnatomy() {
   return (
@@ -66,9 +77,7 @@ export function CardSwapAnatomy() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/card-swap-cycle.tsx
+++ b/apps/docs/src/components/learn/card-swap-cycle.tsx
@@ -84,7 +84,7 @@ export function CardSwapCycle() {
 
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/30 ring-1 ring-fd-border ring-inset" />
+              <span className="h-4 w-5 rounded-2xl border border-fd-border bg-[var(--card)] shadow-md ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Front → back
               </dt>
@@ -93,7 +93,10 @@ export function CardSwapCycle() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
+              <span className="relative h-4 w-5">
+                <span className="absolute inset-0 translate-x-1 -translate-y-1 scale-[0.94] rounded-2xl border border-fd-border bg-[var(--card)] opacity-70 ring-1 ring-fd-border ring-inset" />
+                <span className="absolute inset-0 rounded-2xl border border-fd-border bg-[var(--card)] shadow-sm ring-1 ring-fd-border ring-inset" />
+              </span>
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Everyone else
               </dt>

--- a/apps/docs/src/components/learn/card-swap-tilt.tsx
+++ b/apps/docs/src/components/learn/card-swap-tilt.tsx
@@ -58,7 +58,7 @@ export function CardSwapTilt() {
 
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/30 ring-1 ring-fd-border ring-inset" />
+              <span className="size-2 rounded-full bg-[var(--foreground)]/50 ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Pointer map
               </dt>
@@ -67,7 +67,7 @@ export function CardSwapTilt() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
+              <span className="h-4 w-5 rounded-2xl border border-fd-border bg-[var(--card)] shadow-md [transform:rotateX(6deg)_rotateY(7deg)] ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Spring
               </dt>

--- a/apps/docs/src/components/learn/combobox-anatomy.tsx
+++ b/apps/docs/src/components/learn/combobox-anatomy.tsx
@@ -30,23 +30,38 @@ const CSS = `
 .ca-static .ca-row { opacity: 1; animation: none; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "input" | "listbox" | "row";
+}[] = [
   {
     name: "Input",
     desc: "role=combobox · aria-autocomplete=list",
-    swatch: "bg-[var(--card)]",
+    kind: "input",
   },
   {
     name: "Listbox popover",
     desc: "AnimatePresence sibling · origin-top",
-    swatch: "bg-[var(--foreground)]/15",
+    kind: "listbox",
   },
   {
     name: "Option row",
     desc: "label + description · check when selected",
-    swatch: "bg-[var(--foreground)]/30",
+    kind: "row",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "input" || kind === "listbox") {
+    return (
+      <span className="h-3.5 w-7 rounded-md border border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/30 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function ComboboxAnatomy() {
   return (
@@ -117,9 +132,7 @@ export function ComboboxAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/combobox-race.tsx
+++ b/apps/docs/src/components/learn/combobox-race.tsx
@@ -37,18 +37,30 @@ const CSS = `
 .cr-static .cr-reject  { opacity: 0; animation: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "current" | "stale";
+}[] = [
   {
     name: "Current request",
     desc: "id === reqId.current — result applied",
-    swatch: "bg-[var(--foreground)]/30",
+    kind: "current",
   },
   {
     name: "Stale request",
     desc: "resolves late — dropped by the id guard",
-    swatch: "bg-[var(--foreground)]/10",
+    kind: "stale",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  return (
+    <span
+      className={`h-2 w-6 rounded-md ring-1 ring-fd-border ring-inset ${kind === "current" ? "bg-[var(--foreground)]/30" : "bg-[var(--foreground)]/10"}`}
+    />
+  );
+}
 
 function Track({
   pillClass,
@@ -130,9 +142,7 @@ export function ComboboxRace() {
           <dl className="grid w-full max-w-[320px] grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/comment-pin-anatomy.tsx
+++ b/apps/docs/src/components/learn/comment-pin-anatomy.tsx
@@ -18,18 +18,29 @@ const CSS = `
 .cpa-static .cpa-el { opacity: 1; animation: none; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: { name: string; desc: string; kind: "pin" | "panel" }[] = [
   {
     name: "Pin",
     desc: "rounded-full rounded-bl-sm, presence color, initials or a dot",
-    swatch: "bg-[var(--foreground)]/70",
+    kind: "pin",
   },
   {
     name: "Thread panel",
     desc: "absolute left-0 top-9, origin-top-left, anchored to the pin",
-    swatch: "bg-[var(--card)]",
+    kind: "panel",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "pin") {
+    return (
+      <span className="size-3 rounded-full rounded-bl-sm bg-[var(--foreground)]/70 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-3.5 w-6 rounded-md border border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function CommentPinAnatomy() {
   return (
@@ -74,9 +85,7 @@ export function CommentPinAnatomy() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/comment-pin-resolved.tsx
+++ b/apps/docs/src/components/learn/comment-pin-resolved.tsx
@@ -60,7 +60,9 @@ export function CommentPinResolved() {
 
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--primary)] ring-1 ring-fd-border ring-inset" />
+              <span className="flex size-4 items-center justify-center rounded-full rounded-bl-sm bg-[var(--primary)] shadow-sm ring-2 ring-fd-card">
+                <span className="size-1 rounded-full bg-white" />
+              </span>
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Active
               </dt>
@@ -69,7 +71,9 @@ export function CommentPinResolved() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--primary)] opacity-60 [filter:grayscale(1)] ring-1 ring-fd-border ring-inset" />
+              <span className="flex size-4 scale-[0.85] items-center justify-center rounded-full rounded-bl-sm bg-[var(--primary)] shadow-sm ring-2 ring-fd-card [filter:grayscale(1)] [opacity:0.6]">
+                <span className="size-1 rounded-full bg-white" />
+              </span>
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Resolved
               </dt>

--- a/apps/docs/src/components/learn/comment-pin-spring.tsx
+++ b/apps/docs/src/components/learn/comment-pin-spring.tsx
@@ -27,18 +27,33 @@ const CSS = `
 .cps-static .cps-pop { animation: none; opacity: 1; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "pin" | "panel";
+}[] = [
   {
     name: "Pin spring",
     desc: "stiffness: 520, damping: 32 — snaps in first",
-    swatch: "bg-[var(--foreground)]/70",
+    kind: "pin",
   },
   {
     name: "Panel spring",
     desc: "stiffness: 320, damping: 32, mass: 0.9 — softer, follows",
-    swatch: "bg-[var(--card)]",
+    kind: "panel",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "pin") {
+    return (
+      <span className="size-3 rounded-full rounded-bl-sm bg-[var(--foreground)]/70 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-3 w-6 rounded-xl border border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function CommentPinSpring() {
   return (
@@ -78,9 +93,7 @@ export function CommentPinSpring() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/confetti-anatomy.tsx
+++ b/apps/docs/src/components/learn/confetti-anatomy.tsx
@@ -55,19 +55,35 @@ const LEGEND = [
   {
     name: "spread",
     desc: "70° cone — how wide the burst fans",
-    swatch: "bg-[var(--muted)]",
+    kind: "spread",
   },
   {
     name: "startVelocity",
     desc: "45 — how far chips travel from origin",
-    swatch: "bg-[var(--foreground)]/40",
+    kind: "velocity",
   },
   {
     name: "particleCount",
     desc: "120 pieces per fire(); origin.y defaults to 0.7",
-    swatch: "bg-[var(--card)] ring-1 ring-fd-border ring-inset",
+    kind: "particle",
   },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "spread") {
+    return (
+      <span className="h-3.5 w-5 bg-[var(--foreground)]/12 ring-1 ring-[var(--foreground)]/30 ring-inset [clip-path:polygon(50%_100%,0_0,100%_0)]" />
+    );
+  }
+  if (kind === "velocity") {
+    return (
+      <span className="h-2 w-3 rounded-[2px] bg-[var(--foreground)]/45 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-2 w-2.5 rounded-[2px] bg-[var(--foreground)]/45 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function ConfettiAnatomy() {
   return (
@@ -131,9 +147,7 @@ export function ConfettiAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/confetti-api.tsx
+++ b/apps/docs/src/components/learn/confetti-api.tsx
@@ -50,19 +50,37 @@ const LEGEND = [
   {
     name: "ConfettiButton",
     desc: "click → rect origin → fire",
-    swatch: "bg-[var(--muted)]",
+    kind: "btn",
   },
   {
     name: "Confetti.fire()",
     desc: "imperative ref — toast()-style ergonomics",
-    swatch: "bg-[var(--foreground)]/40",
+    kind: "ref",
   },
   {
     name: "confetti()",
     desc: "bare helper; all three honor disableForReducedMotion",
-    swatch: "bg-[var(--card)] ring-1 ring-fd-border ring-inset",
+    kind: "fn",
   },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "btn") {
+    return (
+      <span className="h-2.5 w-7 rounded-md bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "ref") {
+    return (
+      <span className="relative flex size-3 items-center justify-center rounded-full border border-fd-border bg-[var(--muted)] ring-1 ring-fd-border ring-inset">
+        <span className="size-1.5 rounded-full bg-[var(--foreground)]/50" />
+      </span>
+    );
+  }
+  return (
+    <span className="flex size-3 items-center justify-center rounded-lg border border-dashed border-fd-border bg-[var(--muted)]/50 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function ConfettiApi() {
   return (
@@ -107,9 +125,7 @@ export function ConfettiApi() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/confetti-origin.tsx
+++ b/apps/docs/src/components/learn/confetti-origin.tsx
@@ -54,19 +54,35 @@ const LEGEND = [
   {
     name: "Button rect",
     desc: "e.currentTarget.getBoundingClientRect()",
-    swatch: "bg-[var(--muted)]",
+    kind: "button",
   },
   {
     name: "Normalized origin",
     desc: "x = (left + w/2) / innerWidth · y = (top + h/2) / innerHeight",
-    swatch: "bg-[var(--foreground)]/45",
+    kind: "origin",
   },
   {
     name: "Burst",
     desc: "canvasConfetti({ ...DEFAULTS, origin: { x, y }, ...options })",
-    swatch: "bg-[var(--card)] ring-1 ring-fd-border ring-inset",
+    kind: "burst",
   },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "button") {
+    return (
+      <span className="h-2.5 w-7 rounded-lg border border-fd-border bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "origin") {
+    return (
+      <span className="size-2 rounded-full bg-[var(--foreground)]/60 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-1.5 w-2.5 rounded-[1px] bg-[var(--foreground)]/40 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function ConfettiOrigin() {
   return (
@@ -117,9 +133,7 @@ export function ConfettiOrigin() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/container-scroll-anatomy.tsx
+++ b/apps/docs/src/components/learn/container-scroll-anatomy.tsx
@@ -18,18 +18,31 @@ const CSS = `
 .csra-static .csra-frame { opacity: 1; animation: none; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: { name: string; desc: string; kind: "header" | "frame" }[] = [
   {
     name: "Header",
     desc: "translateY 0 → -100 as the section scrolls",
-    swatch: "bg-[var(--foreground)]/30",
+    kind: "header",
   },
   {
     name: "Frame",
     desc: "rotateX 20° → 0°, scale 1.05 → 1, in its own 3D stage",
-    swatch: "bg-[var(--muted)]",
+    kind: "frame",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "header") {
+    return (
+      <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/30 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-3.5 w-6 rounded-md border border-fd-border bg-[var(--card)] p-0.5 ring-1 ring-fd-border ring-inset">
+      <span className="block h-full w-full rounded-[3px] bg-[var(--muted)]" />
+    </span>
+  );
+}
 
 export function ContainerScrollAnatomy() {
   return (
@@ -57,9 +70,7 @@ export function ContainerScrollAnatomy() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/container-scroll-scrub.tsx
+++ b/apps/docs/src/components/learn/container-scroll-scrub.tsx
@@ -25,6 +25,24 @@ const CSS = `
 .csrs-static .csrs-track { animation: none; transform: scaleX(0.5); }
 `;
 
+function LegendSwatch({ kind }: { kind: "frame" | "header" | "track" }) {
+  if (kind === "header") {
+    return (
+      <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/50 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "track") {
+    return (
+      <span className="relative h-1 w-8 overflow-hidden rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset">
+        <span className="absolute inset-y-0 left-0 w-1/2 rounded-full bg-[var(--foreground)]/60" />
+      </span>
+    );
+  }
+  return (
+    <span className="h-3 w-6 rounded-xl border border-fd-border bg-[var(--card)] [transform:rotateX(12deg)_scale(1.05)] ring-1 ring-fd-border ring-inset" />
+  );
+}
+
 export function ContainerScrollScrub() {
   return (
     <ScrollScene label="The scrub" note="one scrollYProgress, three transforms">
@@ -56,25 +74,29 @@ export function ContainerScrollScrub() {
 
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/30 ring-1 ring-fd-border ring-inset" />
+              <LegendSwatch kind="frame" />
               <dt className="font-medium font-mono text-[12px] text-fd-foreground">
-                rotateX
+                frame
               </dt>
-              <dd className="text-[11px] text-fd-muted-foreground">20° → 0°</dd>
+              <dd className="text-[11px] text-fd-muted-foreground">
+                rotateX 20°→0° · scale 1.05→1
+              </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/50 ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium font-mono text-[12px] text-fd-foreground">
-                scale
-              </dt>
-              <dd className="text-[11px] text-fd-muted-foreground">1.05 → 1</dd>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
+              <LegendSwatch kind="header" />
               <dt className="font-medium font-mono text-[12px] text-fd-foreground">
                 header y
               </dt>
               <dd className="text-[11px] text-fd-muted-foreground">0 → -100</dd>
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <LegendSwatch kind="track" />
+              <dt className="font-medium font-mono text-[12px] text-fd-foreground">
+                progress
+              </dt>
+              <dd className="text-[11px] text-fd-muted-foreground">
+                scrollYProgress fill
+              </dd>
             </div>
           </dl>
         </div>

--- a/apps/docs/src/components/learn/context-menu-anatomy.tsx
+++ b/apps/docs/src/components/learn/context-menu-anatomy.tsx
@@ -26,28 +26,51 @@ function Bar({
   return <span className={`h-2 rounded-full ${w} ${tone}`} />;
 }
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "label" | "item" | "separator" | "destructive";
+}[] = [
   {
     name: "label",
     desc: "muted header, not focusable",
-    swatch: "bg-[var(--foreground)]/20",
+    kind: "label",
   },
   {
     name: "item",
     desc: "icon · label · shortcut",
-    swatch: "bg-[var(--foreground)]/30",
+    kind: "item",
   },
   {
     name: "separator",
     desc: "a hairline <hr>",
-    swatch: "bg-[var(--foreground)]/15",
+    kind: "separator",
   },
   {
     name: "destructive",
     desc: "red tint, same row",
-    swatch: "bg-destructive/70",
+    kind: "destructive",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "separator") {
+    return <span className="h-px w-8 bg-border" />;
+  }
+  if (kind === "destructive") {
+    return (
+      <span className="h-1.5 w-8 rounded-full bg-destructive/70 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "label") {
+    return (
+      <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/20 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/30 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function ContextMenuAnatomy() {
   return (
@@ -118,9 +141,7 @@ export function ContextMenuAnatomy() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5 sm:grid-cols-4">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium font-mono text-[12px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/context-menu-flip.tsx
+++ b/apps/docs/src/components/learn/context-menu-flip.tsx
@@ -84,7 +84,10 @@ export function ContextMenuFlip() {
 
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/30 ring-1 ring-fd-border ring-inset" />
+              <span className="relative h-3 w-6">
+                <span className="absolute top-0 left-0 size-1.5 rounded-sm bg-[var(--foreground)]" />
+                <span className="absolute top-1 left-2 h-2.5 w-4 rounded-lg border border-border bg-background ring-1 ring-fd-border ring-inset" />
+              </span>
               <dt className="font-medium font-mono text-[12px] text-fd-foreground">
                 no flip
               </dt>
@@ -93,7 +96,10 @@ export function ContextMenuFlip() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/30 ring-1 ring-fd-border ring-inset" />
+              <span className="relative h-3 w-6">
+                <span className="absolute right-0 bottom-0 h-2.5 w-4 rounded-lg border border-border bg-background ring-1 ring-fd-border ring-inset" />
+                <span className="absolute right-0 bottom-0 size-1.5 rotate-180 rounded-sm bg-[var(--foreground)]" />
+              </span>
               <dt className="font-medium font-mono text-[12px] text-fd-foreground">
                 flipX · flipY
               </dt>

--- a/apps/docs/src/components/learn/conversation-thread-anatomy.tsx
+++ b/apps/docs/src/components/learn/conversation-thread-anatomy.tsx
@@ -19,23 +19,43 @@ const CSS = `
 .cta-static .cta-msg { opacity: 1; animation: none; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "user" | "assistant" | "actions";
+}[] = [
   {
     name: "User bubble",
     desc: "bg-primary, row reversed, rounded-br-md",
-    swatch: "bg-[var(--foreground)]/70",
+    kind: "user",
   },
   {
     name: "Assistant bubble",
     desc: "bg-muted, rounded-bl-md",
-    swatch: "bg-[var(--muted)]",
+    kind: "assistant",
   },
   {
     name: "Actions row",
     desc: "opacity-0 → 100 on hover, px-1 below the bubble",
-    swatch: "bg-[var(--foreground)]/15",
+    kind: "actions",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "user") {
+    return (
+      <span className="h-3.5 w-6 rounded-md bg-[var(--foreground)]/70 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "assistant") {
+    return (
+      <span className="h-3.5 w-6 rounded-md bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="size-2.5 rounded-md bg-[var(--foreground)]/15 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function ConversationThreadAnatomy() {
   return (
@@ -96,9 +116,7 @@ export function ConversationThreadAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ring-1 ring-fd-border ring-inset ${item.swatch}`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/conversation-thread-scroll.tsx
+++ b/apps/docs/src/components/learn/conversation-thread-scroll.tsx
@@ -30,24 +30,45 @@ const CSS = `
 
 const ROWS: string[] = ["w-24", "w-32", "w-20", "w-28", "w-16", "w-32"];
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "row" | "threshold" | "pill";
+}[] = [
   {
     name: "Message row",
     desc: "content taller than the viewport, scrolls under it",
-    swatch: "bg-[var(--foreground)]/25",
+    kind: "row",
   },
   {
     name: "48px threshold",
     desc: "scrollHeight − scrollTop − clientHeight",
-    swatch:
-      "border-t border-dashed border-[var(--foreground)]/40 bg-transparent",
+    kind: "threshold",
   },
   {
     name: "Jump-to-latest pill",
     desc: "sticky bottom-2, spring opacity/y/scale",
-    swatch: "bg-[var(--popover)]",
+    kind: "pill",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "row") {
+    return (
+      <span className="h-2.5 w-10 rounded-full bg-[var(--foreground)]/25 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "threshold") {
+    return (
+      <span className="h-px w-8 border-t border-dashed border-[var(--foreground)]/40" />
+    );
+  }
+  return (
+    <span className="flex size-4 items-center justify-center rounded-full border border-fd-border bg-[var(--popover)] shadow-sm">
+      <span className="size-1.5 rounded-full bg-[var(--foreground)]/70" />
+    </span>
+  );
+}
 
 function ArrowDownIcon({ className }: { className?: string }) {
   return (
@@ -106,9 +127,7 @@ export function ConversationThreadScroll() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ring-1 ring-fd-border ring-inset ${item.swatch}`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/conversation-thread-stream.tsx
+++ b/apps/docs/src/components/learn/conversation-thread-stream.tsx
@@ -39,23 +39,43 @@ const CHUNKS: { w: string; delay: string }[] = [
   { w: "w-12", delay: "450ms" },
 ];
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "chunk" | "caret" | "cadence";
+}[] = [
   {
     name: "Token chunk",
     desc: "count += chunk (2 chars) per tick",
-    swatch: "bg-[var(--foreground)]/45",
+    kind: "chunk",
   },
   {
     name: "Caret",
     desc: "animate-pulse, only while streaming is true",
-    swatch: "bg-[var(--foreground)]",
+    kind: "caret",
   },
   {
     name: "Cadence",
     desc: "setInterval every speed (24ms)",
-    swatch: "bg-[var(--foreground)]/20",
+    kind: "cadence",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "caret") {
+    return (
+      <span className="inline-block h-3 w-[2px] rounded-full bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "cadence") {
+    return (
+      <span className="h-1.5 w-5 rounded-full bg-[var(--foreground)]/20 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-1.5 w-6 rounded-full bg-[var(--foreground)]/45 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function ConversationThreadStream() {
   return (
@@ -92,9 +112,7 @@ export function ConversationThreadStream() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ring-1 ring-fd-border ring-inset ${item.swatch}`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/cover-flow-anatomy.tsx
+++ b/apps/docs/src/components/learn/cover-flow-anatomy.tsx
@@ -33,18 +33,33 @@ const CSS = `
 .cfa-static .cfa-slide { animation: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "center" | "neighbour";
+}[] = [
   {
     name: "Center slide",
     desc: "offset 0 — flat, full scale, faces the camera",
-    swatch: "bg-[var(--foreground)]/70",
+    kind: "center",
   },
   {
     name: "Neighbours",
     desc: "offset ±1, ±2 — rotateY, translateZ, and scale by distance",
-    swatch: "bg-[var(--muted)]",
+    kind: "neighbour",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "center") {
+    return (
+      <span className="h-3.5 w-5 rounded-md bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-3.5 w-5 rounded-md bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function CoverFlowAnatomy() {
   return (
@@ -94,9 +109,7 @@ export function CoverFlowAnatomy() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/cover-flow-fan.tsx
+++ b/apps/docs/src/components/learn/cover-flow-fan.tsx
@@ -59,18 +59,43 @@ ${Array.from({ length: COUNT })
 .cff-static .cff-card { animation: none !important; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "pointer" | "active" | "neighbor";
+}[] = [
   {
-    name: "Drag",
-    desc: "active = dragFrom − offset.x / spacing, live while dragging",
-    swatch: "bg-[var(--foreground)]/30",
+    name: "Pointer",
+    desc: "pan live — active ← offset.x / spacing",
+    kind: "pointer",
   },
   {
-    name: "Flick",
-    desc: "|velocity.x| > 600 nudges one extra slide on release",
-    swatch: "bg-[var(--foreground)]",
+    name: "Active slide",
+    desc: "foreground plate at offset 0",
+    kind: "active",
+  },
+  {
+    name: "Neighbours",
+    desc: "muted plates · flick |vx| > 600 nudges +1",
+    kind: "neighbor",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "pointer") {
+    return (
+      <span className="size-2.5 rounded-full bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "active") {
+    return (
+      <span className="h-3.5 w-5 rounded-md bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-3.5 w-5 rounded-md bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function CoverFlowFan() {
   return (
@@ -144,12 +169,10 @@ export function CoverFlowFan() {
             </div>
           </div>
 
-          <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
+          <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/decorative-background-anatomy.tsx
+++ b/apps/docs/src/components/learn/decorative-background-anatomy.tsx
@@ -38,7 +38,10 @@ export function DecorativeBackgroundAnatomy() {
           </div>
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span
+                className="h-3.5 w-5 rounded-md ring-1 ring-fd-border ring-inset [background:radial-gradient(125%_125%_at_50%_10%,#fff_40%,#a1a1aa_100%)]"
+                aria-hidden="true"
+              />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Wash
               </dt>
@@ -47,7 +50,10 @@ export function DecorativeBackgroundAnatomy() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span
+                className="h-3.5 w-5 rounded-md border border-fd-border bg-transparent ring-1 ring-fd-border ring-inset"
+                aria-hidden="true"
+              />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Shell
               </dt>

--- a/apps/docs/src/components/learn/decorative-background-presets.tsx
+++ b/apps/docs/src/components/learn/decorative-background-presets.tsx
@@ -41,7 +41,13 @@ export function DecorativeBackgroundPresets() {
           </div>
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span
+                className="h-3 w-5 rounded-xl border border-fd-border ring-1 ring-fd-border ring-inset"
+                style={{
+                  background:
+                    "radial-gradient(125% 125% at 50% 10%, #fff 40%, #a1a1aa 100%)",
+                }}
+              />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Top
               </dt>
@@ -50,7 +56,13 @@ export function DecorativeBackgroundPresets() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span
+                className="h-3 w-5 rounded-xl border border-fd-border ring-1 ring-fd-border ring-inset"
+                style={{
+                  background:
+                    "radial-gradient(125% 125% at 50% 90%, #fff 40%, #a1a1aa 100%)",
+                }}
+              />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Bottom
               </dt>
@@ -59,7 +71,13 @@ export function DecorativeBackgroundPresets() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span
+                className="h-3 w-5 rounded-xl border border-fd-border ring-1 ring-fd-border ring-inset"
+                style={{
+                  background:
+                    "radial-gradient(ellipse at 100% 0%, #d4d4d8 0%, transparent 55%), #fafafa",
+                }}
+              />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Corner
               </dt>

--- a/apps/docs/src/components/learn/decorative-background-stack.tsx
+++ b/apps/docs/src/components/learn/decorative-background-stack.tsx
@@ -40,7 +40,13 @@ export function DecorativeBackgroundStack() {
           </div>
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span
+                className="h-3 w-8 rounded-md ring-1 ring-fd-border ring-inset"
+                style={{
+                  background:
+                    "radial-gradient(125% 125% at 50% 10%, #fff 40%, #a1a1aa 100%)",
+                }}
+              />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Layer
               </dt>
@@ -49,7 +55,10 @@ export function DecorativeBackgroundStack() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span className="flex h-3 w-8 flex-col justify-end gap-0.5 rounded-md border border-fd-border bg-[var(--card)] p-0.5 ring-1 ring-fd-border ring-inset">
+                <span className="h-0.5 w-3 rounded-full bg-[var(--foreground)]/35" />
+                <span className="h-0.5 w-5 rounded-full bg-[var(--foreground)]/18" />
+              </span>
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Copy
               </dt>

--- a/apps/docs/src/components/learn/dock-anatomy.tsx
+++ b/apps/docs/src/components/learn/dock-anatomy.tsx
@@ -26,18 +26,33 @@ const CSS = `
 .da-static .da-ptr { opacity: 1; animation: none; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "bus" | "item";
+}[] = [
   {
     name: "Pointer signal",
     desc: "one mouseX MotionValue, set on every mousemove",
-    swatch: "bg-[var(--foreground)]/30",
+    kind: "bus",
   },
   {
     name: "Dock items",
     desc: "each reads its own distance off that one value",
-    swatch: "bg-[var(--muted)]",
+    kind: "item",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "bus") {
+    return (
+      <span className="h-1 w-8 rounded-full bg-[var(--foreground)]/30 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="size-3.5 rounded-md border border-border bg-[var(--muted)] shadow-sm" />
+  );
+}
 
 export function DockAnatomy() {
   return (
@@ -91,9 +106,7 @@ export function DockAnatomy() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/dock-magnify.tsx
+++ b/apps/docs/src/components/learn/dock-magnify.tsx
@@ -28,18 +28,33 @@ function cellVars(i: number): CSSProperties {
   return { "--delay": `${(i - 2) * 0.16}s` } as CSSProperties;
 }
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "base" | "magnified";
+}[] = [
   {
     name: "Distance map",
     desc: "[-distance, 0, distance] → [baseSize, magnification, baseSize]",
-    swatch: "bg-[var(--foreground)]/30",
+    kind: "base",
   },
   {
     name: "Spring",
     desc: "mass 0.1 · stiffness 170 · damping 12 chases the target size",
-    swatch: "bg-[var(--foreground)]",
+    kind: "magnified",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "magnified") {
+    return (
+      <span className="size-4 rounded-xl bg-[var(--muted)] shadow-sm ring-1 ring-fd-border ring-inset [transform:scale(1.45)]" />
+    );
+  }
+  return (
+    <span className="size-3.5 rounded-xl bg-[var(--muted)] shadow-sm ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function DockMagnify() {
   return (
@@ -75,9 +90,7 @@ export function DockMagnify() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/drawer-anatomy.tsx
+++ b/apps/docs/src/components/learn/drawer-anatomy.tsx
@@ -16,23 +16,43 @@ const CSS = `
 .dwa-static .dwa-row { opacity: 1; animation: none; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "backdrop" | "panel" | "handle";
+}[] = [
   {
     name: "backdrop",
     desc: "click-through scrim, closes on click",
-    swatch: "bg-[var(--foreground)]/10",
+    kind: "backdrop",
   },
   {
     name: "panel",
     desc: "role=dialog, pinned to one edge",
-    swatch: "bg-[var(--card)] ring-1",
+    kind: "panel",
   },
   {
     name: "handle",
     desc: "bottom only — drag target",
-    swatch: "bg-[var(--muted-foreground)]/40",
+    kind: "handle",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "backdrop") {
+    return (
+      <span className="h-3.5 w-7 rounded-md bg-[var(--foreground)]/[0.04] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "handle") {
+    return (
+      <span className="h-1.5 w-6 rounded-full bg-[var(--muted-foreground)]/40" />
+    );
+  }
+  return (
+    <span className="h-3.5 w-7 rounded-md border border-border bg-card shadow-sm" />
+  );
+}
 
 export function DrawerAnatomy() {
   return (
@@ -71,9 +91,7 @@ export function DrawerAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium font-mono text-[12px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/dropdown-menu-anatomy.tsx
+++ b/apps/docs/src/components/learn/dropdown-menu-anatomy.tsx
@@ -34,28 +34,48 @@ const CSS = `
 .dma-static .dma-row { opacity: 1; animation: none; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "label" | "item" | "separator" | "submenu";
+}[] = [
   {
     name: "label",
     desc: "muted, non-interactive heading",
-    swatch: "bg-[var(--foreground)]/15",
+    kind: "label",
   },
   {
     name: "item",
     desc: "icon · text · shortcut",
-    swatch: "bg-[var(--card)]",
+    kind: "item",
   },
   {
     name: "separator",
     desc: "a hairline <hr> between groups",
-    swatch: "bg-[var(--foreground)]/30",
+    kind: "separator",
   },
   {
     name: "submenu",
     desc: "an item with a chevron + nested list",
-    swatch: "bg-[var(--muted)]",
+    kind: "submenu",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "label") {
+    return (
+      <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/20 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "separator") {
+    return (
+      <span className="h-px w-8 rounded-full bg-[var(--border)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/35 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function DropdownMenuAnatomy() {
   return (
@@ -118,9 +138,7 @@ export function DropdownMenuAnatomy() {
           <dl className="grid w-full grid-cols-4 gap-3 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium font-mono text-[12px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/dropdown-menu-spring.tsx
+++ b/apps/docs/src/components/learn/dropdown-menu-spring.tsx
@@ -27,23 +27,43 @@ const CSS = `
 .dms-static .dms-dot   { animation: none; opacity: 1; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "trigger" | "panel" | "origin";
+}[] = [
   {
     name: "Trigger",
     desc: "the panel hangs off its edge",
-    swatch: "bg-[var(--muted)]",
+    kind: "trigger",
   },
   {
     name: "Panel",
     desc: "scale 0.94 → 1, opacity 0 → 1 on a spring",
-    swatch: "bg-[var(--card)]",
+    kind: "panel",
   },
   {
     name: "transform-origin",
     desc: "the corner it grows from",
-    swatch: "bg-[var(--foreground)]/40",
+    kind: "origin",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "trigger") {
+    return (
+      <span className="h-2 w-7 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "panel") {
+    return (
+      <span className="h-3.5 w-6 rounded-xl border border-border bg-[var(--background)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="size-2 rounded-full bg-[var(--foreground)]/60 ring-2 ring-fd-card ring-inset" />
+  );
+}
 
 export function DropdownMenuSpring() {
   return (
@@ -82,9 +102,7 @@ export function DropdownMenuSpring() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/dropdown-menu-submenu.tsx
+++ b/apps/docs/src/components/learn/dropdown-menu-submenu.tsx
@@ -36,23 +36,43 @@ const CSS = `
 .dmsub-static .dmsub-child { opacity: 1; transform: none; animation: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "row" | "panel" | "origin";
+}[] = [
   {
     name: "Parent row",
     desc: "hover or ArrowRight sets openSub",
-    swatch: "bg-[var(--muted)]",
+    kind: "row",
   },
   {
     name: "Nested panel",
     desc: "side=right, align=start, left-full ml-1",
-    swatch: "bg-[var(--card)]",
+    kind: "panel",
   },
   {
     name: "origin-top-left",
     desc: "the corner it springs from",
-    swatch: "bg-[var(--foreground)]/40",
+    kind: "origin",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "row") {
+    return (
+      <span className="h-2 w-7 rounded-md bg-[var(--foreground)]/[0.08] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "panel") {
+    return (
+      <span className="h-3.5 w-6 rounded-xl border border-border bg-[var(--background)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="size-2 rounded-full bg-[var(--foreground)]/60 ring-2 ring-fd-card ring-inset" />
+  );
+}
 
 function Row({ w, active }: { w: string; active?: boolean }) {
   return (
@@ -101,9 +121,7 @@ export function DropdownMenuSubmenu() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/dynamic-island-crossfade.tsx
+++ b/apps/docs/src/components/learn/dynamic-island-crossfade.tsx
@@ -27,18 +27,39 @@ const CSS = `
 .dic-static .dic-b { animation: none; opacity: 1; transform: scale(1); filter: blur(0px); }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "exit" | "enter";
+}[] = [
   {
     name: "Exiting view",
     desc: "opacity 1→0 · scale 1→0.9 · blur 0→4px",
-    swatch: "bg-black/50",
+    kind: "exit",
   },
   {
     name: "Entering view",
     desc: "same curve, reversed, same 0.2s",
-    swatch: "bg-black",
+    kind: "enter",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "exit") {
+    return (
+      <span className="flex h-2.5 w-7 items-center gap-1 rounded-full bg-black px-1.5 opacity-70 blur-[0.5px] ring-1 ring-fd-border ring-inset">
+        <span className="size-1 rounded-full bg-white/70" />
+        <span className="h-1 w-3 rounded-full bg-white/50" />
+      </span>
+    );
+  }
+  return (
+    <span className="flex h-2.5 w-7 items-center gap-1 rounded-full bg-black px-1.5 ring-1 ring-fd-border ring-inset">
+      <span className="size-1 rounded-full bg-white" />
+      <span className="h-1 w-4 rounded-full bg-white/80" />
+    </span>
+  );
+}
 
 export function DynamicIslandCrossfade() {
   return (
@@ -65,9 +86,7 @@ export function DynamicIslandCrossfade() {
           <dl className="grid w-full max-w-[400px] grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/effect-background-alive.tsx
+++ b/apps/docs/src/components/learn/effect-background-alive.tsx
@@ -51,7 +51,7 @@ export function EffectBackgroundAlive() {
           </p>
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span className="size-7 rounded-full bg-black/15 blur-[2px] ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Overlap
               </dt>
@@ -60,7 +60,7 @@ export function EffectBackgroundAlive() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span className="h-3 w-8 rounded-2xl border border-fd-border bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Cost
               </dt>

--- a/apps/docs/src/components/learn/effect-background-anatomy.tsx
+++ b/apps/docs/src/components/learn/effect-background-anatomy.tsx
@@ -35,7 +35,7 @@ export function EffectBackgroundAnatomy() {
           />
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span className="h-1.5 w-8 rounded-full bg-black/12 ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Blobs
               </dt>
@@ -44,7 +44,7 @@ export function EffectBackgroundAnatomy() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span className="h-1.5 w-8 rounded-full bg-[#ececee] ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Wash
               </dt>
@@ -53,7 +53,7 @@ export function EffectBackgroundAnatomy() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span className="h-1.5 w-8 rounded-full bg-[#e8e8ec] ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Base
               </dt>

--- a/apps/docs/src/components/learn/effect-background-stack.tsx
+++ b/apps/docs/src/components/learn/effect-background-stack.tsx
@@ -40,7 +40,14 @@ export function EffectBackgroundStack() {
           </div>
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span
+                className="h-3 w-8 rounded-lg ring-1 ring-fd-border ring-inset"
+                style={{
+                  backgroundColor: "#e8e8ec",
+                  backgroundImage:
+                    "radial-gradient(ellipse at 30% 20%, rgba(0,0,0,0.1), transparent 50%), linear-gradient(180deg, #f4f4f5, #e4e4e7)",
+                }}
+              />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Effect
               </dt>
@@ -49,7 +56,7 @@ export function EffectBackgroundStack() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span className="h-2 w-8 rounded-full bg-[var(--foreground)]/35 ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">UI</dt>
               <dd className="text-[12px] text-fd-muted-foreground">
                 relative z-raised

--- a/apps/docs/src/components/learn/elastic-text-anatomy.tsx
+++ b/apps/docs/src/components/learn/elastic-text-anatomy.tsx
@@ -27,18 +27,33 @@ const CSS = `
 .eta-static .eta-bar { opacity: 1; animation: none; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "segment" | "weight";
+}[] = [
   {
     name: "Segment",
     desc: "one character · data-elastic-segment",
-    swatch: "bg-[var(--foreground)]/35",
+    kind: "segment",
   },
   {
     name: "Weight axis",
     desc: "'wght' via --et-wght · min ↔ max",
-    swatch: "bg-[var(--foreground)]",
+    kind: "weight",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "weight") {
+    return (
+      <span className="h-4 w-2 rounded-sm bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-3 w-2 rounded-sm bg-[var(--foreground)]/70 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function ElasticTextAnatomy() {
   return (
@@ -75,9 +90,7 @@ export function ElasticTextAnatomy() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ring-1 ring-fd-border ring-inset ${item.swatch}`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/elastic-text-spotlight.tsx
+++ b/apps/docs/src/components/learn/elastic-text-spotlight.tsx
@@ -32,18 +32,37 @@ function barVars(i: number): CSSProperties {
   return { "--delay": `${(i / (CHARS - 1)) * -2.4}s` } as CSSProperties;
 }
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "spotlight" | "influence";
+}[] = [
   {
     name: "Spotlight",
     desc: "MotionValue · starts at −AUTO_SPREAD",
-    swatch: "bg-[var(--foreground)]/30",
+    kind: "spotlight",
   },
   {
     name: "Influence",
     desc: "clamp(1 − |i − pos| / 2.5, 0, 1)",
-    swatch: "bg-[var(--foreground)]",
+    kind: "influence",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "influence") {
+    return (
+      <span className="flex h-6 items-end">
+        <span className="h-6 w-2 rounded-sm bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
+      </span>
+    );
+  }
+  return (
+    <span className="flex h-6 items-end">
+      <span className="h-2.5 w-2 rounded-sm bg-[var(--foreground)]/35 ring-1 ring-fd-border ring-inset" />
+    </span>
+  );
+}
 
 export function ElasticTextSpotlight() {
   return (
@@ -77,9 +96,7 @@ export function ElasticTextSpotlight() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ring-1 ring-fd-border ring-inset ${item.swatch}`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/elastic-text-spring.tsx
+++ b/apps/docs/src/components/learn/elastic-text-spring.tsx
@@ -45,18 +45,37 @@ const CSS = `
 }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "target" | "spring";
+}[] = [
   {
     name: "Raw target",
     desc: "useTransform(spotlight → influence)",
-    swatch: "bg-[var(--foreground)]/30",
+    kind: "target",
   },
   {
     name: "Spring",
     desc: "stiffness 150 · damping 18 · mass 1",
-    swatch: "bg-[var(--foreground)]",
+    kind: "spring",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "spring") {
+    return (
+      <span className="flex h-6 items-end">
+        <span className="h-6 w-2 rounded-sm bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
+      </span>
+    );
+  }
+  return (
+    <span className="flex h-6 items-end">
+      <span className="h-2 w-2 rounded-sm bg-[var(--foreground)]/35 ring-1 ring-fd-border ring-inset" />
+    </span>
+  );
+}
 
 export function ElasticTextSpring() {
   return (
@@ -91,9 +110,7 @@ export function ElasticTextSpring() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ring-1 ring-fd-border ring-inset ${item.swatch}`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/encrypted-card-anatomy.tsx
+++ b/apps/docs/src/components/learn/encrypted-card-anatomy.tsx
@@ -24,14 +24,25 @@ const LEGEND = [
   {
     name: "Glyph stream",
     desc: "absolute inset-0 · STREAM_LEN 1500 · aria-hidden",
-    swatch: "bg-[var(--muted)]",
+    kind: "stream" as const,
   },
   {
     name: "Content",
     desc: "relative z-raised — children always on top",
-    swatch: "bg-[var(--card)]",
+    kind: "content" as const,
   },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "stream") {
+    return (
+      <span className="h-3 w-6 rounded-lg bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-3 w-6 rounded-lg bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function EncryptedCardAnatomy() {
   return (
@@ -86,9 +97,7 @@ export function EncryptedCardAnatomy() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/encrypted-card-mask.tsx
+++ b/apps/docs/src/components/learn/encrypted-card-mask.tsx
@@ -67,14 +67,31 @@ const LEGEND = [
   {
     name: "Stream (full)",
     desc: "always painted · opacity gated by group-hover",
-    swatch: "bg-[var(--muted)]",
+    kind: "stream" as const,
   },
   {
     name: "Radial mask",
     desc: "#000 inside → transparent outside · reveals, doesn't hide",
-    swatch: "bg-[var(--foreground)]/40",
+    kind: "mask" as const,
   },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "mask") {
+    return (
+      <span
+        className="size-6 rounded-full ring-1 ring-fd-border ring-inset"
+        style={{
+          boxShadow:
+            "0 0 0 1px color-mix(in oklab, var(--foreground) 22%, transparent)",
+        }}
+      />
+    );
+  }
+  return (
+    <span className="h-3.5 w-6 rounded-lg border border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function EncryptedCardMask() {
   return (
@@ -124,9 +141,7 @@ export function EncryptedCardMask() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/encrypted-card-scramble.tsx
+++ b/apps/docs/src/components/learn/encrypted-card-scramble.tsx
@@ -35,14 +35,27 @@ const LEGEND = [
   {
     name: "Opacity in",
     desc: "300ms ease · group-hover:[opacity:var(--stream-opacity)]",
-    swatch: "bg-[var(--foreground)]/40",
+    kind: "opacity" as const,
   },
   {
     name: "Re-randomize",
     desc: "setInterval(speed) · default 55ms · glyphs change, opacity steady",
-    swatch: "bg-[var(--muted)]",
+    kind: "scramble" as const,
   },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "scramble") {
+    return (
+      <span className="h-3.5 w-6 rounded-lg border border-fd-border bg-[var(--card)] font-mono text-[6px] leading-none text-[var(--foreground)]/50 ring-1 ring-fd-border ring-inset">
+        Xy7#
+      </span>
+    );
+  }
+  return (
+    <span className="h-3.5 w-6 rounded-lg bg-[var(--foreground)]/50 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 function ScrambleCard({ cycle, reduced }: { cycle: number; reduced: boolean }) {
   const [stream, setStream] = useState(() => randomString(STREAM_LEN));
@@ -96,9 +109,7 @@ export function EncryptedCardScramble() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/floating-toolbar-anatomy.tsx
+++ b/apps/docs/src/components/learn/floating-toolbar-anatomy.tsx
@@ -18,23 +18,43 @@ const CSS = `
 .fta-static .fta-cell { opacity: 1; animation: none; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "shell" | "action" | "active";
+}[] = [
   {
     name: "shell",
     desc: "backdrop-blur pill, role=toolbar",
-    swatch: "bg-[var(--muted)]",
+    kind: "shell",
   },
   {
     name: "action",
     desc: "an idle motion.button",
-    swatch: "bg-[var(--foreground)]/12",
+    kind: "action",
   },
   {
     name: "active",
     desc: "aria-pressed, filled fill",
-    swatch: "bg-[var(--foreground)]",
+    kind: "active",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "shell") {
+    return (
+      <span className="h-3.5 w-7 rounded-lg bg-[var(--muted)]/90 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "active") {
+    return (
+      <span className="size-3.5 rounded-lg bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="size-3.5 rounded-lg bg-[var(--foreground)]/12 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function FloatingToolbarAnatomy() {
   return (
@@ -68,9 +88,7 @@ export function FloatingToolbarAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium font-mono text-[12px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/floating-toolbar-enter.tsx
+++ b/apps/docs/src/components/learn/floating-toolbar-enter.tsx
@@ -21,23 +21,43 @@ const CSS = `
 .fte-static .fte-shell { animation: none; opacity: 1; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "enter" | "exit" | "reduced";
+}[] = [
   {
     name: "enter",
     desc: "opacity 0, y 12, scale 0.92 → spring 520/32",
-    swatch: "bg-[var(--foreground)]/60",
+    kind: "enter",
   },
   {
     name: "exit",
     desc: "opacity 0, y 8, scale 0.95 — a plain tween",
-    swatch: "bg-[var(--foreground)]/25",
+    kind: "exit",
   },
   {
     name: "reduced motion",
     desc: "collapses to an opacity-only fade",
-    swatch: "bg-[var(--foreground)]/12",
+    kind: "reduced",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "enter") {
+    return (
+      <span className="size-3.5 rounded-lg bg-[var(--foreground)]/60 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "exit") {
+    return (
+      <span className="size-3.5 rounded-lg bg-[var(--foreground)]/25 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="size-3.5 rounded-lg bg-[var(--foreground)]/12 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function FloatingToolbarEnter() {
   return (
@@ -69,9 +89,7 @@ export function FloatingToolbarEnter() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/floating-toolbar-magnetic.tsx
+++ b/apps/docs/src/components/learn/floating-toolbar-magnetic.tsx
@@ -21,23 +21,43 @@ const CSS = `
 .ftm-static .ftm-hovered { animation: none; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "idle" | "hover" | "press";
+}[] = [
   {
     name: "idle",
     desc: "resting scale, no transform",
-    swatch: "bg-[var(--foreground)]/12",
+    kind: "idle",
   },
   {
     name: "hover",
     desc: "y: -2, scale: 1.08",
-    swatch: "bg-[var(--foreground)]/60",
+    kind: "hover",
   },
   {
     name: "press",
     desc: "whileTap scale: 0.94",
-    swatch: "bg-[var(--foreground)]",
+    kind: "press",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "hover") {
+    return (
+      <span className="size-3.5 translate-y-[-1px] scale-110 rounded-lg bg-[var(--foreground)]/60 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "press") {
+    return (
+      <span className="size-3.5 scale-95 rounded-lg bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="size-3.5 rounded-lg bg-[var(--foreground)]/12 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function FloatingToolbarMagnetic() {
   return (
@@ -75,9 +95,7 @@ export function FloatingToolbarMagnetic() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/flow-field-anatomy.tsx
+++ b/apps/docs/src/components/learn/flow-field-anatomy.tsx
@@ -69,7 +69,7 @@ export function FlowFieldAnatomy() {
           </div>
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span className="h-0.5 w-8 rounded-full bg-[var(--foreground)]/30 ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Noise
               </dt>
@@ -78,7 +78,7 @@ export function FlowFieldAnatomy() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span className="h-0.5 w-8 rotate-[-25deg] rounded-full bg-[var(--foreground)]/50 ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Angle
               </dt>
@@ -87,7 +87,7 @@ export function FlowFieldAnatomy() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span className="h-0.5 w-8 rounded-full bg-[var(--foreground)]/50 ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Step
               </dt>

--- a/apps/docs/src/components/learn/flow-field-lifecycle.tsx
+++ b/apps/docs/src/components/learn/flow-field-lifecycle.tsx
@@ -155,6 +155,45 @@ const GLYPHS = {
   reduce: ReduceGlyph,
 } as const;
 
+function LegendSwatch({ id }: { id: (typeof CARDS)[number]["id"] }) {
+  if (id === "io") {
+    return (
+      <span
+        className="h-3 w-5 rounded-sm bg-[var(--foreground)]/25 ring-1 ring-fd-border ring-inset"
+        style={{
+          backgroundImage:
+            "linear-gradient(135deg, transparent 40%, rgba(0,0,0,0.12) 40%, rgba(0,0,0,0.12) 60%, transparent 60%)",
+          backgroundSize: "8px 8px",
+        }}
+      />
+    );
+  }
+  if (id === "vis") {
+    return (
+      <span className="relative h-3.5 w-5 overflow-hidden rounded-md border border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset">
+        <span className="absolute inset-x-0 top-0 h-1 border-fd-border border-b bg-[var(--muted)]" />
+        <span className="absolute inset-x-1 bottom-1 h-px rounded-full bg-[var(--foreground)]/35" />
+      </span>
+    );
+  }
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 32 12"
+      className="h-3 w-8 text-[var(--foreground)]"
+    >
+      <path
+        d="M2 8 C8 4, 12 4, 16 8 S24 10, 30 6"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        opacity={0.85}
+      />
+    </svg>
+  );
+}
+
 export function FlowFieldLifecycle() {
   return (
     <ScrollScene label="Lifecycle" note="IO · visibility · reduced">
@@ -187,7 +226,7 @@ export function FlowFieldLifecycle() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {CARDS.map((card) => (
               <div key={card.id} className="flex flex-col gap-1.5">
-                <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+                <LegendSwatch id={card.id} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {card.name}
                 </dt>

--- a/apps/docs/src/components/learn/flow-field-trails.tsx
+++ b/apps/docs/src/components/learn/flow-field-trails.tsx
@@ -51,7 +51,7 @@ export function FlowFieldTrails() {
           </p>
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span className="h-3 w-8 rounded-md bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Wipe
               </dt>
@@ -60,7 +60,7 @@ export function FlowFieldTrails() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span className="h-4 w-2 rounded-full bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Silk
               </dt>

--- a/apps/docs/src/components/learn/fluid-cursor-anatomy.tsx
+++ b/apps/docs/src/components/learn/fluid-cursor-anatomy.tsx
@@ -26,14 +26,25 @@ const LEGEND = [
   {
     name: "Trail",
     desc: "size × 2.4 · blur-md · lerp 0.12",
-    swatch: "bg-[var(--foreground)]/25",
+    kind: "trail" as const,
   },
   {
     name: "Dot",
     desc: "leading circle · lerp 0.25 · same center at rest",
-    swatch: "bg-[var(--foreground)]",
+    kind: "dot" as const,
   },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "trail") {
+    return (
+      <span className="size-4 rounded-full bg-[var(--foreground)]/20 blur-sm ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="size-2.5 rounded-full bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function FluidCursorAnatomy() {
   return (
@@ -78,9 +89,7 @@ export function FluidCursorAnatomy() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/fluid-cursor-lerp.tsx
+++ b/apps/docs/src/components/learn/fluid-cursor-lerp.tsx
@@ -37,19 +37,35 @@ const LEGEND = [
   {
     name: "Dot lerp 0.25",
     desc: "x += (tx − x) × 0.25 each frame",
-    swatch: "bg-[var(--foreground)]",
+    kind: "dot" as const,
   },
   {
     name: "Trail lerp 0.12",
     desc: "sx += (tx − sx) × 0.12 — soft lag",
-    swatch: "bg-[var(--foreground)]/25",
+    kind: "trail" as const,
   },
   {
     name: "Hover lerp 0.15",
     desc: "scale(1 + hover × 1.6) on interactive",
-    swatch: "bg-[var(--muted)]",
+    kind: "hover" as const,
   },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "trail") {
+    return (
+      <span className="size-4 rounded-full bg-[var(--foreground)]/20 blur-[1px] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "hover") {
+    return (
+      <span className="h-3.5 w-5 rounded-lg border border-fd-border bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="size-3.5 rounded-full bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function FluidCursorLerp() {
   return (
@@ -79,9 +95,7 @@ export function FluidCursorLerp() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/fluid-cursor-lifecycle.tsx
+++ b/apps/docs/src/components/learn/fluid-cursor-lifecycle.tsx
@@ -20,14 +20,28 @@ const LEGEND = [
   {
     name: "Running",
     desc: "pointer active · deltas ≥ SETTLE · rAF spinning",
-    swatch: "bg-[var(--foreground)]/60",
+    kind: "running" as const,
   },
   {
     name: "Idle",
     desc: "settled or document.hidden — raf = 0",
-    swatch: "bg-[var(--foreground)]/20",
+    kind: "idle" as const,
   },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "idle") {
+    return (
+      <span className="size-2 rounded-full bg-[var(--foreground)]/25 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="relative flex size-4 items-center justify-center">
+      <span className="size-2 rounded-full bg-[var(--foreground)]" />
+      <span className="absolute size-4 rounded-full border border-dashed border-[var(--foreground)]/30" />
+    </span>
+  );
+}
 
 export function FluidCursorLifecycle() {
   return (
@@ -70,9 +84,7 @@ export function FluidCursorLifecycle() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/fold-stages.tsx
+++ b/apps/docs/src/components/learn/fold-stages.tsx
@@ -122,7 +122,7 @@ export function FoldStages() {
 
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--card)] ring-1 ring-[var(--foreground)]/15 ring-inset" />
+              <span className="h-3.5 w-6 rounded-lg border border-[var(--foreground)]/15 bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Front face
               </dt>
@@ -131,7 +131,9 @@ export function FoldStages() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/20 ring-1 ring-fd-border ring-inset" />
+              <span className="relative h-3.5 w-6 overflow-hidden rounded-lg bg-[var(--foreground)]/[0.07] ring-1 ring-fd-border ring-inset">
+                <span className="absolute inset-y-0 left-0 w-[55%] bg-[var(--foreground)]/25" />
+              </span>
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Back layer
               </dt>

--- a/apps/docs/src/components/learn/geometric-background-anatomy.tsx
+++ b/apps/docs/src/components/learn/geometric-background-anatomy.tsx
@@ -35,7 +35,7 @@ export function GeometricBackgroundAnatomy() {
           />
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span className="h-1.5 w-8 rounded-full bg-[#e5e5e5] ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 X lines
               </dt>
@@ -44,7 +44,7 @@ export function GeometricBackgroundAnatomy() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span className="h-1.5 w-8 rounded-full bg-[#e5e5e5] ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Y lines
               </dt>

--- a/apps/docs/src/components/learn/geometric-background-composite.tsx
+++ b/apps/docs/src/components/learn/geometric-background-composite.tsx
@@ -35,7 +35,14 @@ export function GeometricBackgroundComposite() {
           />
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span
+                className="h-3 w-8 rounded-md ring-1 ring-fd-border ring-inset"
+                style={{
+                  backgroundImage:
+                    "linear-gradient(to right, #e5e5e5 1px, transparent 1px), linear-gradient(to bottom, #e5e5e5 1px, transparent 1px)",
+                  backgroundSize: "6px 6px",
+                }}
+              />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Grid
               </dt>
@@ -44,7 +51,13 @@ export function GeometricBackgroundComposite() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span
+                className="h-3 w-8 rounded-md ring-1 ring-fd-border ring-inset"
+                style={{
+                  backgroundImage:
+                    "radial-gradient(circle at 100% 40%, rgba(0,0,0,0.08), transparent 45%)",
+                }}
+              />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Glow
               </dt>

--- a/apps/docs/src/components/learn/geometric-background-mask.tsx
+++ b/apps/docs/src/components/learn/geometric-background-mask.tsx
@@ -39,7 +39,18 @@ export function GeometricBackgroundMask() {
           />
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span
+                className="h-3 w-8 rounded-md ring-1 ring-fd-border ring-inset"
+                style={{
+                  backgroundImage:
+                    "linear-gradient(to right, #d4d4d8 1px, transparent 1px), linear-gradient(to bottom, #d4d4d8 1px, transparent 1px)",
+                  backgroundSize: "6px 6px",
+                  WebkitMaskImage:
+                    "linear-gradient(to bottom, black 30%, transparent 95%)",
+                  maskImage:
+                    "linear-gradient(to bottom, black 30%, transparent 95%)",
+                }}
+              />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Mask
               </dt>
@@ -48,7 +59,13 @@ export function GeometricBackgroundMask() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span
+                className="h-3 w-8 rounded-md ring-1 ring-fd-border ring-inset"
+                style={{
+                  backgroundImage:
+                    "repeating-linear-gradient(90deg, transparent 0 3px, #d4d4d8 3px 4px), repeating-linear-gradient(0deg, transparent 0 3px, #d4d4d8 3px 4px)",
+                }}
+              />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Presets
               </dt>

--- a/apps/docs/src/components/learn/globe-anatomy.tsx
+++ b/apps/docs/src/components/learn/globe-anatomy.tsx
@@ -46,19 +46,35 @@ const LEGEND = [
   {
     name: "Canvas",
     desc: "cobe WebGL surface — createGlobe(canvas, config)",
-    swatch: "bg-[var(--muted)]",
+    kind: "canvas" as const,
   },
   {
     name: "Markers",
     desc: "config.markers — location + size, glowColor tint",
-    swatch: "bg-[var(--foreground)]/50",
+    kind: "marker" as const,
   },
   {
     name: "Drag",
     desc: "pointerMovement offsets phi while held",
-    swatch: "bg-transparent ring-1 ring-[var(--foreground)]/40 ring-inset",
+    kind: "drag" as const,
   },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "canvas") {
+    return (
+      <span className="size-3.5 rounded-full shadow-inner [background:radial-gradient(circle_at_35%_30%,var(--card),var(--muted)_65%)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "marker") {
+    return (
+      <span className="size-2 rounded-full bg-[var(--foreground)]/60 shadow-[0_0_4px_var(--foreground)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="size-3.5 rounded-full border border-[var(--foreground)]/40 bg-transparent" />
+  );
+}
 
 export function GlobeAnatomy() {
   return (
@@ -115,9 +131,7 @@ export function GlobeAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/globe-lifecycle.tsx
+++ b/apps/docs/src/components/learn/globe-lifecycle.tsx
@@ -36,19 +36,37 @@ const LEGEND = [
   {
     name: "Mount",
     desc: "createGlobe(canvas, config) + rAF loop starts",
-    swatch: "bg-[var(--foreground)]/60",
+    kind: "mount" as const,
   },
   {
     name: "Idle spin",
     desc: "tick → phi += 0.005 → globe.update(), forever",
-    swatch: "bg-[var(--foreground)]/30",
+    kind: "spin" as const,
   },
   {
     name: "Destroy",
     desc: "cleanup: cancelAnimationFrame + globe.destroy()",
-    swatch: "border border-dashed border-[var(--foreground)]/40 bg-transparent",
+    kind: "destroy" as const,
   },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "destroy") {
+    return (
+      <span className="size-4 rounded-full border border-dashed border-[var(--foreground)]/30 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "spin") {
+    return (
+      <span className="size-4 rounded-full [background:conic-gradient(from_0deg,var(--foreground)_0deg,transparent_60deg,transparent_360deg)] opacity-30 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="relative flex size-4 items-center justify-center rounded-full border border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset">
+      <span className="size-2 rounded-full bg-[var(--muted)]" />
+    </span>
+  );
+}
 
 export function GlobeLifecycle() {
   return (
@@ -107,9 +125,7 @@ export function GlobeLifecycle() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/globe-rotate.tsx
+++ b/apps/docs/src/components/learn/globe-rotate.tsx
@@ -67,19 +67,37 @@ const LEGEND = [
   {
     name: "Idle",
     desc: "phi += 0.005 every frame, nobody's touching it",
-    swatch: "bg-[var(--foreground)]/30",
+    kind: "idle" as const,
   },
   {
     name: "Drag",
     desc: "pointerMovement / 200 drives phi instead",
-    swatch: "bg-[var(--foreground)]/70",
+    kind: "drag" as const,
   },
   {
     name: "Phi",
     desc: "the one angle globe.update() sets, every frame",
-    swatch: "bg-transparent ring-1 ring-[var(--foreground)]/40 ring-inset",
+    kind: "phi" as const,
   },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "drag") {
+    return (
+      <span className="relative flex size-4 items-center justify-center rounded-full [background:repeating-linear-gradient(90deg,transparent_0px_4px,var(--foreground)_4px_5px)] opacity-[0.35] ring-1 ring-fd-border ring-inset">
+        <span className="absolute -top-0.5 size-1.5 rounded-full bg-[var(--foreground)]/70" />
+      </span>
+    );
+  }
+  if (kind === "phi") {
+    return (
+      <span className="size-4 rounded-full ring-1 ring-[var(--foreground)]/10 ring-inset" />
+    );
+  }
+  return (
+    <span className="size-4 rounded-full [background:repeating-linear-gradient(90deg,transparent_0px_4px,var(--foreground)_4px_5px)] opacity-[0.16] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 function GrabHand({ className }: { className?: string }) {
   return (
@@ -142,9 +160,7 @@ export function GlobeRotate() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/gooey-layers.tsx
+++ b/apps/docs/src/components/learn/gooey-layers.tsx
@@ -26,18 +26,35 @@ const CSS = `
 .gl-static .gl-col { opacity: 1; animation: none; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "blob" | "control";
+}[] = [
   {
     name: "Blob layer",
     desc: "soft discs under the goo filter",
-    swatch: "bg-[var(--foreground)]/20",
+    kind: "blob",
   },
   {
     name: "Control layer",
     desc: "sharp icons + hit targets",
-    swatch: "border-2 border-[var(--foreground)]/50 bg-transparent",
+    kind: "control",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "blob") {
+    return (
+      <span className="size-3.5 rounded-full bg-[var(--foreground)]/20 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="relative flex size-3.5 items-center justify-center rounded-full border-2 border-[var(--foreground)]/50 bg-transparent ring-1 ring-fd-border ring-inset">
+      <span className="size-1 rounded-full bg-[var(--foreground)]/70" />
+    </span>
+  );
+}
 
 function FabStage({
   blobs,
@@ -145,9 +162,7 @@ export function GooeyLayers() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`size-3.5 rounded-full ring-1 ring-fd-border ring-inset ${item.swatch}`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/gooey-stack-anatomy.tsx
+++ b/apps/docs/src/components/learn/gooey-stack-anatomy.tsx
@@ -18,23 +18,43 @@ const CSS = `
 .gsa-static .gsa-col { opacity: 1; animation: none; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "merge" | "native" | "content";
+}[] = [
   {
     name: "Merge surface",
     desc: "blurred silhouettes, fused by the goo filter",
-    swatch: "bg-[var(--foreground)]/25 blur-[2px]",
+    kind: "merge",
   },
   {
     name: "Native surface",
     desc: "crisp bg-card + border, pixel-perfect at rest",
-    swatch: "border border-[var(--foreground)]/50 bg-transparent",
+    kind: "native",
   },
   {
     name: "Content",
     desc: "your children — never filtered, never faded flat",
-    swatch: "bg-[var(--foreground)]/70",
+    kind: "content",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "merge") {
+    return (
+      <span className="h-3 w-6 rounded-[10px] bg-[var(--foreground)]/25 blur-[2px] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "native") {
+    return (
+      <span className="h-3 w-6 rounded-[10px] border border-[var(--foreground)]/50 bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-1.5 w-5 rounded-full bg-[var(--foreground)]/70 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 function StackPair({
   merge,
@@ -134,9 +154,7 @@ export function GooeyStackAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ring-1 ring-fd-border ring-inset ${item.swatch}`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/gradient-background-anatomy.tsx
+++ b/apps/docs/src/components/learn/gradient-background-anatomy.tsx
@@ -39,7 +39,7 @@ export function GradientBackgroundAnatomy() {
           </div>
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span className="h-1.5 w-8 rounded-full bg-[#020617] ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Base
               </dt>
@@ -48,7 +48,7 @@ export function GradientBackgroundAnatomy() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span className="h-1.5 w-8 rounded-full bg-[#3e3e3e] ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Glow
               </dt>

--- a/apps/docs/src/components/learn/gradient-background-ownership.tsx
+++ b/apps/docs/src/components/learn/gradient-background-ownership.tsx
@@ -56,7 +56,14 @@ export function GradientBackgroundOwnership() {
           </div>
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span
+                className="h-3 w-8 rounded-lg ring-1 ring-fd-border ring-inset"
+                style={{
+                  backgroundColor: "#020617",
+                  backgroundImage:
+                    "radial-gradient(circle 80px at 50% 40%, #3e3e3e, transparent)",
+                }}
+              />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Probe
               </dt>
@@ -65,7 +72,12 @@ export function GradientBackgroundOwnership() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span
+                className="h-3 w-8 rounded-lg ring-1 ring-fd-border ring-inset"
+                style={{
+                  backgroundImage: "linear-gradient(135deg, #0f172a, #312e81)",
+                }}
+              />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Merge
               </dt>

--- a/apps/docs/src/components/learn/gradient-background-stack.tsx
+++ b/apps/docs/src/components/learn/gradient-background-stack.tsx
@@ -41,7 +41,14 @@ export function GradientBackgroundStack() {
           </div>
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span
+                className="h-3 w-8 rounded-lg ring-1 ring-fd-border ring-inset"
+                style={{
+                  backgroundColor: "#020617",
+                  backgroundImage:
+                    "radial-gradient(circle 100px at 50% 30%, #444, transparent)",
+                }}
+              />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Background
               </dt>
@@ -50,7 +57,10 @@ export function GradientBackgroundStack() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span className="flex flex-col gap-0.5">
+                <span className="h-1 w-8 rounded-full bg-[var(--foreground)]/40" />
+                <span className="h-0.5 w-6 rounded-full bg-[var(--foreground)]/20" />
+              </span>
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Content
               </dt>

--- a/apps/docs/src/components/learn/gravity-anatomy.tsx
+++ b/apps/docs/src/components/learn/gravity-anatomy.tsx
@@ -16,23 +16,43 @@ const CSS = `
 .grv-static .grv-body { opacity: 1; animation: none; transform: rotate(var(--r)); }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "world" | "walls" | "body";
+}[] = [
   {
     name: "World",
     desc: "relative overflow-hidden container, sized by CSS",
-    swatch: "bg-[var(--card)] ring-1 ring-fd-border ring-inset",
+    kind: "world",
   },
   {
     name: "Walls",
     desc: "static 200px-thick rectangles just past each edge",
-    swatch: "bg-[var(--muted)]",
+    kind: "walls",
   },
   {
     name: "Body",
     desc: "one MatterBody = one rectangle or circle body",
-    swatch: "bg-[var(--foreground)]/60",
+    kind: "body",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "world") {
+    return (
+      <span className="h-3 w-6 rounded-md bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "walls") {
+    return (
+      <span className="h-1 w-6 rounded-sm bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="size-3 rounded-full bg-[var(--foreground)]/60 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function GravityAnatomy() {
   return (
@@ -72,9 +92,7 @@ export function GravityAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ring-1 ring-fd-border ring-inset ${item.swatch}`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/gravity-lifecycle.tsx
+++ b/apps/docs/src/components/learn/gravity-lifecycle.tsx
@@ -56,7 +56,7 @@ export function GravityLifecycle() {
 
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/60 ring-1 ring-fd-border ring-inset" />
+              <span className="size-3.5 rounded-[10px] bg-[var(--foreground)]/60 ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Running
               </dt>
@@ -65,7 +65,7 @@ export function GravityLifecycle() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/25 ring-1 ring-fd-border ring-inset" />
+              <span className="size-3.5 rounded-[10px] bg-[var(--foreground)]/25 ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Paused
               </dt>

--- a/apps/docs/src/components/learn/gravity-sync.tsx
+++ b/apps/docs/src/components/learn/gravity-sync.tsx
@@ -21,18 +21,33 @@ const CSS = `
 .grv-static .grv-ghost, .grv-static .grv-plate { animation: none; transform: translate(0px, 4px) rotate(-4deg); }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "body" | "plate";
+}[] = [
   {
     name: "Body (physics)",
     desc: "Matter.Body position + angle — never rendered",
-    swatch: "bg-transparent ring-1 ring-dashed ring-[var(--foreground)]/50",
+    kind: "body",
   },
   {
     name: "DOM plate",
     desc: "style.transform, rewritten every rAF",
-    swatch: "bg-[var(--foreground)]/60",
+    kind: "plate",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "body") {
+    return (
+      <span className="size-3.5 rounded-[10px] border-2 border-dashed border-[var(--foreground)]/50" />
+    );
+  }
+  return (
+    <span className="size-3.5 rounded-[10px] bg-[var(--foreground)]/60 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function GravitySync() {
   return (
@@ -64,7 +79,7 @@ export function GravitySync() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span className={`h-1.5 w-8 rounded-full ${item.swatch}`} />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/hero-parallax-anatomy.tsx
+++ b/apps/docs/src/components/learn/hero-parallax-anatomy.tsx
@@ -25,7 +25,7 @@ const LEGEND: { name: string; desc: string; swatch: string }[] = [
   {
     name: "translateX",
     desc: "rows 1 & 3 — scrollYProgress [0,1] → [0, 1000]",
-    swatch: "bg-[var(--foreground)]/70",
+    swatch: "bg-[var(--muted)]",
   },
   {
     name: "translateXReverse",
@@ -91,7 +91,7 @@ export function HeroParallaxAnatomy() {
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
                 <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
+                  className={`h-3 w-5 rounded-lg ${item.swatch} ring-1 ring-fd-border ring-inset`}
                 />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}

--- a/apps/docs/src/components/learn/hero-parallax-scrub.tsx
+++ b/apps/docs/src/components/learn/hero-parallax-scrub.tsx
@@ -40,18 +40,33 @@ const CSS = `
 .hps-static .hps-row-rev { animation: none; transform: none; opacity: 1; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "plane" | "rows";
+}[] = [
   {
     name: "Plane",
     desc: "rotateX 15→0 · rotateZ 14→0 · translateY, opacity .2→1 — first 20% of scroll",
-    swatch: "bg-[var(--foreground)]/70",
+    kind: "plane",
   },
   {
     name: "Rows",
     desc: "translateX / translateXReverse spread across the full scroll",
-    swatch: "bg-[var(--muted)]",
+    kind: "rows",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "plane") {
+    return (
+      <span className="h-3 w-8 rounded-lg border border-border bg-[var(--muted)]/60 ring-1 ring-fd-border ring-inset [transform:rotateX(12deg)_rotateZ(6deg)]" />
+    );
+  }
+  return (
+    <span className="h-3 w-5 rounded-lg border border-border bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function HeroParallaxScrub() {
   return (
@@ -91,9 +106,7 @@ export function HeroParallaxScrub() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/highlighter-anatomy.tsx
+++ b/apps/docs/src/components/learn/highlighter-anatomy.tsx
@@ -16,18 +16,33 @@ const CSS = `
 .hl-anat-static .hl-anat-col { opacity: 1; animation: none; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "text" | "annotation";
+}[] = [
   {
     name: "Text span",
     desc: "inline-block children, always in the DOM",
-    swatch: "bg-[var(--foreground)]/40",
+    kind: "text",
   },
   {
     name: "Annotation",
     desc: "rough-notation SVG, drawn over the span",
-    swatch: "border-2 border-black/50 bg-transparent",
+    kind: "annotation",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "annotation") {
+    return (
+      <span className="h-3 w-6 rounded-md border-2 border-black/45 bg-transparent ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/35 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 function TokenBar() {
   return <span className="h-2 w-14 rounded-full bg-[var(--foreground)]/35" />;
@@ -112,9 +127,7 @@ export function HighlighterAnatomy() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ring-1 ring-fd-border ring-inset ${item.swatch}`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/highlighter-draw.tsx
+++ b/apps/docs/src/components/learn/highlighter-draw.tsx
@@ -28,18 +28,33 @@ const CSS = `
 .hl-draw-static .hl-draw-panel { opacity: 1; animation: none; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "highlight" | "underline";
+}[] = [
   {
     name: "Highlight",
     desc: "pale fill grows left → right behind the text",
-    swatch: "bg-[#ffd1dc]",
+    kind: "highlight",
   },
   {
     name: "Underline",
     desc: "stroke grows left → right under the text",
-    swatch: "bg-[#60a5fa]",
+    kind: "underline",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "underline") {
+    return (
+      <span className="h-0.5 w-8 rounded-full bg-[#60a5fa] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-3 w-6 rounded-sm bg-[#ffd1dc] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function HighlighterDraw() {
   return (
@@ -89,9 +104,7 @@ export function HighlighterDraw() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ring-1 ring-fd-border ring-inset ${item.swatch}`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/highlighter-lifecycle.tsx
+++ b/apps/docs/src/components/learn/highlighter-lifecycle.tsx
@@ -51,18 +51,33 @@ const CSS = `
 .hl-life-static .hl-life-mark { animation: none; opacity: 1; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "gate" | "resize";
+}[] = [
   {
     name: "In-view gate",
     desc: "useInView once, margin −10% — annotate only when shouldShow",
-    swatch: "bg-[var(--foreground)]/35",
+    kind: "gate",
   },
   {
     name: "Resize redraw",
     desc: "ResizeObserver: hide() then show() on the same annotation",
-    swatch: "border border-dashed border-[var(--foreground)]/50 bg-transparent",
+    kind: "resize",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "resize") {
+    return (
+      <span className="h-3 w-6 rounded-lg border border-dashed border-[var(--foreground)]/30 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-3 w-6 rounded-sm bg-black/20 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function HighlighterLifecycle() {
   return (
@@ -130,9 +145,7 @@ export function HighlighterLifecycle() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ring-1 ring-fd-border ring-inset ${item.swatch}`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/hold-cancel.tsx
+++ b/apps/docs/src/components/learn/hold-cancel.tsx
@@ -68,18 +68,39 @@ function Pill({ fillClass }: { fillClass: string }) {
   );
 }
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "cancel" | "confirm";
+}[] = [
   {
     name: "Cancel",
     desc: "spring(320, 32, 0.9) back to 0",
-    swatch: "bg-[var(--foreground)]/30",
+    kind: "cancel",
   },
   {
     name: "Confirm",
     desc: "linear to 1, then check draws in 0.3s",
-    swatch: "bg-[var(--foreground)]/50",
+    kind: "confirm",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "cancel") {
+    return (
+      <span className="relative h-3.5 w-8 overflow-hidden rounded-lg ring-1 ring-fd-border ring-inset">
+        <span className="absolute inset-0 bg-[var(--foreground)]" />
+        <span className="absolute inset-y-0 left-0 w-[55%] bg-[var(--background)]/30" />
+      </span>
+    );
+  }
+  return (
+    <span className="relative h-3.5 w-8 overflow-hidden rounded-lg ring-1 ring-fd-border ring-inset">
+      <span className="absolute inset-0 bg-[var(--foreground)]" />
+      <span className="absolute inset-0 bg-[var(--background)]/30" />
+    </span>
+  );
+}
 
 export function HoldCancel() {
   return (
@@ -98,9 +119,7 @@ export function HoldCancel() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/hold-fill.tsx
+++ b/apps/docs/src/components/learn/hold-fill.tsx
@@ -17,18 +17,36 @@ const CSS = `
 .hf-static .hf-fill { animation: none; transform: scaleX(1); }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "surface" | "fill";
+}[] = [
   {
     name: "Button surface",
     desc: "the real destructive fill color",
-    swatch: "bg-[var(--foreground)]",
+    kind: "surface",
   },
   {
     name: "Progress fill",
     desc: "scaleX(progress), origin-left",
-    swatch: "bg-[var(--foreground)]/30",
+    kind: "fill",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "fill") {
+    return (
+      <span className="relative h-3.5 w-8 overflow-hidden rounded-lg ring-1 ring-fd-border ring-inset">
+        <span className="absolute inset-0 bg-[var(--foreground)]" />
+        <span className="absolute inset-y-0 left-0 w-1/2 bg-[var(--background)]/30" />
+      </span>
+    );
+  }
+  return (
+    <span className="h-3.5 w-8 rounded-lg bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function HoldFill() {
   return (
@@ -50,9 +68,7 @@ export function HoldFill() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/holographic-card-foil.tsx
+++ b/apps/docs/src/components/learn/holographic-card-foil.tsx
@@ -30,6 +30,36 @@ const CSS = `
 .hcf-foil-anim { animation: hcf-foil 4s cubic-bezier(0.34,1.4,0.64,1) infinite; }
 `;
 
+const LEGEND = [
+  {
+    name: "Tilt",
+    desc: "rotateX/rotateY from the shared spring",
+    kind: "tilt" as const,
+  },
+  {
+    name: "Foil",
+    desc: "same sx/sy, mapped to a background position",
+    kind: "foil" as const,
+  },
+] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "foil") {
+    return (
+      <span
+        className="h-4 w-7 rounded-2xl border border-white/10 ring-1 ring-fd-border ring-inset"
+        style={{
+          backgroundImage:
+            "linear-gradient(115deg,#ff2d95,#ffd84d,#4dff9e,#4dd2ff,#a24dff,#ff2d95)",
+        }}
+      />
+    );
+  }
+  return (
+    <span className="h-4 w-7 rounded-2xl border border-white/10 ring-1 ring-fd-border ring-inset [background:radial-gradient(120%_120%_at_30%_15%,#312e81_0%,#0b1020_55%,#020617_100%)]" />
+  );
+}
+
 export function HolographicCardFoil() {
   return (
     <ScrollScene label="The foil" note="one signal, tilt + color together">
@@ -62,30 +92,17 @@ export function HolographicCardFoil() {
           </p>
 
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Tilt
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                rotateX/rotateY from the shared spring
-              </dd>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <span
-                className="h-1.5 w-8 rounded-full ring-1 ring-fd-border ring-inset"
-                style={{
-                  backgroundImage:
-                    "linear-gradient(115deg,#ff2d95,#ffd84d,#4dff9e,#4dd2ff,#a24dff,#ff2d95)",
-                }}
-              />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Foil
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                same sx/sy, mapped to a background position
-              </dd>
-            </div>
+            {LEGEND.map((item) => (
+              <div key={item.name} className="flex flex-col gap-1.5">
+                <LegendSwatch kind={item.kind} />
+                <dt className="font-medium text-[13px] text-fd-foreground">
+                  {item.name}
+                </dt>
+                <dd className="text-[12px] text-fd-muted-foreground">
+                  {item.desc}
+                </dd>
+              </div>
+            ))}
           </dl>
         </div>
       )}

--- a/apps/docs/src/components/learn/image-accordion-grow.tsx
+++ b/apps/docs/src/components/learn/image-accordion-grow.tsx
@@ -93,6 +93,30 @@ const PANELS = [
   { tone: "iag-p3", cap: "iag-c3" },
 ] as const;
 
+const LEGEND = [
+  {
+    name: "Idle panels",
+    desc: "flexGrow: 1 — share the leftover space",
+    kind: "idle" as const,
+  },
+  {
+    name: "Active panel",
+    desc: "flexGrow: 5 · 550ms cubic-bezier(0.22,1,0.36,1)",
+    kind: "active" as const,
+  },
+] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "active") {
+    return (
+      <span className="h-4 w-3 rounded-2xl bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-4 w-2 rounded-2xl bg-[var(--foreground)]/40 ring-1 ring-fd-border ring-inset [filter:saturate(0.45)_brightness(0.72)]" />
+  );
+}
+
 export function ImageAccordionGrow() {
   return (
     <ScrollScene label="The grow" note="one grows · the rest compress">
@@ -124,24 +148,17 @@ export function ImageAccordionGrow() {
           </div>
 
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/35 ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Idle panels
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                flexGrow: 1 — share the leftover space
-              </dd>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Active panel
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                flexGrow: 5 · 550ms cubic-bezier(0.22,1,0.36,1)
-              </dd>
-            </div>
+            {LEGEND.map((item) => (
+              <div key={item.name} className="flex flex-col gap-1.5">
+                <LegendSwatch kind={item.kind} />
+                <dt className="font-medium text-[13px] text-fd-foreground">
+                  {item.name}
+                </dt>
+                <dd className="text-[12px] text-fd-muted-foreground">
+                  {item.desc}
+                </dd>
+              </div>
+            ))}
           </dl>
         </div>
       )}

--- a/apps/docs/src/components/learn/image-compare-anatomy.tsx
+++ b/apps/docs/src/components/learn/image-compare-anatomy.tsx
@@ -50,23 +50,43 @@ const COLUMNS: {
   { key: "both", label: "together", delay: 240 },
 ];
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "after" | "before" | "handle";
+}[] = [
   {
     name: "After",
     desc: "base layer, always full",
-    swatch: "bg-[var(--muted)]",
+    kind: "after",
   },
   {
     name: "Before",
     desc: "clip-path: inset(...) on top",
-    swatch: "bg-[var(--foreground)]/30",
+    kind: "before",
   },
   {
     name: "Handle",
     desc: "role=slider, drag or arrow keys",
-    swatch: "border-2 border-white bg-transparent",
+    kind: "handle",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "handle") {
+    return (
+      <span className="size-3 rounded-full border-2 border-white bg-white/30 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "before") {
+    return (
+      <span className="h-3 w-5 rounded-lg bg-[var(--foreground)]/30 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-3 w-5 rounded-lg bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function ImageCompareAnatomy() {
   return (
@@ -96,9 +116,7 @@ export function ImageCompareAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ring-1 ring-fd-border ring-inset ${item.swatch}`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/image-compare-scrub.tsx
+++ b/apps/docs/src/components/learn/image-compare-scrub.tsx
@@ -59,7 +59,7 @@ export function ImageCompareScrub() {
 
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span className="h-3.5 w-6 rounded-lg bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 After
               </dt>
@@ -68,7 +68,7 @@ export function ImageCompareScrub() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/60 ring-1 ring-fd-border ring-inset" />
+              <span className="h-3.5 w-6 rounded-lg bg-[var(--foreground)]/60 ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Before
               </dt>
@@ -77,7 +77,9 @@ export function ImageCompareScrub() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full border-2 border-white/90 ring-1 ring-fd-border ring-inset" />
+              <span className="relative flex size-3.5 items-center justify-center rounded-full border-2 border-white/90 bg-white/20 ring-1 ring-fd-border ring-inset">
+                <span className="absolute inset-y-0 w-px bg-white/90" />
+              </span>
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Handle
               </dt>

--- a/apps/docs/src/components/learn/image-trail-anatomy.tsx
+++ b/apps/docs/src/components/learn/image-trail-anatomy.tsx
@@ -29,14 +29,25 @@ const LEGEND = [
   {
     name: "Pool slots",
     desc: "Array.from({ length: max }) · refs into slots.current",
-    swatch: "bg-[var(--muted)]",
+    kind: "pool" as const,
   },
   {
     name: "Active write",
     desc: "slots[slotIndex % max] · round-robin reuse",
-    swatch: "bg-[var(--foreground)]/50",
+    kind: "active" as const,
   },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "active") {
+    return (
+      <span className="size-3.5 rounded-xl bg-[var(--foreground)]/35 ring-2 ring-[var(--foreground)]/55 ring-inset" />
+    );
+  }
+  return (
+    <span className="size-3.5 rounded-xl bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function ImageTrailAnatomy() {
   return (
@@ -68,9 +79,7 @@ export function ImageTrailAnatomy() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/image-trail-threshold.tsx
+++ b/apps/docs/src/components/learn/image-trail-threshold.tsx
@@ -51,14 +51,28 @@ const LEGEND = [
   {
     name: "Threshold",
     desc: "Math.hypot(dx, dy) < 64 → return early",
-    swatch: "bg-transparent ring-1 ring-[var(--foreground)]/40 ring-inset",
+    kind: "threshold" as const,
   },
   {
     name: "Spawn",
     desc: "place slot · tilt from atan2(dy, dx)",
-    swatch: "bg-[var(--muted)]",
+    kind: "spawn" as const,
   },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "threshold") {
+    return (
+      <span className="relative h-3 w-8">
+        <span className="absolute inset-x-0 top-1/2 border-t border-dashed border-[var(--foreground)]/20" />
+        <span className="absolute top-1/2 left-1/2 size-1.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-[var(--foreground)]" />
+      </span>
+    );
+  }
+  return (
+    <span className="size-3.5 rounded-[10px] bg-[var(--muted)] shadow-sm ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function ImageTrailThreshold() {
   return (
@@ -106,9 +120,7 @@ export function ImageTrailThreshold() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/image-trail-waapi.tsx
+++ b/apps/docs/src/components/learn/image-trail-waapi.tsx
@@ -46,19 +46,35 @@ const LEGEND = [
   {
     name: "Scale",
     desc: "0.4 → 1 (at 18%) → 0.92",
-    swatch: "bg-[var(--muted)]",
+    kind: "scale" as const,
   },
   {
     name: "Opacity",
     desc: "0 → 1 → 0 · fill: forwards",
-    swatch: "bg-[var(--foreground)]/40",
+    kind: "opacity" as const,
   },
   {
     name: "Drift + tilt",
     desc: "−50% → −65% Y · rotate(tilt)",
-    swatch: "bg-[var(--foreground)]/20",
+    kind: "drift" as const,
   },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "opacity") {
+    return (
+      <span className="size-4 rounded-xl bg-[var(--foreground)]/25 ring-1 ring-fd-border/40 ring-inset" />
+    );
+  }
+  if (kind === "drift") {
+    return (
+      <span className="size-4 rounded-xl bg-[var(--muted)] ring-1 ring-fd-border/40 ring-inset [transform:rotate(-8deg)]" />
+    );
+  }
+  return (
+    <span className="size-4 rounded-xl bg-[var(--muted)] ring-1 ring-fd-border/40 ring-inset" />
+  );
+}
 
 export function ImageTrailWaapi() {
   return (
@@ -88,9 +104,7 @@ export function ImageTrailWaapi() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/inertia-gallery-anatomy.tsx
+++ b/apps/docs/src/components/learn/inertia-gallery-anatomy.tsx
@@ -62,7 +62,7 @@ export function InertiaGalleryAnatomy() {
 
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full border-2 border-dashed border-[var(--foreground)]/50 bg-transparent" />
+              <span className="h-3 w-6 rounded-lg border border-[var(--foreground)]/20 bg-transparent ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Viewport
               </dt>
@@ -71,7 +71,7 @@ export function InertiaGalleryAnatomy() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/30 ring-1 ring-fd-border ring-inset" />
+              <span className="h-3 w-4 rounded-lg bg-[var(--foreground)]/30 ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Track
               </dt>
@@ -80,7 +80,7 @@ export function InertiaGalleryAnatomy() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
+              <span className="h-4 w-5 rounded-lg bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Centered slide
               </dt>

--- a/apps/docs/src/components/learn/inertia-gallery-falloff.tsx
+++ b/apps/docs/src/components/learn/inertia-gallery-falloff.tsx
@@ -29,6 +29,40 @@ const SLIDES: Slide[] = [
   { d: 2, scale: 0.72, opacity: 0.4, blur: 5 },
 ];
 
+const LEGEND = [
+  {
+    name: "Scale",
+    desc: "1 − distance × 0.14 × falloff",
+    kind: "scale" as const,
+  },
+  {
+    name: "Opacity",
+    desc: "clamped 0.4–1",
+    kind: "opacity" as const,
+  },
+  {
+    name: "Blur",
+    desc: "0 when reduced-motion",
+    kind: "blur" as const,
+  },
+] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "opacity") {
+    return (
+      <span className="h-4 w-2.5 rounded-lg bg-[var(--foreground)]/45 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "blur") {
+    return (
+      <span className="h-4 w-2.5 rounded-lg bg-[var(--foreground)]/20 blur-[2px] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-4 w-2.5 rounded-lg bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
+  );
+}
+
 export function InertiaGalleryFalloff() {
   return (
     <ScrollScene label="The falloff" note="distance → scale / opacity / blur">
@@ -58,33 +92,17 @@ export function InertiaGalleryFalloff() {
           </div>
 
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Scale
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                1 − distance × 0.14 × falloff
-              </dd>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/45 ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Opacity
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                clamped 0.4–1
-              </dd>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/20 ring-1 ring-fd-border ring-inset blur-[2px]" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Blur
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                0 when reduced-motion
-              </dd>
-            </div>
+            {LEGEND.map((item) => (
+              <div key={item.name} className="flex flex-col gap-1.5">
+                <LegendSwatch kind={item.kind} />
+                <dt className="font-medium text-[13px] text-fd-foreground">
+                  {item.name}
+                </dt>
+                <dd className="text-[12px] text-fd-muted-foreground">
+                  {item.desc}
+                </dd>
+              </div>
+            ))}
           </dl>
         </div>
       )}

--- a/apps/docs/src/components/learn/lamp-anatomy.tsx
+++ b/apps/docs/src/components/learn/lamp-anatomy.tsx
@@ -36,22 +36,22 @@ const LEGEND = [
   {
     name: "Left cone",
     desc: "conic from 290deg, origin-left",
-    swatch: "bg-[var(--muted)]",
+    swatch: "bg-[var(--foreground)]/35",
   },
   {
     name: "Right cone",
     desc: "conic from 70deg, origin-right",
-    swatch: "bg-[var(--card)] ring-1 ring-fd-border ring-inset",
+    swatch: "bg-[var(--foreground)]/35",
   },
   {
     name: "Bar + wash",
     desc: "scaleX seam + radial ellipse",
-    swatch: "bg-[var(--foreground)]/50",
+    swatch: "bg-[var(--foreground)]/70",
   },
   {
     name: "Children",
     desc: "slot rises into the light",
-    swatch: "bg-[var(--foreground)]/25",
+    swatch: "bg-[var(--foreground)]/30",
   },
 ] as const;
 

--- a/apps/docs/src/components/learn/lamp-ignite.tsx
+++ b/apps/docs/src/components/learn/lamp-ignite.tsx
@@ -40,19 +40,41 @@ const LEGEND = [
   {
     name: "Cones",
     desc: "scaleX 0.5→1 · opacity 0.5→1",
-    swatch: "bg-[var(--muted)]",
+    kind: "cones" as const,
   },
   {
     name: "Bar",
     desc: "scaleX 0.5→1, same 0.8s easeInOut",
-    swatch: "bg-[var(--foreground)]/60",
+    kind: "bar" as const,
   },
   {
     name: "Viewport",
     desc: "once:true, margin −20%",
-    swatch: "bg-transparent ring-1 ring-[var(--foreground)]/40 ring-inset",
+    kind: "viewport" as const,
   },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "bar") {
+    return (
+      <span className="h-0.5 w-8 rounded-full bg-[var(--foreground)]/75 blur-[1px] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "viewport") {
+    return (
+      <span className="h-3.5 w-6 rounded-2xl ring-1 ring-[var(--foreground)]/40 ring-inset" />
+    );
+  }
+  return (
+    <span
+      className="h-4 w-8 rounded-t-full ring-1 ring-fd-border ring-inset"
+      style={{
+        backgroundImage:
+          "conic-gradient(from 70deg at 50% 100%, color-mix(in oklch, var(--foreground) 40%, transparent), transparent 55%)",
+      }}
+    />
+  );
+}
 
 export function LampIgnite() {
   return (
@@ -112,9 +134,7 @@ export function LampIgnite() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/lamp-rise.tsx
+++ b/apps/docs/src/components/learn/lamp-rise.tsx
@@ -25,19 +25,41 @@ const LEGEND = [
   {
     name: "Light",
     desc: "cones + bar ignite first (t=0)",
-    swatch: "bg-[var(--muted)]",
+    kind: "light" as const,
   },
   {
     name: "Children",
     desc: "opacity + y:40→0, delay 0.2s",
-    swatch: "bg-[var(--foreground)]/30",
+    kind: "children" as const,
   },
   {
     name: "Reduced motion",
     desc: "start at lit + risen state",
-    swatch: "bg-transparent ring-1 ring-[var(--foreground)]/40 ring-inset",
+    kind: "reduced" as const,
   },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "children") {
+    return (
+      <span className="h-2 w-8 rounded-full bg-[var(--foreground)]/35 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "reduced") {
+    return (
+      <span className="h-3.5 w-6 rounded-2xl ring-1 ring-[var(--foreground)]/40 ring-inset" />
+    );
+  }
+  return (
+    <span
+      className="h-4 w-8 rounded-t-full ring-1 ring-fd-border ring-inset"
+      style={{
+        backgroundImage:
+          "conic-gradient(from 70deg at 50% 100%, color-mix(in oklch, var(--foreground) 28%, transparent), transparent 55%)",
+      }}
+    />
+  );
+}
 
 export function LampRise() {
   return (
@@ -79,9 +101,7 @@ export function LampRise() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/light-rays-anatomy.tsx
+++ b/apps/docs/src/components/learn/light-rays-anatomy.tsx
@@ -27,16 +27,35 @@ const LEGEND = [
   {
     name: "Source",
     desc: "ellipse glow parked just above the top edge",
+    kind: "source" as const,
   },
   {
     name: "Wedges",
     desc: "repeating-conic · one spoke every 360° / rayCount",
+    kind: "wedges" as const,
   },
   {
     name: "Soft fan",
     desc: "inset −50% · blur(8px) · mask fades downward",
+    kind: "soft" as const,
   },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "source") {
+    return (
+      <span className="size-2 rounded-full bg-[var(--foreground)]/40 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "wedges") {
+    return (
+      <span className="h-3 w-6 rounded-sm bg-[var(--foreground)]/45 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-3 w-6 rounded-xl border border-[var(--foreground)]/15 border-dashed bg-[var(--foreground)]/10 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 function Stage({
   delay,
@@ -126,7 +145,7 @@ export function LightRaysAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/light-rays-grain.tsx
+++ b/apps/docs/src/components/learn/light-rays-grain.tsx
@@ -19,6 +19,41 @@ const CSS = `
 const FAN =
   "repeating-conic-gradient(from 0deg at 50% 0%, transparent 0deg, rgba(0,0,0,0.3) 4deg, transparent 26deg)";
 
+const LEGEND = [
+  {
+    name: "Noise",
+    desc: "fractalNoise · baseFrequency 0.9",
+    kind: "noise" as const,
+  },
+  {
+    name: "Blend",
+    desc: "mix-blend-overlay · opacity = grain",
+    kind: "blend" as const,
+  },
+] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "blend") {
+    return (
+      <span className="relative h-4 w-8 overflow-hidden rounded-md ring-1 ring-fd-border ring-inset">
+        <span
+          className="absolute inset-0"
+          style={{
+            backgroundImage: FAN,
+            WebkitMaskImage:
+              "linear-gradient(to bottom, black 8%, transparent 78%)",
+            maskImage: "linear-gradient(to bottom, black 8%, transparent 78%)",
+          }}
+        />
+        <span className="absolute inset-0 bg-[var(--foreground)]/20 mix-blend-overlay" />
+      </span>
+    );
+  }
+  return (
+    <span className="h-4 w-8 rounded-md bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+  );
+}
+
 export function LightRaysGrain() {
   const uid = useId().replace(/:/g, "");
   const noiseId = `lrg-noise-${uid}`;
@@ -127,24 +162,17 @@ export function LightRaysGrain() {
           </p>
 
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Noise
-              </dt>
-              <dd className="font-mono text-[12px] text-fd-muted-foreground">
-                fractalNoise · baseFrequency 0.9
-              </dd>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Blend
-              </dt>
-              <dd className="font-mono text-[12px] text-fd-muted-foreground">
-                mix-blend-overlay · opacity = grain
-              </dd>
-            </div>
+            {LEGEND.map((item) => (
+              <div key={item.name} className="flex flex-col gap-1.5">
+                <LegendSwatch kind={item.kind} />
+                <dt className="font-medium text-[13px] text-fd-foreground">
+                  {item.name}
+                </dt>
+                <dd className="font-mono text-[12px] text-fd-muted-foreground">
+                  {item.desc}
+                </dd>
+              </div>
+            ))}
           </dl>
         </div>
       )}

--- a/apps/docs/src/components/learn/light-rays-sweep.tsx
+++ b/apps/docs/src/components/learn/light-rays-sweep.tsx
@@ -39,6 +39,41 @@ const CSS = `
 const FAN =
   "repeating-conic-gradient(from 0deg at 50% 0%, transparent 0deg, rgba(0,0,0,0.42) 3.5deg, transparent 24deg)";
 
+const LEGEND = [
+  {
+    name: "Transform",
+    desc: "rotate(±6deg) scale(1→1.08)",
+    kind: "transform" as const,
+  },
+  {
+    name: "Timing",
+    desc: "ease-in-out alternate · --rays-speed",
+    kind: "timing" as const,
+  },
+] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "timing") {
+    return (
+      <span className="relative h-3 w-8">
+        <span className="absolute inset-x-0 top-0 h-px border-t border-dashed border-[var(--foreground)]/25" />
+        <span className="absolute top-0 left-1/2 h-3 w-px -translate-x-1/2 bg-[var(--foreground)]/45" />
+      </span>
+    );
+  }
+  return (
+    <span
+      className="h-4 w-8 rounded-t-full ring-1 ring-fd-border ring-inset"
+      style={{
+        backgroundImage: FAN,
+        WebkitMaskImage:
+          "linear-gradient(to bottom, black 5%, transparent 80%)",
+        maskImage: "linear-gradient(to bottom, black 5%, transparent 80%)",
+      }}
+    />
+  );
+}
+
 export function LightRaysSweep() {
   return (
     <ScrollScene label="Sweep" note="±6° rotate · scale 1→1.08 · alternate">
@@ -107,24 +142,17 @@ export function LightRaysSweep() {
           </p>
 
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Transform
-              </dt>
-              <dd className="font-mono text-[12px] text-fd-muted-foreground">
-                rotate(±6deg) scale(1→1.08)
-              </dd>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Timing
-              </dt>
-              <dd className="font-mono text-[12px] text-fd-muted-foreground">
-                ease-in-out alternate · --rays-speed
-              </dd>
-            </div>
+            {LEGEND.map((item) => (
+              <div key={item.name} className="flex flex-col gap-1.5">
+                <LegendSwatch kind={item.kind} />
+                <dt className="font-medium text-[13px] text-fd-foreground">
+                  {item.name}
+                </dt>
+                <dd className="font-mono text-[12px] text-fd-muted-foreground">
+                  {item.desc}
+                </dd>
+              </div>
+            ))}
           </dl>
         </div>
       )}

--- a/apps/docs/src/components/learn/liquid-glass-card-anatomy.tsx
+++ b/apps/docs/src/components/learn/liquid-glass-card-anatomy.tsx
@@ -17,10 +17,38 @@ const CSS = `
 `;
 
 const LEGEND = [
-  { name: "Frost", desc: "backdrop-filter blur + optional url(#filter)" },
-  { name: "Sheen", desc: "pointer-tracked radial · mix-blend-screen" },
-  { name: "Rim map", desc: "band=0.3 — neutral mid, bend only at edges" },
+  {
+    name: "Frost",
+    desc: "backdrop-filter blur + optional url(#filter)",
+    kind: "frost" as const,
+  },
+  {
+    name: "Sheen",
+    desc: "pointer-tracked radial · mix-blend-screen",
+    kind: "sheen" as const,
+  },
+  {
+    name: "Rim map",
+    desc: "band=0.3 — neutral mid, bend only at edges",
+    kind: "rim" as const,
+  },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "frost") {
+    return (
+      <span className="h-4 w-3 rounded-xl bg-[var(--muted)]/80 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "sheen") {
+    return (
+      <span className="h-4 w-3 rounded-xl bg-[var(--foreground)]/25 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-3 w-4 rounded-md border border-[var(--foreground)]/25 border-dashed bg-transparent ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function LiquidGlassCardAnatomy() {
   return (
@@ -108,7 +136,7 @@ export function LiquidGlassCardAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/liquid-glass-card-dispersion.tsx
+++ b/apps/docs/src/components/learn/liquid-glass-card-dispersion.tsx
@@ -49,6 +49,26 @@ const CHANNELS = [
   },
 ] as const;
 
+function LegendSwatch({
+  fill,
+  ox,
+  oy,
+}: {
+  fill: number;
+  ox: string;
+  oy: string;
+}) {
+  return (
+    <span
+      className="h-4 w-5 rounded-2xl border border-[var(--foreground)]/20 ring-1 ring-fd-border ring-inset"
+      style={{
+        backgroundColor: `color-mix(in oklab, var(--foreground) ${fill * 100}%, transparent)`,
+        transform: `translate(${ox}, ${oy})`,
+      }}
+    />
+  );
+}
+
 export function LiquidGlassCardDispersion() {
   return (
     <ScrollScene label="Dispersion" note="three scales · then screen-blend">
@@ -97,7 +117,7 @@ export function LiquidGlassCardDispersion() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {CHANNELS.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+                <LegendSwatch fill={item.fill} ox={item.ox} oy={item.oy} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/liquid-glass-card-sheen.tsx
+++ b/apps/docs/src/components/learn/liquid-glass-card-sheen.tsx
@@ -37,6 +37,40 @@ const CSS = `
 .lgcs-static .lgcs-glow { animation: none; opacity: 1; --sx: 35%; --sy: 30%; }
 `;
 
+const LEGEND = [
+  {
+    name: "CSS vars",
+    desc: "--lg-x / --lg-y as %",
+    kind: "vars" as const,
+  },
+  {
+    name: "Fade",
+    desc: "transition-opacity duration-200",
+    kind: "fade" as const,
+  },
+] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "fade") {
+    return (
+      <span className="relative h-4 w-7 overflow-hidden rounded-2xl border border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset">
+        <span
+          className="absolute inset-0 mix-blend-screen"
+          style={{
+            background:
+              "radial-gradient(circle at 35% 30%, color-mix(in oklab, var(--foreground) 40%, transparent) 0%, transparent 45%)",
+          }}
+        />
+      </span>
+    );
+  }
+  return (
+    <span className="relative h-4 w-7 overflow-hidden rounded-2xl border border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset">
+      <span className="absolute inset-0 bg-[var(--muted)]/35" />
+    </span>
+  );
+}
+
 export function LiquidGlassCardSheen() {
   return (
     <ScrollScene label="Sheen" note="--lg-x · --lg-y · 200ms fade">
@@ -66,24 +100,17 @@ export function LiquidGlassCardSheen() {
           </div>
 
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                CSS vars
-              </dt>
-              <dd className="font-mono text-[12px] text-fd-muted-foreground">
-                --lg-x / --lg-y as %
-              </dd>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Fade
-              </dt>
-              <dd className="font-mono text-[12px] text-fd-muted-foreground">
-                transition-opacity duration-200
-              </dd>
-            </div>
+            {LEGEND.map((item) => (
+              <div key={item.name} className="flex flex-col gap-1.5">
+                <LegendSwatch kind={item.kind} />
+                <dt className="font-medium text-[13px] text-fd-foreground">
+                  {item.name}
+                </dt>
+                <dd className="font-mono text-[12px] text-fd-muted-foreground">
+                  {item.desc}
+                </dd>
+              </div>
+            ))}
           </dl>
         </div>
       )}

--- a/apps/docs/src/components/learn/liquid-glass-lens-anatomy.tsx
+++ b/apps/docs/src/components/learn/liquid-glass-lens-anatomy.tsx
@@ -89,7 +89,7 @@ export function LiquidGlassLensAnatomy() {
 
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span className="size-3.5 rounded-full bg-[var(--muted)]/60 ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Frost
               </dt>
@@ -98,7 +98,7 @@ export function LiquidGlassLensAnatomy() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span className="size-3.5 rounded-full bg-[var(--foreground)]/20 ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Glint
               </dt>
@@ -107,7 +107,7 @@ export function LiquidGlassLensAnatomy() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span className="size-3.5 rounded-full bg-[var(--foreground)]/55 ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Full map
               </dt>

--- a/apps/docs/src/components/learn/liquid-glass-lens-map.tsx
+++ b/apps/docs/src/components/learn/liquid-glass-lens-map.tsx
@@ -40,6 +40,46 @@ function MapPlate({ band, className }: { band: number; className?: string }) {
   );
 }
 
+const LEGEND = [
+  {
+    name: "Neutral mid",
+    desc: "dashed band = no displacement",
+    kind: "band" as const,
+  },
+  {
+    name: "Converging lens",
+    desc: "continuous ramp edge-to-edge",
+    kind: "lens" as const,
+  },
+] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "lens") {
+    return (
+      <span
+        className="size-4 rounded-full border border-fd-border ring-1 ring-fd-border ring-inset"
+        style={{
+          backgroundImage:
+            "linear-gradient(90deg, var(--foreground) 0%, transparent 50%, var(--foreground) 100%)",
+          opacity: 0.55,
+        }}
+      />
+    );
+  }
+  return (
+    <span
+      className="relative h-4 w-7 overflow-hidden rounded-2xl border border-fd-border ring-1 ring-fd-border ring-inset"
+      style={{
+        backgroundImage:
+          "linear-gradient(90deg, var(--foreground) 0%, transparent 35%, transparent 65%, var(--foreground) 100%)",
+        opacity: 0.55,
+      }}
+    >
+      <span className="absolute inset-y-0 left-[35%] right-[35%] border-[var(--foreground)]/30 border-x border-dashed" />
+    </span>
+  );
+}
+
 export function LiquidGlassLensMap() {
   return (
     <ScrollScene label="Displacement map" note="band=0.3 card · band=0 lens">
@@ -85,24 +125,17 @@ export function LiquidGlassLensMap() {
           </p>
 
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Neutral mid
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                dashed band = no displacement
-              </dd>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Converging lens
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                continuous ramp edge-to-edge
-              </dd>
-            </div>
+            {LEGEND.map((item) => (
+              <div key={item.name} className="flex flex-col gap-1.5">
+                <LegendSwatch kind={item.kind} />
+                <dt className="font-medium text-[13px] text-fd-foreground">
+                  {item.name}
+                </dt>
+                <dd className="text-[12px] text-fd-muted-foreground">
+                  {item.desc}
+                </dd>
+              </div>
+            ))}
           </dl>
         </div>
       )}

--- a/apps/docs/src/components/learn/liquid-glass-lens-parent.tsx
+++ b/apps/docs/src/components/learn/liquid-glass-lens-parent.tsx
@@ -24,6 +24,36 @@ const CSS = `
 .lglp-static .lglp-lens { animation: none; transform: translate(40%, 35%); }
 `;
 
+const LEGEND = [
+  {
+    name: "Parent events",
+    desc: "pointermove / enter / leave",
+    kind: "parent" as const,
+  },
+  {
+    name: "Centering",
+    desc: "translate(calc(var(--lg-px) - 50%), …)",
+    kind: "lens" as const,
+  },
+] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "lens") {
+    return (
+      <span
+        className="size-4 rounded-full border border-fd-border bg-[var(--muted)]/70 shadow-sm ring-1 ring-fd-border ring-inset backdrop-blur-[2px]"
+        style={{
+          boxShadow:
+            "inset 0 2px 2px color-mix(in oklab, var(--foreground) 18%, transparent), inset 0 -4px 8px color-mix(in oklab, var(--foreground) 10%, transparent)",
+        }}
+      />
+    );
+  }
+  return (
+    <span className="h-4 w-7 rounded-2xl border border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+  );
+}
+
 export function LiquidGlassLensParent() {
   return (
     <ScrollScene label="Parent pointer" note="listeners on offsetParent">
@@ -58,24 +88,17 @@ export function LiquidGlassLensParent() {
           </div>
 
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Parent events
-              </dt>
-              <dd className="font-mono text-[12px] text-fd-muted-foreground">
-                pointermove / enter / leave
-              </dd>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Centering
-              </dt>
-              <dd className="font-mono text-[12px] text-fd-muted-foreground">
-                {"translate(calc(var(--lg-px) - 50%), …)"}
-              </dd>
-            </div>
+            {LEGEND.map((item) => (
+              <div key={item.name} className="flex flex-col gap-1.5">
+                <LegendSwatch kind={item.kind} />
+                <dt className="font-medium text-[13px] text-fd-foreground">
+                  {item.name}
+                </dt>
+                <dd className="font-mono text-[12px] text-fd-muted-foreground">
+                  {item.desc}
+                </dd>
+              </div>
+            ))}
           </dl>
         </div>
       )}

--- a/apps/docs/src/components/learn/liquid-image-anatomy.tsx
+++ b/apps/docs/src/components/learn/liquid-image-anatomy.tsx
@@ -170,16 +170,35 @@ const LEGEND = [
   {
     name: "Source",
     desc: "the img — SourceGraphic into the filter",
+    kind: "source" as const,
   },
   {
     name: "Noise",
     desc: "feTurbulence · baseFrequency drifts so it never freezes",
+    kind: "noise" as const,
   },
   {
     name: "Displaced",
     desc: "scale pushes pixels — edges fray into the liquid border",
+    kind: "displaced" as const,
   },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "noise") {
+    return (
+      <span className="h-4 w-3 rounded-xl bg-[var(--foreground)]/20 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "displaced") {
+    return (
+      <span className="h-4 w-3 rounded-xl bg-[var(--foreground)]/18 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-4 w-3 rounded-xl bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function LiquidImageAnatomy() {
   const uid = useId().replace(/:/g, "");
@@ -239,7 +258,7 @@ export function LiquidImageAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/liquid-image-edge.tsx
+++ b/apps/docs/src/components/learn/liquid-image-edge.tsx
@@ -22,19 +22,38 @@ const LEGEND = [
   {
     name: "Noise drift",
     desc: "SMIL animates baseFrequency over ~16s — field never freezes",
-    swatch: "bg-[var(--muted)]",
+    kind: "noise" as const,
   },
   {
     name: "Scale",
     desc: "feDisplacementMap scale — how hard pixels are pushed",
-    swatch: "bg-[var(--foreground)]/40",
+    kind: "scale" as const,
   },
   {
     name: "Padded filter",
     desc: "x/y −20%, 140% size — edge pixels can spill past the rect",
-    swatch: "bg-transparent ring-1 ring-[var(--foreground)]/40 ring-inset",
+    kind: "filter" as const,
   },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "scale") {
+    return (
+      <span className="h-3.5 w-6 rounded-[5px] bg-[var(--foreground)]/14 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "filter") {
+    return (
+      <span className="h-3.5 w-6 rounded-[5px] ring-1 ring-[var(--foreground)]/40 ring-inset" />
+    );
+  }
+  return (
+    <span className="relative h-3.5 w-6 overflow-hidden rounded-[5px] ring-1 ring-fd-border ring-inset">
+      <span className="absolute inset-x-0 top-0 h-1/3 bg-[var(--muted)]" />
+      <span className="absolute inset-x-0 bottom-0 h-2/3 bg-[var(--card)]" />
+    </span>
+  );
+}
 
 export function LiquidImageEdge() {
   const uid = useId().replace(/:/g, "");
@@ -158,9 +177,7 @@ export function LiquidImageEdge() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/liquid-image-lerp.tsx
+++ b/apps/docs/src/components/learn/liquid-image-lerp.tsx
@@ -40,19 +40,40 @@ const LEGEND = [
   {
     name: "current",
     desc: "lerp: current += (target − current) × 0.12",
-    swatch: "bg-[var(--foreground)]/50",
+    kind: "current" as const,
   },
   {
     name: "target",
     desc: "hover / always / velocity write here",
-    swatch: "bg-transparent ring-1 ring-[var(--foreground)]/50 ring-inset",
+    kind: "target" as const,
   },
   {
     name: "setAttribute",
     desc: "scale written on dispRef — no setState",
-    swatch: "bg-[var(--muted)]",
+    kind: "tick" as const,
   },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "target") {
+    return (
+      <span className="relative flex h-4 w-8 items-end justify-center">
+        <span className="h-3 w-px bg-[var(--foreground)]/70" />
+        <span className="absolute bottom-0 size-1.5 rounded-full bg-[var(--foreground)]" />
+      </span>
+    );
+  }
+  if (kind === "tick") {
+    return (
+      <span className="size-2 rounded-full bg-[var(--foreground)]/60 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="relative h-3 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset">
+      <span className="absolute inset-y-0 left-0 w-[45%] rounded-full bg-[var(--foreground)]/45" />
+    </span>
+  );
+}
 
 export function LiquidImageLerp() {
   return (
@@ -96,9 +117,7 @@ export function LiquidImageLerp() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/liquid-image-trigger.tsx
+++ b/apps/docs/src/components/learn/liquid-image-trigger.tsx
@@ -58,6 +58,20 @@ const COLS = [
   },
 ] as const;
 
+function LegendSwatch({ kind }: { kind: (typeof COLS)[number]["name"] }) {
+  if (kind === "Velocity") {
+    return (
+      <span className="relative h-4 w-3">
+        <span className="absolute inset-x-0 bottom-0 h-full w-2 rounded-md bg-[var(--foreground)]/40" />
+        <span className="absolute top-0 right-0 size-2 rounded-full border border-fd-border bg-[var(--muted)] shadow-sm" />
+      </span>
+    );
+  }
+  return (
+    <span className="h-4 w-2 rounded-md bg-[var(--foreground)]/40 ring-1 ring-fd-border ring-inset" />
+  );
+}
+
 export function LiquidImageTrigger() {
   return (
     <ScrollScene label="Targets" note="hover · always · velocity boost">
@@ -94,7 +108,7 @@ export function LiquidImageTrigger() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {COLS.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/40 ring-1 ring-fd-border ring-inset" />
+                <LegendSwatch kind={item.name} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/liquid-metaballs-anatomy.tsx
+++ b/apps/docs/src/components/learn/liquid-metaballs-anatomy.tsx
@@ -48,7 +48,7 @@ export function LiquidMetaballsAnatomy() {
           </div>
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span className="size-3.5 rounded-full bg-[var(--foreground)]/70 ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Blobs
               </dt>
@@ -57,7 +57,7 @@ export function LiquidMetaballsAnatomy() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span className="size-3 rounded-full bg-[var(--foreground)]/60 ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Paint
               </dt>
@@ -66,7 +66,7 @@ export function LiquidMetaballsAnatomy() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span className="size-3.5 rounded-full border border-dashed border-[var(--foreground)]/40 bg-transparent" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Wrap
               </dt>

--- a/apps/docs/src/components/learn/liquid-metaballs-cursor.tsx
+++ b/apps/docs/src/components/learn/liquid-metaballs-cursor.tsx
@@ -18,6 +18,30 @@ const CSS = `
 .lmc-static .lmc-c { animation: none; transform: translate(18px, 0) scale(1); opacity: 1; }
 `;
 
+const LEGEND = [
+  {
+    name: "Active",
+    desc: "r = min(w,h)×0.1 while pointer in",
+    kind: "active" as const,
+  },
+  {
+    name: "Idle",
+    desc: "r = 0 — no leftover disc",
+    kind: "idle" as const,
+  },
+] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "idle") {
+    return (
+      <span className="size-3 rounded-full bg-[var(--foreground)]/30 ring-1 ring-fd-border ring-inset [transform:scale(0.4)]" />
+    );
+  }
+  return (
+    <span className="size-3.5 rounded-full bg-[var(--foreground)]/70 ring-1 ring-fd-border ring-inset" />
+  );
+}
+
 export function LiquidMetaballsCursor() {
   return (
     <ScrollScene label="Cursor blob" note="r grows on pointer">
@@ -55,24 +79,17 @@ export function LiquidMetaballsCursor() {
             <div className="lmc-c absolute size-12 rounded-full bg-[var(--foreground)]/65" />
           </div>
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Active
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                r = min(w,h)×0.1 while pointer in
-              </dd>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Idle
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                r = 0 — no leftover disc
-              </dd>
-            </div>
+            {LEGEND.map((item) => (
+              <div key={item.name} className="flex flex-col gap-1.5">
+                <LegendSwatch kind={item.kind} />
+                <dt className="font-medium text-[13px] text-fd-foreground">
+                  {item.name}
+                </dt>
+                <dd className="text-[12px] text-fd-muted-foreground">
+                  {item.desc}
+                </dd>
+              </div>
+            ))}
           </dl>
         </div>
       )}

--- a/apps/docs/src/components/learn/liquid-metaballs-goo.tsx
+++ b/apps/docs/src/components/learn/liquid-metaballs-goo.tsx
@@ -26,6 +26,36 @@ const CSS = `
 .lmg-static .lmg-b { animation: none; transform: translate(-20px, 0); }
 `;
 
+const LEGEND = [
+  {
+    name: "Blur",
+    desc: "feGaussianBlur stdDeviation={gooeyness}",
+    kind: "blur" as const,
+  },
+  {
+    name: "Punch",
+    desc: "alpha ×20 − 9",
+    kind: "punch" as const,
+  },
+] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "punch") {
+    return (
+      <span className="relative flex h-4 w-8 items-center justify-center">
+        <span className="absolute size-3 rounded-full bg-[var(--foreground)]/75" />
+        <span className="absolute size-3 translate-x-2 rounded-full bg-[var(--foreground)]/75" />
+      </span>
+    );
+  }
+  return (
+    <span className="relative flex h-4 w-8 items-center justify-center">
+      <span className="absolute left-1 size-3 rounded-full bg-[var(--foreground)]/75" />
+      <span className="absolute right-1 size-3 rounded-full bg-[var(--foreground)]/75" />
+    </span>
+  );
+}
+
 export function LiquidMetaballsGoo() {
   return (
     <ScrollScene label="Goo filter" note="blur + contrast matrix">
@@ -86,24 +116,23 @@ export function LiquidMetaballsGoo() {
             </div>
           </div>
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Blur
-              </dt>
-              <dd className="font-mono text-[12px] text-fd-muted-foreground">
-                {"feGaussianBlur stdDeviation={gooeyness}"}
-              </dd>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Punch
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                alpha ×20 − 9
-              </dd>
-            </div>
+            {LEGEND.map((item) => (
+              <div key={item.name} className="flex flex-col gap-1.5">
+                <LegendSwatch kind={item.kind} />
+                <dt className="font-medium text-[13px] text-fd-foreground">
+                  {item.name}
+                </dt>
+                <dd
+                  className={
+                    item.kind === "blur"
+                      ? "font-mono text-[12px] text-fd-muted-foreground"
+                      : "text-[12px] text-fd-muted-foreground"
+                  }
+                >
+                  {item.desc}
+                </dd>
+              </div>
+            ))}
           </dl>
         </div>
       )}

--- a/apps/docs/src/components/learn/live-cursors-anatomy.tsx
+++ b/apps/docs/src/components/learn/live-cursors-anatomy.tsx
@@ -18,18 +18,33 @@ const CSS = `
 .lca-static .lca-el { animation: none; opacity: 1; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "pointer" | "flag";
+}[] = [
   {
     name: "Pointer",
     desc: "SVG path, presence-color fill, white stroke",
-    swatch: "bg-[var(--foreground)]/70",
+    kind: "pointer",
   },
   {
     name: "Name flag",
     desc: "mt-3 -ml-1, rounded-tl-sm — the tail points at the pointer",
-    swatch: "bg-[var(--foreground)]/70",
+    kind: "flag",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "pointer") {
+    return (
+      <span className="size-2.5 rounded-full bg-[var(--foreground)]/70 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-3 w-7 rounded-[5px] rounded-tl-sm bg-[var(--foreground)]/70 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function LiveCursorsAnatomy() {
   return (
@@ -71,9 +86,7 @@ export function LiveCursorsAnatomy() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/live-cursors-presence.tsx
+++ b/apps/docs/src/components/learn/live-cursors-presence.tsx
@@ -31,6 +31,34 @@ const CURSORS = [
   { id: "b", top: "58%", left: "62%", delay: "90ms" },
 ];
 
+const LEGEND = [
+  {
+    name: "Enter",
+    desc: "opacity 0 → 1, scale 0.5 → 1, 150ms",
+    kind: "enter" as const,
+  },
+  {
+    name: "Exit",
+    desc: "the mirror transition, then unmounts — no manual timer",
+    kind: "exit" as const,
+  },
+] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "exit") {
+    return (
+      <span className="flex size-4 items-center justify-center rounded-full bg-[var(--foreground)]/40 shadow-sm ring-1 ring-fd-border ring-inset">
+        <span className="size-1.5 rounded-full bg-[var(--background)]/80" />
+      </span>
+    );
+  }
+  return (
+    <span className="flex size-4 items-center justify-center rounded-full bg-[var(--foreground)]/70 shadow-sm ring-1 ring-fd-border ring-inset">
+      <span className="size-1.5 rounded-full bg-[var(--background)]" />
+    </span>
+  );
+}
+
 export function LiveCursorsPresence() {
   return (
     <ScrollScene
@@ -73,24 +101,17 @@ export function LiveCursorsPresence() {
           </div>
 
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/70 ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Enter
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                opacity 0 → 1, scale 0.5 → 1, 150ms
-              </dd>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/40 ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Exit
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                the mirror transition, then unmounts — no manual timer
-              </dd>
-            </div>
+            {LEGEND.map((item) => (
+              <div key={item.name} className="flex flex-col gap-1.5">
+                <LegendSwatch kind={item.kind} />
+                <dt className="font-medium text-[13px] text-fd-foreground">
+                  {item.name}
+                </dt>
+                <dd className="text-[12px] text-fd-muted-foreground">
+                  {item.desc}
+                </dd>
+              </div>
+            ))}
           </dl>
         </div>
       )}

--- a/apps/docs/src/components/learn/live-cursors-spring.tsx
+++ b/apps/docs/src/components/learn/live-cursors-spring.tsx
@@ -48,6 +48,43 @@ const LANES = [
   },
 ];
 
+const LEGEND = [
+  {
+    name: "Raw",
+    desc: "position snaps — no interpolation between updates",
+    kind: "raw" as const,
+  },
+  {
+    name: "Spring",
+    desc: "chases the target, arrives with a touch of overshoot",
+    kind: "spring" as const,
+  },
+] as const;
+
+function LegendSwatch({
+  kind: _kind,
+}: {
+  kind: (typeof LEGEND)[number]["kind"];
+}) {
+  if (kind === "spring") {
+    return (
+      <span className="relative h-3 w-8">
+        <span className="absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-[var(--foreground)]/15" />
+        <span className="absolute left-0 top-1/2 size-2.5 -translate-y-1/2 rounded-full border-2 border-dashed border-[var(--foreground)]/30" />
+        <span className="absolute right-1 top-1/2 size-2.5 -translate-y-1/2 rounded-full bg-[var(--foreground)]/70 shadow-sm" />
+        <span className="absolute right-0 top-1/2 size-1.5 -translate-y-1/2 rounded-full bg-[var(--foreground)]/35" />
+      </span>
+    );
+  }
+  return (
+    <span className="relative h-3 w-8">
+      <span className="absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-[var(--foreground)]/15" />
+      <span className="absolute left-0 top-1/2 size-2.5 -translate-y-1/2 rounded-full border-2 border-dashed border-[var(--foreground)]/30" />
+      <span className="absolute right-0 top-1/2 size-2.5 -translate-y-1/2 rounded-full bg-[var(--foreground)]/70 shadow-sm" />
+    </span>
+  );
+}
+
 export function LiveCursorsSpring() {
   return (
     <ScrollScene label="The motion" note="same update, two ways to land it">
@@ -80,24 +117,17 @@ export function LiveCursorsSpring() {
           </div>
 
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/70 ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Raw
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                position snaps — no interpolation between updates
-              </dd>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/70 ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Spring
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                chases the target, arrives with a touch of overshoot
-              </dd>
-            </div>
+            {LEGEND.map((item) => (
+              <div key={item.name} className="flex flex-col gap-1.5">
+                <LegendSwatch kind={item.kind} />
+                <dt className="font-medium text-[13px] text-fd-foreground">
+                  {item.name}
+                </dt>
+                <dd className="text-[12px] text-fd-muted-foreground">
+                  {item.desc}
+                </dd>
+              </div>
+            ))}
           </dl>
         </div>
       )}

--- a/apps/docs/src/components/learn/live-cursors-spring.tsx
+++ b/apps/docs/src/components/learn/live-cursors-spring.tsx
@@ -61,11 +61,7 @@ const LEGEND = [
   },
 ] as const;
 
-function LegendSwatch({
-  kind: _kind,
-}: {
-  kind: (typeof LEGEND)[number]["kind"];
-}) {
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
   if (kind === "spring") {
     return (
       <span className="relative h-3 w-8">

--- a/apps/docs/src/components/learn/magic-input-anatomy.tsx
+++ b/apps/docs/src/components/learn/magic-input-anatomy.tsx
@@ -36,23 +36,43 @@ const PLATES: Plate[] = [
   },
 ];
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "front" | "edge" | "shadow";
+}[] = [
   {
     name: "Front",
     desc: "the real <input> you type in",
-    swatch: "bg-[var(--card)]",
+    kind: "front",
   },
   {
     name: "Edge",
     desc: "colored gradient, fakes the 3D wall",
-    swatch: "bg-[var(--foreground)]/15",
+    kind: "edge",
   },
   {
     name: "Shadow",
     desc: "blurred, grounds the lift",
-    swatch: "bg-black/60",
+    kind: "shadow",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "front") {
+    return (
+      <span className="h-3.5 w-7 rounded-[4px] border-2 border-[var(--foreground)]/40 bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "edge") {
+    return (
+      <span className="h-3.5 w-7 rounded-[4px] bg-[var(--foreground)]/15 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-3.5 w-7 rounded-[4px] bg-black/60 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function MagicInputAnatomy() {
   return (
@@ -88,9 +108,7 @@ export function MagicInputAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/magic-tab-anatomy.tsx
+++ b/apps/docs/src/components/learn/magic-tab-anatomy.tsx
@@ -26,23 +26,43 @@ const CSS = `
 .mta-static .mta-col { opacity: 1; animation: none; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "front" | "edge" | "shadow";
+}[] = [
   {
     name: "Front",
     desc: "label face — lifts −4px when selected",
-    swatch: "bg-[var(--card)]",
+    kind: "front",
   },
   {
     name: "Edge",
     desc: "gradient wall, fakes the 3D side",
-    swatch: "bg-[var(--muted)]",
+    kind: "edge",
   },
   {
     name: "Shadow",
     desc: "blurred, grounds the raised tab",
-    swatch: "bg-black/60",
+    kind: "shadow",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "front") {
+    return (
+      <span className="h-3 w-6 rounded-lg border border-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "edge") {
+    return (
+      <span className="h-3 w-6 rounded-lg bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-3 w-6 rounded-lg bg-black/60 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 function TokenBar({ className = "" }: { className?: string }) {
   return (
@@ -152,9 +172,7 @@ export function MagicTabAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/magnetic-parallax.tsx
+++ b/apps/docs/src/components/learn/magnetic-parallax.tsx
@@ -27,18 +27,33 @@ const CSS = `
 }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "shell" | "label";
+}[] = [
   {
     name: "Shell",
     desc: "the whole button, full spring offset",
-    swatch: "border border-fd-border bg-[var(--card)]",
+    kind: "shell",
   },
   {
     name: "Label",
     desc: "nested inside — adds its own ×0.4 (0 if staticLabel)",
-    swatch: "bg-[var(--foreground)]",
+    kind: "label",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "label") {
+    return (
+      <span className="h-1.5 w-6 rounded-full bg-[var(--foreground)]/30 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-3.5 w-6 rounded-[10px] border border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function MagneticParallax() {
   return (
@@ -84,9 +99,7 @@ export function MagneticParallax() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ring-1 ring-fd-border ring-inset ${item.swatch}`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/magnetic-pull.tsx
+++ b/apps/docs/src/components/learn/magnetic-pull.tsx
@@ -34,19 +34,39 @@ const CSS = `
 }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
-  { name: "Cursor", desc: "clientX inside the sensor", swatch: "bg-black/70" },
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "cursor" | "target" | "shell";
+}[] = [
+  { name: "Cursor", desc: "clientX inside the sensor", kind: "cursor" },
   {
     name: "Raw target",
     desc: "(x − cx) × strength, no easing",
-    swatch: "border-2 border-dashed border-black/50 bg-transparent",
+    kind: "target",
   },
   {
     name: "Spring shell",
     desc: "170 / 12 / 0.1 — lags, then overshoots",
-    swatch: "border border-fd-border bg-[var(--card)]",
+    kind: "shell",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "cursor") {
+    return (
+      <span className="size-2.5 rounded-full bg-black/70 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "target") {
+    return (
+      <span className="h-3.5 w-6 rounded-[10px] border-2 border-dashed border-black/50 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-3.5 w-6 rounded-[10px] border border-fd-border bg-[var(--card)] shadow-sm ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function MagneticPull() {
   return (
@@ -80,9 +100,7 @@ export function MagneticPull() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`size-3.5 rounded-full ring-1 ring-fd-border ring-inset ${item.swatch}`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/marquee-anatomy.tsx
+++ b/apps/docs/src/components/learn/marquee-anatomy.tsx
@@ -21,23 +21,43 @@ const CSS = `
 
 const ITEMS = [0, 1, 2, 3] as const;
 
-const LEGEND = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "track0" | "trackN" | "repeat";
+}[] = [
   {
     name: "Track 0",
     desc: "live copy — readable to AT",
-    swatch: "bg-[var(--muted)]",
+    kind: "track0",
   },
   {
     name: "Track 1…n",
     desc: "identical clones, aria-hidden",
-    swatch: "bg-[var(--card)] ring-1 ring-fd-border ring-inset",
+    kind: "trackN",
   },
   {
     name: "repeat",
     desc: "Math.max(2, repeat) tracks",
-    swatch: "bg-[var(--foreground)]/40",
+    kind: "repeat",
   },
-] as const;
+];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "track0") {
+    return (
+      <span className="h-3 w-5 rounded-md bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "trackN") {
+    return (
+      <span className="h-3 w-5 rounded-md border border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/40 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 function Track({ tone, delay }: { tone: "muted" | "card"; delay: string }) {
   return (
@@ -86,9 +106,7 @@ export function MarqueeAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/marquee-fade.tsx
+++ b/apps/docs/src/components/learn/marquee-fade.tsx
@@ -29,19 +29,42 @@ const LEGEND = [
   {
     name: "Mask",
     desc: "linear-gradient transparent → black 12%/88%",
-    swatch: "bg-[var(--foreground)]/25",
+    kind: "mask" as const,
   },
   {
     name: "Horizontal",
     desc: "to_right on both mask-image props",
-    swatch: "bg-[var(--muted)]",
+    kind: "horizontal" as const,
   },
   {
     name: "Vertical",
     desc: "to_bottom when direction is up/down",
-    swatch: "bg-[var(--card)] ring-1 ring-fd-border ring-inset",
+    kind: "vertical" as const,
   },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "mask") {
+    return (
+      <span
+        className="h-3 w-5 rounded-md ring-1 ring-fd-border ring-inset"
+        style={{
+          backgroundImage:
+            "linear-gradient(to right, transparent, var(--foreground) 12%, var(--foreground) 88%, transparent)",
+          opacity: 0.25,
+        }}
+      />
+    );
+  }
+  if (kind === "vertical") {
+    return (
+      <span className="h-3 w-5 rounded-md border border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-3 w-5 rounded-md bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function MarqueeFade() {
   return (
@@ -99,9 +122,7 @@ export function MarqueeFade() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/marquee-track.tsx
+++ b/apps/docs/src/components/learn/marquee-track.tsx
@@ -73,19 +73,35 @@ const LEGEND = [
   {
     name: "Duration",
     desc: "--duration from speed prop",
-    swatch: "bg-[var(--foreground)]/40",
+    kind: "duration" as const,
   },
   {
     name: "Reverse",
     desc: "animation-direction: reverse",
-    swatch: "bg-[var(--muted)]",
+    kind: "reverse" as const,
   },
   {
     name: "Pause",
     desc: "group-hover play-state paused",
-    swatch: "bg-[var(--card)] ring-1 ring-fd-border ring-inset",
+    kind: "pause" as const,
   },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "pause") {
+    return (
+      <span className="size-2.5 rounded-full bg-[var(--foreground)]/60 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "reverse") {
+    return (
+      <span className="h-3 w-5 rounded-md border border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-3 w-5 rounded-md bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function MarqueeTrack() {
   return (
@@ -122,9 +138,7 @@ export function MarqueeTrack() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/mega-menu-anatomy.tsx
+++ b/apps/docs/src/components/learn/mega-menu-anatomy.tsx
@@ -37,23 +37,43 @@ const CSS = `
 .mma-static .mma-link { opacity: 1; animation: none; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "triggers" | "pill" | "panel";
+}[] = [
   {
     name: "Triggers",
     desc: "plain buttons/links — one per top-level item",
-    swatch: "bg-[var(--foreground)]/25",
+    kind: "triggers",
   },
   {
     name: "Highlight pill",
     desc: "one layoutId span, rendered only under the hot trigger",
-    swatch: "bg-[var(--foreground)]/12",
+    kind: "pill",
   },
   {
     name: "Panel",
     desc: "opens below a trigger that carries sections",
-    swatch: "bg-[var(--card)]",
+    kind: "panel",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "triggers") {
+    return (
+      <span className="h-1.5 w-6 rounded-full bg-[var(--foreground)]/25 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "pill") {
+    return (
+      <span className="h-3 w-7 rounded-md bg-[var(--foreground)]/12 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-4 w-8 rounded-lg border border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function MegaMenuAnatomy() {
   return (
@@ -119,9 +139,7 @@ export function MegaMenuAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/morph-gallery-anatomy.tsx
+++ b/apps/docs/src/components/learn/morph-gallery-anatomy.tsx
@@ -17,28 +17,53 @@ const CSS = `
 .mga-static .mga-el { opacity: 1; animation: none; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "tile" | "layoutId" | "detail" | "nav";
+}[] = [
   {
     name: "Tile",
     desc: "grid button, layoutId starts here",
-    swatch: "bg-[var(--card)]",
+    kind: "tile",
   },
   {
     name: "layoutId",
     desc: "one id, measured on both ends",
-    swatch: "bg-[var(--foreground)]/40",
+    kind: "layoutId",
   },
   {
     name: "Detail",
     desc: 'role="dialog", same image element',
-    swatch: "bg-[var(--muted)]",
+    kind: "detail",
   },
   {
     name: "Nav",
     desc: "prev / next / close, fade in on their own",
-    swatch: "bg-[var(--foreground)]/25",
+    kind: "nav",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "tile") {
+    return (
+      <span className="size-3 rounded-md bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "layoutId") {
+    return (
+      <span className="size-3 rounded-md bg-[var(--foreground)]/40 ring-2 ring-[var(--foreground)]/60 ring-inset" />
+    );
+  }
+  if (kind === "detail") {
+    return (
+      <span className="h-4 w-7 rounded-lg border border-border bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="size-3 rounded-full border border-border bg-[var(--card)] shadow-sm ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function MorphGalleryAnatomy() {
   return (
@@ -102,9 +127,7 @@ export function MorphGalleryAnatomy() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5 sm:grid-cols-4">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/morph-gallery-morph.tsx
+++ b/apps/docs/src/components/learn/morph-gallery-morph.tsx
@@ -32,18 +32,35 @@ const CSS = `
 .mgm-static .mgm-backdrop { animation: none; opacity: 1; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "image" | "backdrop";
+}[] = [
   {
     name: "Image box",
     desc: "shared layoutId, spring 320 / 32 / 0.9",
-    swatch: "bg-[var(--muted)]",
+    kind: "image",
   },
   {
     name: "Backdrop",
     desc: "flat opacity tween, 0.2s — finishes on its own",
-    swatch: "bg-black/50",
+    kind: "backdrop",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "backdrop") {
+    return (
+      <span className="h-3.5 w-8 rounded-sm bg-black/50 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="relative h-4 w-7 overflow-hidden rounded-lg bg-[var(--card)] shadow-sm ring-1 ring-fd-border ring-inset">
+      <span className="absolute inset-1 rounded-md bg-[var(--muted)]" />
+    </span>
+  );
+}
 
 export function MorphGalleryMorph() {
   return (
@@ -66,9 +83,7 @@ export function MorphGalleryMorph() {
           <dl className="grid w-full max-w-[420px] grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/morphing-dialog-anatomy.tsx
+++ b/apps/docs/src/components/learn/morphing-dialog-anatomy.tsx
@@ -26,28 +26,53 @@ function Bar({
   return <span className={`h-2 rounded-full ${w} ${tone}`} />;
 }
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "trigger" | "layoutId" | "content" | "close";
+}[] = [
   {
     name: "Trigger",
     desc: "layoutId on a small card",
-    swatch: "bg-[var(--muted)]",
+    kind: "trigger",
   },
   {
     name: "layoutId",
     desc: "same id, measured on both ends",
-    swatch: "bg-[var(--foreground)]/40",
+    kind: "layoutId",
   },
   {
     name: "Content",
     desc: "layoutId on the modal panel",
-    swatch: "bg-[var(--card)]",
+    kind: "content",
   },
   {
     name: "Close",
     desc: "fades in, not part of the morph",
-    swatch: "bg-[var(--foreground)]/25",
+    kind: "close",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "trigger") {
+    return (
+      <span className="h-4 w-6 rounded-lg border border-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "layoutId") {
+    return (
+      <span className="h-1.5 w-5 rounded-full bg-[var(--foreground)]/40 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "content") {
+    return (
+      <span className="h-5 w-7 rounded-xl border border-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="size-2.5 rounded-full bg-[var(--foreground)]/20 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function MorphingDialogAnatomy() {
   return (
@@ -108,9 +133,7 @@ export function MorphingDialogAnatomy() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5 sm:grid-cols-4">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/morphing-dialog-backdrop.tsx
+++ b/apps/docs/src/components/learn/morphing-dialog-backdrop.tsx
@@ -36,23 +36,45 @@ const CSS = `
 .mdb-static .mdb-close    { animation: none; opacity: 1; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "backdrop" | "panel" | "close";
+}[] = [
   {
     name: "Backdrop",
     desc: "opacity 0 → 1, 0.2s tween",
-    swatch: "bg-black/50",
+    kind: "backdrop",
   },
   {
     name: "Panel",
     desc: "spring settle, 0.9 → 1.04 → 1",
-    swatch: "bg-[var(--card)]",
+    kind: "panel",
   },
   {
     name: "Close",
     desc: "opacity fade, delay 0.1s",
-    swatch: "bg-[var(--foreground)]/25",
+    kind: "close",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "backdrop") {
+    return (
+      <span className="h-3.5 w-8 rounded-sm bg-black/50 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "close") {
+    return (
+      <span className="size-4 rounded-full bg-background/80 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="relative h-3.5 w-6 overflow-hidden rounded-xl bg-[var(--card)] shadow-sm ring-1 ring-fd-border ring-inset">
+      <span className="absolute inset-x-1 top-1 h-2 rounded-md bg-[var(--muted)]" />
+    </span>
+  );
+}
 
 export function MorphingDialogBackdrop() {
   return (
@@ -77,9 +99,7 @@ export function MorphingDialogBackdrop() {
           <dl className="grid w-full max-w-[420px] grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/notification-inbox-anatomy.tsx
+++ b/apps/docs/src/components/learn/notification-inbox-anatomy.tsx
@@ -24,28 +24,53 @@ const CSS = `
 .nia-static .nia-part { opacity: 1; animation: none; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "header" | "group" | "row" | "dot";
+}[] = [
   {
     name: "Header",
     desc: "title + unread badge + mark-all-read",
-    swatch: "bg-[var(--foreground)]/40",
+    kind: "header",
   },
   {
     name: "Group label",
     desc: "sticky top-0, one per group() bucket",
-    swatch: "bg-[var(--muted)]",
+    kind: "group",
   },
   {
     name: "Row",
     desc: "avatar + two text lines + time",
-    swatch: "bg-[var(--foreground)]/25",
+    kind: "row",
   },
   {
     name: "Unread dot",
     desc: "primary, only while notification.read is falsy",
-    swatch: "bg-primary",
+    kind: "dot",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "header") {
+    return (
+      <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/40 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "group") {
+    return (
+      <span className="h-2 w-8 rounded-sm bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "row") {
+    return (
+      <span className="size-3 rounded-full bg-[var(--foreground)]/15 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="size-2 rounded-full bg-primary ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function NotificationInboxAnatomy() {
   return (
@@ -114,9 +139,7 @@ export function NotificationInboxAnatomy() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/notification-inbox-badge.tsx
+++ b/apps/docs/src/components/learn/notification-inbox-badge.tsx
@@ -27,23 +27,43 @@ const CSS = `
 .nib-static .nib-press { animation: none; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "badge" | "markAll" | "dot";
+}[] = [
   {
     name: "Badge",
     desc: "AnimatePresence, scale 0.6 → 1 spring",
-    swatch: "bg-primary",
+    kind: "badge",
   },
   {
     name: "Mark all read",
     desc: "flips every notification.read at once",
-    swatch: "bg-[var(--foreground)]/20",
+    kind: "markAll",
   },
   {
     name: "Unread dot",
     desc: "clears in the same frame as the badge",
-    swatch: "bg-primary",
+    kind: "dot",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "markAll") {
+    return (
+      <span className="h-2 w-8 rounded-full bg-[var(--foreground)]/20 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "dot") {
+    return (
+      <span className="size-2 rounded-full bg-primary ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="size-5 rounded-full bg-primary ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function NotificationInboxBadge() {
   return (
@@ -84,9 +104,7 @@ export function NotificationInboxBadge() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/notification-inbox-swipe.tsx
+++ b/apps/docs/src/components/learn/notification-inbox-swipe.tsx
@@ -35,23 +35,41 @@ const CSS = `
 .nis-static .nis-strip { animation: none; opacity: 0; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "row" | "threshold" | "archive";
+}[] = [
   {
     name: "Row",
     desc: 'drag="x" · dragElastic left 0.7, right 0',
-    swatch: "bg-[var(--foreground)]/25",
+    kind: "row",
   },
   {
     name: "Threshold",
     desc: "offset.x < -80",
-    swatch: "bg-[var(--foreground)]/40",
+    kind: "threshold",
   },
   {
     name: "Archive strip",
     desc: "sits behind the row, revealed while dragging",
-    swatch: "bg-destructive",
+    kind: "archive",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "threshold") {
+    return <span className="h-4 w-px bg-[var(--foreground)]/35" />;
+  }
+  if (kind === "archive") {
+    return (
+      <span className="h-3.5 w-6 rounded-sm bg-destructive ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-3.5 w-8 rounded-md border border-fd-border bg-[var(--card)]" />
+  );
+}
 
 export function NotificationInboxSwipe() {
   return (
@@ -90,9 +108,7 @@ export function NotificationInboxSwipe() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/number-ticker-spring.tsx
+++ b/apps/docs/src/components/learn/number-ticker-spring.tsx
@@ -33,23 +33,43 @@ const CSS = `
 
 const HEIGHTS = [28, 44, 62, 78, 92];
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "overshoot" | "stagger" | "defaults";
+}[] = [
   {
     name: "overshoot",
     desc: "scaleY past 1, then settle — spring feel",
-    swatch: "bg-[var(--foreground)]/40",
+    kind: "overshoot",
   },
   {
     name: "stagger",
     desc: "each slot delayed 90ms — digits cascade in",
-    swatch: "bg-[var(--foreground)]/70",
+    kind: "stagger",
   },
   {
     name: "defaults",
     desc: "damping 60 · stiffness 100",
-    swatch: "bg-[var(--foreground)]",
+    kind: "defaults",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "stagger") {
+    return (
+      <span className="h-4 w-2.5 rounded-sm bg-[var(--foreground)]/65 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "defaults") {
+    return (
+      <span className="h-5 w-2.5 rounded-sm bg-[var(--foreground)]/65 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-3.5 w-2.5 origin-bottom rounded-sm bg-[var(--foreground)]/65 ring-1 ring-fd-border ring-inset [transform:scaleY(1.08)]" />
+  );
+}
 
 export function NumberTickerSpring() {
   return (
@@ -87,9 +107,7 @@ export function NumberTickerSpring() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ring-1 ring-fd-border ring-inset ${item.swatch}`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/number-ticker-view.tsx
+++ b/apps/docs/src/components/learn/number-ticker-view.tsx
@@ -39,23 +39,49 @@ const CSS = `
 .ntv-static .ntv-fire   { animation: none; opacity: 1; transform: none; }
 `;
 
-const STEPS: { name: string; desc: string; swatch: string }[] = [
+const STEPS: {
+  name: string;
+  desc: string;
+  kind: "gate" | "delay" | "fire";
+}[] = [
   {
     name: "in view",
     desc: "useInView(ref, { once: true })",
-    swatch: "bg-[var(--foreground)]/30",
+    kind: "gate",
   },
   {
     name: "delay",
     desc: "setTimeout(delay * 1000)",
-    swatch: "bg-[var(--foreground)]/55",
+    kind: "delay",
   },
   {
     name: "set target",
     desc: "motionValue.set(target)",
-    swatch: "bg-[var(--foreground)]",
+    kind: "fire",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof STEPS)[number]["kind"] }) {
+  if (kind === "fire") {
+    return (
+      <span className="flex size-6 items-center justify-center rounded-lg border border-fd-border bg-[var(--card)]">
+        <span className="size-2.5 rounded-full bg-[var(--foreground)]" />
+      </span>
+    );
+  }
+  if (kind === "delay") {
+    return (
+      <span className="flex h-6 w-10 items-center justify-center rounded-lg border border-fd-border bg-[var(--card)] px-1.5">
+        <span className="h-1.5 w-full rounded-full bg-[var(--foreground)]/65" />
+      </span>
+    );
+  }
+  return (
+    <span className="flex h-6 w-10 items-center justify-center rounded-lg border border-fd-border bg-[var(--card)] px-1.5">
+      <span className="h-1.5 w-full rounded-full bg-[var(--foreground)]/45" />
+    </span>
+  );
+}
 
 export function NumberTickerView() {
   return (
@@ -116,9 +142,7 @@ export function NumberTickerView() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {STEPS.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ring-1 ring-fd-border ring-inset ${item.swatch}`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/orbiting-circles-anatomy.tsx
+++ b/apps/docs/src/components/learn/orbiting-circles-anatomy.tsx
@@ -28,19 +28,35 @@ const LEGEND = [
   {
     name: "Path",
     desc: "showPath — a faint static circle at radius*2",
-    swatch: "border border-dashed border-[var(--foreground)]/40 bg-transparent",
+    kind: "path" as const,
   },
   {
     name: "Ring",
     desc: "invisible motion.div, rotates 360° and carries every slot",
-    swatch: "bg-transparent ring-1 ring-[var(--foreground)]/40 ring-inset",
+    kind: "ring" as const,
   },
   {
     name: "Slot",
     desc: "rotate(angle) translateY(−radius), one per child",
-    swatch: "bg-[var(--foreground)]/50",
+    kind: "slot" as const,
   },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "path") {
+    return (
+      <span className="size-3.5 rounded-full border border-dashed border-[var(--foreground)]/40" />
+    );
+  }
+  if (kind === "ring") {
+    return (
+      <span className="size-3.5 rounded-full bg-transparent ring-1 ring-[var(--foreground)]/40 ring-inset" />
+    );
+  }
+  return (
+    <span className="size-3.5 rounded-full border border-fd-border bg-[var(--card)] shadow-sm" />
+  );
+}
 
 export function OrbitingCirclesAnatomy() {
   return (
@@ -147,9 +163,7 @@ export function OrbitingCirclesAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/orbiting-circles-counter.tsx
+++ b/apps/docs/src/components/learn/orbiting-circles-counter.tsx
@@ -27,14 +27,29 @@ const LEGEND = [
   {
     name: "Without",
     desc: "no inner transform — content tumbles with the ring",
-    swatch: "bg-[var(--foreground)]/60",
+    kind: "without" as const,
   },
   {
     name: "With",
     desc: "rotate([-angle, -angle-360]) cancels the ring exactly",
-    swatch: "bg-[var(--foreground)]",
+    kind: "with" as const,
   },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "with") {
+    return (
+      <span className="relative flex size-4 items-center justify-center rounded-lg border border-fd-border bg-[var(--card)] shadow-sm ring-1 ring-fd-border ring-inset">
+        <span className="h-1.5 w-4 rounded-full bg-[var(--foreground)]/50" />
+      </span>
+    );
+  }
+  return (
+    <span className="relative flex size-4 items-center justify-center rounded-lg border border-fd-border bg-[var(--card)] shadow-sm ring-1 ring-fd-border ring-inset [transform:rotate(12deg)]">
+      <span className="h-1.5 w-4 rounded-full bg-[var(--foreground)]/50 [transform:rotate(-12deg)]" />
+    </span>
+  );
+}
 
 function Panel({
   caption,
@@ -100,9 +115,7 @@ export function OrbitingCirclesCounter() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/orbiting-circles-rings.tsx
+++ b/apps/docs/src/components/learn/orbiting-circles-rings.tsx
@@ -35,19 +35,37 @@ const LEGEND = [
   {
     name: "Inner ring",
     desc: `radius ${INNER.radius} · ${INNER.duration}s · forward`,
-    swatch: "bg-[var(--foreground)]/45",
+    kind: "inner" as const,
   },
   {
     name: "Outer ring",
     desc: `radius ${OUTER.radius} · ${OUTER.duration}s · reverse`,
-    swatch: "bg-[var(--foreground)]/70",
+    kind: "outer" as const,
   },
   {
     name: "Center",
     desc: "shared anchor — each ring is its own instance",
-    swatch: "bg-[var(--foreground)]/15",
+    kind: "center" as const,
   },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "center") {
+    return (
+      <span className="flex h-3.5 w-6 items-center justify-center rounded-xl bg-[var(--foreground)]/10 ring-1 ring-fd-border ring-inset">
+        <span className="h-1 w-4 rounded-full bg-[var(--foreground)]/40" />
+      </span>
+    );
+  }
+  if (kind === "outer") {
+    return (
+      <span className="size-4 rounded-full border border-dashed border-[var(--foreground)]/15 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="size-3 rounded-full border border-dashed border-[var(--foreground)]/15 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 function Slots({
   radius,
@@ -164,9 +182,7 @@ export function OrbitingCirclesRings() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/otp-anatomy.tsx
+++ b/apps/docs/src/components/learn/otp-anatomy.tsx
@@ -26,18 +26,33 @@ const CSS = `
 .oa-static .oa-ghost { opacity: 1; animation: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "cells" | "input";
+}[] = [
   {
     name: "Display cells",
     desc: "what you see — driven by value[i]",
-    swatch: "bg-[var(--card)]",
+    kind: "cells",
   },
   {
     name: "Hidden input",
     desc: "one size-0 field catches every key",
-    swatch: "bg-[var(--foreground)]/15",
+    kind: "input",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "cells") {
+    return (
+      <span className="size-3 rounded-md border border-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="size-3 rounded-md border-2 border-[var(--foreground)]/40 border-dashed bg-[var(--foreground)]/[0.06] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function OtpAnatomy() {
   return (
@@ -65,9 +80,7 @@ export function OtpAnatomy() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/particle-dissolve-anatomy.tsx
+++ b/apps/docs/src/components/learn/particle-dissolve-anatomy.tsx
@@ -46,23 +46,43 @@ const CSS = `
 .pda-static .pda-frame { animation: none; opacity: 1; transform: none; }
 `;
 
-const LEGEND = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "sample" | "targets" | "scatter";
+}[] = [
   {
     name: "Sample",
     desc: "offscreen canvas · alpha > 128",
-    swatch: "bg-[var(--muted)]",
+    kind: "sample",
   },
   {
     name: "Targets",
     desc: "tx, ty from pixel grid",
-    swatch: "bg-[var(--foreground)]/50",
+    kind: "targets",
   },
   {
     name: "Scatter",
     desc: "sx, sy random across canvas",
-    swatch: "bg-transparent ring-1 ring-[var(--foreground)]/40 ring-inset",
+    kind: "scatter",
   },
-] as const;
+];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "sample") {
+    return (
+      <span className="h-3.5 w-8 rounded-lg border border-dashed border-[var(--foreground)]/25 bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "targets") {
+    return (
+      <span className="size-1.5 rounded-[1px] bg-[var(--foreground)]/70 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="size-1.5 rounded-[1px] bg-transparent ring-1 ring-[var(--foreground)]/40 ring-inset" />
+  );
+}
 
 export function ParticleDissolveAnatomy() {
   return (
@@ -106,9 +126,7 @@ export function ParticleDissolveAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/particle-dissolve-cycle.tsx
+++ b/apps/docs/src/components/learn/particle-dissolve-cycle.tsx
@@ -58,23 +58,43 @@ const CSS = `
 }
 `;
 
-const LEGEND = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "assemble" | "disperse" | "loop";
+}[] = [
   {
     name: "Assemble",
     desc: "goal → 1 · easeInOut per particle",
-    swatch: "bg-[var(--foreground)]/50",
+    kind: "assemble",
   },
   {
     name: "Disperse",
     desc: "goal → 0 · back to sx, sy",
-    swatch: "bg-[var(--muted)]",
+    kind: "disperse",
   },
   {
     name: "Loop",
     desc: "flip goal every 2600ms",
-    swatch: "bg-transparent ring-1 ring-[var(--foreground)]/40 ring-inset",
+    kind: "loop",
   },
-] as const;
+];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "assemble") {
+    return (
+      <span className="size-1.5 rounded-[1px] bg-[var(--foreground)]/75 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "disperse") {
+    return (
+      <span className="size-1.5 rounded-[1px] bg-transparent opacity-20 ring-1 ring-[var(--foreground)]/40 ring-inset" />
+    );
+  }
+  return (
+    <span className="size-1.5 rounded-[1px] bg-transparent ring-1 ring-[var(--foreground)]/40 ring-inset" />
+  );
+}
 
 export function ParticleDissolveCycle() {
   return (
@@ -118,9 +138,7 @@ export function ParticleDissolveCycle() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/particle-dissolve-trigger.tsx
+++ b/apps/docs/src/components/learn/particle-dissolve-trigger.tsx
@@ -49,20 +49,45 @@ const COLS = [
     desc: "start() on effect resolve",
     bar: "pdt-mount",
     badge: null,
+    kind: "mount" as const,
   },
   {
     name: "In-view",
     desc: "IO threshold 0.3 · once",
     bar: "pdt-view",
     badge: "pdt-io",
+    kind: "inView" as const,
   },
   {
     name: "Hover",
     desc: "enter/leave flips goal",
     bar: "pdt-hover",
     badge: "pdt-ptr",
+    kind: "hover" as const,
   },
 ] as const;
+
+function LegendSwatch({ kind }: { kind: (typeof COLS)[number]["kind"] }) {
+  if (kind === "mount") {
+    return (
+      <span className="relative flex h-3.5 w-6 items-end justify-center rounded-md bg-[var(--foreground)]/40 ring-1 ring-fd-border ring-inset">
+        <span className="absolute top-0 size-1.5 rounded-full bg-[var(--foreground)]/50" />
+      </span>
+    );
+  }
+  if (kind === "inView") {
+    return (
+      <span className="relative flex h-3.5 w-6 items-end justify-center rounded-md bg-[var(--foreground)]/40 ring-1 ring-fd-border ring-inset">
+        <span className="absolute top-0 size-2.5 rounded-full border border-fd-border bg-[var(--muted)]" />
+      </span>
+    );
+  }
+  return (
+    <span className="relative flex h-3.5 w-6 items-end justify-center rounded-md bg-[var(--foreground)]/40 ring-1 ring-fd-border ring-inset">
+      <span className="absolute top-0 size-1.5 rounded-full bg-[var(--foreground)]/50" />
+    </span>
+  );
+}
 
 export function ParticleDissolveTrigger() {
   return (
@@ -106,7 +131,7 @@ export function ParticleDissolveTrigger() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {COLS.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/40 ring-1 ring-fd-border ring-inset" />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/pixel-grid-anatomy.tsx
+++ b/apps/docs/src/components/learn/pixel-grid-anatomy.tsx
@@ -41,7 +41,7 @@ export function PixelGridAnatomy() {
           </div>
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span className="size-2 rounded-[1px] bg-[var(--foreground)]/35 ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Cell
               </dt>
@@ -50,7 +50,7 @@ export function PixelGridAnatomy() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span className="size-2 rounded-[1px] bg-[var(--foreground)]/15 ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Cap
               </dt>
@@ -59,7 +59,7 @@ export function PixelGridAnatomy() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span className="size-2 rounded-[1px] border border-dashed border-[var(--foreground)]/30 ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Mode
               </dt>

--- a/apps/docs/src/components/learn/pixel-grid-flicker.tsx
+++ b/apps/docs/src/components/learn/pixel-grid-flicker.tsx
@@ -19,6 +19,34 @@ const CSS = `
 .pgf-static .pgf-c { animation: none; opacity: 0.25; }
 `;
 
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "cell" | "dimCell";
+}[] = [
+  {
+    name: "Chance",
+    desc: "flickerChance=0.3 / second",
+    kind: "cell",
+  },
+  {
+    name: "Draw",
+    desc: "opacity re-rolled when triggered",
+    kind: "dimCell",
+  },
+];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "cell") {
+    return (
+      <span className="size-2 rounded-[1px] bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="size-2 rounded-[1px] bg-[var(--foreground)]/15 ring-1 ring-fd-border ring-inset" />
+  );
+}
+
 export function PixelGridFlicker() {
   return (
     <ScrollScene label="Flicker" note="P(re-roll) = chance × dt">
@@ -47,24 +75,17 @@ export function PixelGridFlicker() {
             ))}
           </div>
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Chance
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                flickerChance=0.3 / second
-              </dd>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Draw
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                opacity re-rolled when triggered
-              </dd>
-            </div>
+            {LEGEND.map((item) => (
+              <div key={item.name} className="flex flex-col gap-1.5">
+                <LegendSwatch kind={item.kind} />
+                <dt className="font-medium text-[13px] text-fd-foreground">
+                  {item.name}
+                </dt>
+                <dd className="text-[12px] text-fd-muted-foreground">
+                  {item.desc}
+                </dd>
+              </div>
+            ))}
           </dl>
         </div>
       )}

--- a/apps/docs/src/components/learn/pixel-grid-reveal.tsx
+++ b/apps/docs/src/components/learn/pixel-grid-reveal.tsx
@@ -62,6 +62,34 @@ const GRID_STYLE = {
   gridTemplateColumns: "repeat(16, 0.5rem)",
 } as CSSProperties;
 
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "dimCell" | "cell";
+}[] = [
+  {
+    name: "Hidden",
+    desc: "baseline off — cells only under the disc",
+    kind: "dimCell",
+  },
+  {
+    name: "Falloff",
+    desc: "interactionRadius=120 · smoothstep edge",
+    kind: "cell",
+  },
+];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "dimCell") {
+    return (
+      <span className="size-2 rounded-[1px] bg-[var(--foreground)]/15 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="size-2 rounded-[1px] bg-[var(--foreground)]/75 ring-1 ring-fd-border ring-inset" />
+  );
+}
+
 export function PixelGridReveal() {
   return (
     <ScrollScene label="Reveal" note="smoothstep spotlight · intensity lerp">
@@ -118,24 +146,17 @@ export function PixelGridReveal() {
           </p>
 
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Hidden
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                baseline off — cells only under the disc
-              </dd>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Falloff
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                interactionRadius=120 · smoothstep edge
-              </dd>
-            </div>
+            {LEGEND.map((item) => (
+              <div key={item.name} className="flex flex-col gap-1.5">
+                <LegendSwatch kind={item.kind} />
+                <dt className="font-medium text-[13px] text-fd-foreground">
+                  {item.name}
+                </dt>
+                <dd className="text-[12px] text-fd-muted-foreground">
+                  {item.desc}
+                </dd>
+              </div>
+            ))}
           </dl>
         </div>
       )}

--- a/apps/docs/src/components/learn/presence-facepile-anatomy.tsx
+++ b/apps/docs/src/components/learn/presence-facepile-anatomy.tsx
@@ -19,23 +19,43 @@ const CSS = `
 .pfa-static .pfa-avatar { opacity: 1; animation: none; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "avatar" | "status" | "chip";
+}[] = [
   {
     name: "Avatar",
     desc: 'flex row, "-space-x-2" — DOM order, no z-index',
-    swatch: "bg-[var(--muted)]",
+    kind: "avatar",
   },
   {
     name: "Status dot",
     desc: "ring-2 ring-background, bottom-right corner",
-    swatch: "bg-[var(--foreground)]/50",
+    kind: "status",
   },
   {
     name: "+N chip",
     desc: "same row, same -space-x-2, opens on click",
-    swatch: "bg-[var(--foreground)]/30",
+    kind: "chip",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "avatar") {
+    return (
+      <span className="size-3 rounded-full bg-[var(--muted)] ring-2 ring-background ring-inset" />
+    );
+  }
+  if (kind === "status") {
+    return (
+      <span className="size-1.5 rounded-full bg-[var(--foreground)]/50 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="size-3 rounded-full bg-[var(--foreground)]/30 ring-2 ring-background ring-inset" />
+  );
+}
 
 export function PresenceFacepileAnatomy() {
   return (
@@ -72,9 +92,7 @@ export function PresenceFacepileAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/presence-facepile-enter.tsx
+++ b/apps/docs/src/components/learn/presence-facepile-enter.tsx
@@ -36,23 +36,43 @@ const CSS = `
 .pfe-static .pfe-joiner { animation: none; opacity: 0; transform: scale(0.5) translateX(-8px); }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "leave" | "reflow" | "join";
+}[] = [
   {
     name: "Leave",
     desc: "popLayout removes it immediately, opacity/scale down",
-    swatch: "bg-[var(--foreground)]/25",
+    kind: "leave",
   },
   {
     name: "Reflow",
     desc: "siblings shift on the same spring — a transform, not a resize",
-    swatch: "bg-[var(--foreground)]/40",
+    kind: "reflow",
   },
   {
     name: "Join",
     desc: "enters from opacity 0, scale 0.5, x -8",
-    swatch: "bg-[var(--muted)]",
+    kind: "join",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "leave") {
+    return (
+      <span className="size-3 rounded-full bg-[var(--muted)] opacity-40 ring-2 ring-background ring-inset" />
+    );
+  }
+  if (kind === "join") {
+    return (
+      <span className="size-3 rounded-full bg-[var(--foreground)]/30 ring-2 ring-background ring-inset" />
+    );
+  }
+  return (
+    <span className="size-3 rounded-full bg-[var(--muted)] ring-2 ring-background ring-inset" />
+  );
+}
 
 export function PresenceFacepileEnter() {
   return (
@@ -81,9 +101,7 @@ export function PresenceFacepileEnter() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/presence-facepile-status.tsx
+++ b/apps/docs/src/components/learn/presence-facepile-status.tsx
@@ -55,6 +55,48 @@ const CSS = `
 .pfs-static .pfs-dot { animation: none; transform: none; }
 `;
 
+function LegendSwatch({
+  kind,
+  color,
+}: {
+  kind: (typeof STATES)[number]["kind"];
+  color: string;
+}) {
+  if (kind === "typing") {
+    return (
+      <span className="flex gap-0.5 rounded-full bg-background px-0.5 py-0.5 ring-1 ring-fd-border ring-inset">
+        {[0, 1, 2].map((d) => (
+          <span
+            key={d}
+            className="size-1 rounded-full"
+            style={{ backgroundColor: color }}
+          />
+        ))}
+      </span>
+    );
+  }
+  if (kind === "ping") {
+    return (
+      <span className="relative size-2.5 rounded-full ring-2 ring-background ring-inset">
+        <span
+          className="absolute inset-0 rounded-full opacity-40 scale-150"
+          style={{ backgroundColor: color }}
+        />
+        <span
+          className="absolute inset-0 rounded-full"
+          style={{ backgroundColor: color }}
+        />
+      </span>
+    );
+  }
+  return (
+    <span
+      className="size-2.5 rounded-full ring-2 ring-background ring-inset"
+      style={{ backgroundColor: color }}
+    />
+  );
+}
+
 export function PresenceFacepileStatus() {
   return (
     <ScrollScene label="The showpiece" note="status color · typing bounces">
@@ -114,10 +156,7 @@ export function PresenceFacepileStatus() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5 sm:grid-cols-4">
             {STATES.map((state) => (
               <div key={state.name} className="flex flex-col gap-1.5">
-                <span
-                  className="h-1.5 w-8 rounded-full ring-1 ring-fd-border ring-inset"
-                  style={{ backgroundColor: state.color }}
-                />
+                <LegendSwatch kind={state.kind} color={state.color} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {state.name}
                 </dt>

--- a/apps/docs/src/components/learn/progressive-card-reveal-anatomy.tsx
+++ b/apps/docs/src/components/learn/progressive-card-reveal-anatomy.tsx
@@ -27,28 +27,53 @@ const ROWS: { width: string; expanded: boolean; delay: number }[] = [
   { width: "83%", expanded: false, delay: 240 },
 ];
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "root" | "card" | "collapsed" | "expanded";
+}[] = [
   {
     name: "Root",
     desc: "owns activeIndex, the only state",
-    swatch: "bg-[var(--muted)]",
+    kind: "root",
   },
   {
     name: "Card",
     desc: "compares its index, measures its own layout",
-    swatch: "bg-[var(--foreground)]/40",
+    kind: "card",
   },
   {
     name: "Collapsed",
     desc: "pill, width from distance to active",
-    swatch: "bg-[var(--foreground)]/20",
+    kind: "collapsed",
   },
   {
     name: "Expanded",
     desc: "full width, distance 0",
-    swatch: "bg-[var(--card)]",
+    kind: "expanded",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "root") {
+    return (
+      <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "card") {
+    return (
+      <span className="h-2 w-7 rounded-full bg-[var(--foreground)]/40 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "collapsed") {
+    return (
+      <span className="h-1.5 w-6 rounded-full bg-[var(--foreground)]/20 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-2.5 w-8 rounded-2xl border border-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function ProgressiveCardRevealAnatomy() {
   return (
@@ -90,9 +115,7 @@ export function ProgressiveCardRevealAnatomy() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/progressive-card-reveal-funnel.tsx
+++ b/apps/docs/src/components/learn/progressive-card-reveal-funnel.tsx
@@ -41,6 +41,34 @@ const CSS = `
 
 const CARDS = [0, 1, 2];
 
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "expanded" | "collapsed";
+}[] = [
+  {
+    name: "Active card",
+    desc: "100% width, 20px radius",
+    kind: "expanded",
+  },
+  {
+    name: "Collapsed cards",
+    desc: "narrower per step away, pill radius",
+    kind: "collapsed",
+  },
+];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "expanded") {
+    return (
+      <span className="h-2.5 w-8 rounded-2xl border border-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-1.5 w-6 rounded-full bg-[var(--foreground)]/20 ring-1 ring-fd-border ring-inset" />
+  );
+}
+
 export function ProgressiveCardRevealFunnel() {
   return (
     <ScrollScene label="The funnel morph" note="width + radius, layout-driven">
@@ -67,24 +95,17 @@ export function ProgressiveCardRevealFunnel() {
           </p>
 
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Active card
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                100% width, 20px radius
-              </dd>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/20 ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Collapsed cards
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                narrower per step away, pill radius
-              </dd>
-            </div>
+            {LEGEND.map((item) => (
+              <div key={item.name} className="flex flex-col gap-1.5">
+                <LegendSwatch kind={item.kind} />
+                <dt className="font-medium text-[13px] text-fd-foreground">
+                  {item.name}
+                </dt>
+                <dd className="text-[12px] text-fd-muted-foreground">
+                  {item.desc}
+                </dd>
+              </div>
+            ))}
           </dl>
         </div>
       )}

--- a/apps/docs/src/components/learn/prompt-composer-anatomy.tsx
+++ b/apps/docs/src/components/learn/prompt-composer-anatomy.tsx
@@ -25,23 +25,43 @@ function TokenBar({ w = "w-10", tone = 30 }: { w?: string; tone?: number }) {
   );
 }
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "chips" | "field" | "send";
+}[] = [
   {
     name: "Chips",
     desc: "AnimatePresence height, collapses to 0 when empty",
-    swatch: "bg-[var(--foreground)]/25",
+    kind: "chips",
   },
   {
     name: "Field",
     desc: "textarea, auto-grows to maxRows then scrolls",
-    swatch: "bg-[var(--foreground)]/40",
+    kind: "field",
   },
   {
     name: "Send",
     desc: "attach + model left, count + send right",
-    swatch: "bg-[var(--foreground)]/15",
+    kind: "send",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "chips") {
+    return (
+      <span className="inline-flex h-3.5 w-7 items-center rounded-lg border border-border bg-[var(--background)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "field") {
+    return (
+      <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/35 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="size-3 rounded-xl bg-[var(--foreground)]/80 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function PromptComposerAnatomy() {
   return (
@@ -104,9 +124,7 @@ export function PromptComposerAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ring-1 ring-fd-border ring-inset ${item.swatch}`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/prompt-composer-chips.tsx
+++ b/apps/docs/src/components/learn/prompt-composer-chips.tsx
@@ -37,18 +37,33 @@ const CSS = `
 .pcc-static .pcc-wrap, .pcc-static .pcc-a, .pcc-static .pcc-b { animation: none; opacity: 1; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "field" | "chips";
+}[] = [
   {
     name: "Wrapper",
     desc: "outer AnimatePresence, height 0 → auto + opacity",
-    swatch: "bg-[var(--foreground)]/20",
+    kind: "field",
   },
   {
     name: "Chip",
     desc: "scale 0.8 → 1 spring (520/32) + opacity, layout on exit",
-    swatch: "bg-[var(--foreground)]/40",
+    kind: "chips",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "field") {
+    return (
+      <span className="h-3 w-8 rounded-lg border border-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="inline-flex h-3.5 w-7 items-center rounded-lg border border-border bg-[var(--background)] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function PromptComposerChips() {
   return (
@@ -77,9 +92,7 @@ export function PromptComposerChips() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ring-1 ring-fd-border ring-inset ${item.swatch}`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/prompt-composer-send-morph.tsx
+++ b/apps/docs/src/components/learn/prompt-composer-send-morph.tsx
@@ -29,18 +29,33 @@ const CSS = `
 .pcsm-static .pcsm-stop { animation: none; opacity: 0; transform: scale(0.6); }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "send" | "stop";
+}[] = [
   {
     name: "Send",
     desc: 'key="send" · scale 1 → 0.6 out, 0.15s',
-    swatch: "bg-[var(--foreground)]/40",
+    kind: "send",
   },
   {
     name: "Stop",
     desc: 'key="stop" · scale 0.6 → 1 in, 0.15s, after send exits',
-    swatch: "bg-[var(--foreground)]/25",
+    kind: "stop",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "stop") {
+    return (
+      <span className="size-2.5 rounded-sm bg-[var(--foreground)]/50 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="size-3 rounded-xl bg-[var(--foreground)]/80 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function PromptComposerSendMorph() {
   return (
@@ -81,9 +96,7 @@ export function PromptComposerSendMorph() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ring-1 ring-fd-border ring-inset ${item.swatch}`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/prompt-suggestions-anatomy.tsx
+++ b/apps/docs/src/components/learn/prompt-suggestions-anatomy.tsx
@@ -25,23 +25,43 @@ function TokenBar({ w = "w-10", tone = 30 }: { w?: string; tone?: number }) {
   );
 }
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "grid" | "chips" | "list";
+}[] = [
   {
     name: "Grid",
     desc: "grid grid-cols-1 sm:grid-cols-2 · card + hint + arrow",
-    swatch: "bg-[var(--foreground)]/25",
+    kind: "grid",
   },
   {
     name: "Chips",
     desc: "flex flex-wrap · rounded-full pill, no hint",
-    swatch: "bg-[var(--foreground)]/40",
+    kind: "chips",
   },
   {
     name: "List",
     desc: "flex flex-col · full-width row + arrow",
-    swatch: "bg-[var(--foreground)]/15",
+    kind: "list",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "grid") {
+    return (
+      <span className="h-4 w-5 rounded-lg border border-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "chips") {
+    return (
+      <span className="h-2.5 w-7 rounded-full border border-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-2.5 w-8 rounded-lg border border-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function PromptSuggestionsAnatomy() {
   return (
@@ -118,9 +138,7 @@ export function PromptSuggestionsAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/prompt-suggestions-hover.tsx
+++ b/apps/docs/src/components/learn/prompt-suggestions-hover.tsx
@@ -27,18 +27,33 @@ const CSS = `
 .psh-static .psh-arrow { animation: none; opacity: 0; transform: translateX(-4px); }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "chips" | "grid";
+}[] = [
   {
     name: "Chip",
     desc: "translateY −1px only, no shadow, no arrow",
-    swatch: "bg-[var(--foreground)]/25",
+    kind: "chips",
   },
   {
     name: "Card",
     desc: "translateY −2px + shadow layer opacity .22→.5, arrow slides in",
-    swatch: "bg-[var(--foreground)]/40",
+    kind: "grid",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "grid") {
+    return (
+      <span className="h-4 w-5 rounded-lg border border-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-2.5 w-7 rounded-full border border-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function PromptSuggestionsHover() {
   return (
@@ -94,9 +109,7 @@ export function PromptSuggestionsHover() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/reorder-list-anatomy.tsx
+++ b/apps/docs/src/components/learn/reorder-list-anatomy.tsx
@@ -20,28 +20,53 @@ const CSS = `
 const ROWS = [0, 1, 2, 3];
 const LIFTED = 1;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "group" | "item" | "lift" | "shadow";
+}[] = [
   {
     name: "Group",
     desc: "Reorder.Group, holds values + axis",
-    swatch: "bg-[var(--muted)]",
+    kind: "group",
   },
   {
     name: "Item",
     desc: "Reorder.Item, one value each",
-    swatch: "bg-[var(--card)]",
+    kind: "item",
   },
   {
     name: "Lift",
     desc: "data-dragging → scale 1.03, CSS transition",
-    swatch: "bg-[var(--foreground)]/40",
+    kind: "lift",
   },
   {
     name: "Shadow",
     desc: "sibling overlay, opacity fade only",
-    swatch: "bg-[var(--foreground)]/20",
+    kind: "shadow",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "group") {
+    return (
+      <span className="h-4 w-8 rounded-lg border border-dashed border-border bg-transparent ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "item") {
+    return (
+      <span className="h-2.5 w-8 rounded-lg border border-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "lift") {
+    return (
+      <span className="h-2.5 w-8 scale-[1.03] rounded-lg border border-border bg-[var(--card)] shadow-lg ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-2.5 w-8 rounded-lg bg-[var(--foreground)]/20 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function ReorderListAnatomy() {
   return (
@@ -87,9 +112,7 @@ export function ReorderListAnatomy() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/reorder-list-flow.tsx
+++ b/apps/docs/src/components/learn/reorder-list-flow.tsx
@@ -69,18 +69,33 @@ const CSS = `
 .rlf-static .rlf-shadow { animation: none; opacity: 0; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "lift" | "item";
+}[] = [
   {
     name: "Dragged",
     desc: "follows the pointer, lift via data-dragging",
-    swatch: "bg-[var(--foreground)]/55",
+    kind: "lift",
   },
   {
     name: "Neighbor",
     desc: "springs into the vacated slot — same REORDER_SPRING",
-    swatch: "bg-[var(--foreground)]/22",
+    kind: "item",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "lift") {
+    return (
+      <span className="h-2.5 w-8 scale-[1.03] rounded-lg border border-border bg-[var(--card)] shadow-lg ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-2.5 w-8 rounded-lg border border-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 function Row({
   className,
@@ -163,9 +178,7 @@ export function ReorderListFlow() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/resizable-header-anatomy.tsx
+++ b/apps/docs/src/components/learn/resizable-header-anatomy.tsx
@@ -24,23 +24,43 @@ const CSS = `
 .rha-static .rha-piece { opacity: 1; animation: none; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "logo" | "links" | "cta";
+}[] = [
   {
     name: "Logo",
     desc: "brand mark, shrink-0 on the left",
-    swatch: "bg-[var(--foreground)]/40",
+    kind: "logo",
   },
   {
     name: "Links",
     desc: "nav row — carries the hover pill + active underline",
-    swatch: "bg-[var(--foreground)]/25",
+    kind: "links",
   },
   {
     name: "CTA",
     desc: "shrink-0 action slot on the right",
-    swatch: "bg-[var(--foreground)]/25",
+    kind: "cta",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "logo") {
+    return (
+      <span className="size-3 rounded-full bg-[var(--foreground)]/45 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "links") {
+    return (
+      <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/28 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-2.5 w-8 rounded-full bg-[var(--foreground)]/25 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function ResizableHeaderAnatomy() {
   return (
@@ -77,9 +97,7 @@ export function ResizableHeaderAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/resizable-header-morph.tsx
+++ b/apps/docs/src/components/learn/resizable-header-morph.tsx
@@ -4,11 +4,13 @@ import { ScrollScene } from "./scroll-scene";
 
 /**
  * The signature move: as `scrollY` crosses `scrollThreshold` the nav flips from a
- * wide rounded bar to a compact floating pill. Here a scroll thumb travels down a
- * rail past a threshold tick, and the bar collapses the instant it passes — the
- * real component drives this from `useMotionValueEvent(scrollY, "change", …)`.
- * The size change is faked with transform only (scaleX/scaleY/translateY), the
- * same way framer's `layout` prop FLIPs it — never animated width/height.
+ * wide `rounded-2xl` bar (`max-w-5xl`) to a compact `rounded-full` pill
+ * (`max-w-2xl`). The real component does this with Framer `layout` + a class
+ * swap — children keep their size; only the shell width/radius/padding change.
+ * This scene mirrors that: animate `width` + `border-radius` + padding, never
+ * `scaleX`/`scaleY` (those squash the logo into an ellipse). Radius stays
+ * pill-shaped while width changes, then settles to `rounded-2xl` only when
+ * fully expanded — so expand never flashes boxy corners.
  */
 const CSS = `
 @keyframes rhm-scroll {
@@ -16,29 +18,96 @@ const CSS = `
   46%, 66% { transform: translateY(60px); }
   100%     { transform: translateY(0); }
 }
+/* Radius stays pill while width changes — only settle to rounded-2xl
+   once fully expanded. Otherwise expand interpolates 9999px→1rem on a
+   still-narrow bar and corners go boxy mid-flight. */
 @keyframes rhm-bar {
-  0%, 20%  { transform: translateY(0) scaleX(1) scaleY(1); }
-  46%, 66% { transform: translateY(-4px) scaleX(0.66) scaleY(0.82); }
-  92%, 100%{ transform: translateY(0) scaleX(1) scaleY(1); }
+  0%, 16% {
+    width: 100%;
+    border-radius: 1rem;
+    padding: 0.75rem 1rem;
+    gap: 1rem;
+  }
+  28% {
+    width: 100%;
+    border-radius: 9999px;
+    padding: 0.75rem 1rem;
+    gap: 1rem;
+  }
+  46%, 66% {
+    width: 68%;
+    border-radius: 9999px;
+    padding: 0.5rem 0.75rem;
+    gap: 0.75rem;
+  }
+  82% {
+    width: 100%;
+    border-radius: 9999px;
+    padding: 0.75rem 1rem;
+    gap: 1rem;
+  }
+  92%, 100% {
+    width: 100%;
+    border-radius: 1rem;
+    padding: 0.75rem 1rem;
+    gap: 1rem;
+  }
 }
 .rhm-scroll { animation: rhm-scroll 4.4s cubic-bezier(0.4,0,0.2,1) infinite; }
-.rhm-bar    { animation: rhm-bar 4.4s cubic-bezier(0.34,1.4,0.64,1) infinite; transform-origin: top center; }
+/* No spring overshoot — a 1.4 bounce on border-radius undershoots
+   past 1rem toward 0 and the corners flash square on expand. */
+.rhm-bar {
+  animation: rhm-bar 4.4s cubic-bezier(0.4,0,0.2,1) infinite;
+  width: 100%;
+  border-radius: 1rem;
+  padding: 0.75rem 1rem;
+  gap: 1rem;
+}
 .rhm-static .rhm-scroll { animation: none; transform: translateY(60px); }
-.rhm-static .rhm-bar    { animation: none; transform: scaleX(0.66) scaleY(0.82); transform-origin: top center; }
+.rhm-static .rhm-bar {
+  animation: none;
+  width: 68%;
+  border-radius: 9999px;
+  padding: 0.5rem 0.75rem;
+  gap: 0.75rem;
+}
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "expanded" | "collapsed";
+}[] = [
   {
     name: "Expanded",
     desc: "max-w-5xl · rounded-2xl · scrollY ≤ threshold",
-    swatch: "bg-[var(--card)]",
+    kind: "expanded",
   },
   {
     name: "Collapsed",
     desc: "max-w-2xl · rounded-full pill · past threshold",
-    swatch: "bg-[var(--foreground)]/25",
+    kind: "collapsed",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "expanded") {
+    return (
+      <span className="flex h-5 w-11 items-center gap-1 rounded-2xl border border-border bg-[var(--card)] px-1.5 shadow-sm">
+        <span className="size-1.5 shrink-0 rounded-full bg-[var(--foreground)]/45" />
+        <span className="h-1 flex-1 rounded-full bg-[var(--foreground)]/28" />
+        <span className="h-2 w-3 shrink-0 rounded-full bg-[var(--foreground)]/25" />
+      </span>
+    );
+  }
+  return (
+    <span className="flex h-4 w-8 items-center gap-0.5 rounded-full border border-border bg-[var(--card)] px-1 shadow-sm">
+      <span className="size-1.5 shrink-0 rounded-full bg-[var(--foreground)]/45" />
+      <span className="h-1 flex-1 rounded-full bg-[var(--foreground)]/28" />
+      <span className="h-1.5 w-2.5 shrink-0 rounded-full bg-[var(--foreground)]/25" />
+    </span>
+  );
+}
 
 export function ResizableHeaderMorph() {
   return (
@@ -52,20 +121,20 @@ export function ResizableHeaderMorph() {
             key={cycle}
             className={`flex w-full items-start gap-6 ${reduced ? "rhm-static" : ""}`}
           >
-            {/* Scroll rail: a thumb travels down past the threshold tick. */}
+            {/* Scroll rail: thumb travels down past the threshold tick. */}
             <div className="relative mt-1 h-[88px] w-1.5 shrink-0 rounded-full bg-[var(--foreground)]/10">
               <div className="absolute inset-x-[-5px] top-[18px] h-px bg-[var(--foreground)]/40" />
               <div className="rhm-scroll absolute inset-x-0 top-0 h-6 rounded-full bg-[var(--foreground)]/40" />
             </div>
 
-            {/* Header surface — logo, nav bars, CTA — scaled by transform. */}
+            {/* Shell width/radius morph — children stay unscaled. */}
             <div className="min-w-0 flex-1 pt-1">
-              <div className="rhm-bar flex items-center justify-between gap-4 rounded-full border border-border bg-[var(--card)] px-4 py-3 shadow-sm">
+              <div className="rhm-bar mx-auto flex items-center justify-between border border-border bg-[var(--card)] shadow-sm">
                 <span className="size-5 shrink-0 rounded-full bg-[var(--foreground)]/45" />
-                <div className="flex items-center gap-3">
-                  <span className="h-2 w-10 rounded-full bg-[var(--foreground)]/30" />
-                  <span className="h-2 w-10 rounded-full bg-[var(--foreground)]/30" />
-                  <span className="h-2 w-10 rounded-full bg-[var(--foreground)]/30" />
+                <div className="flex min-w-0 items-center gap-3 overflow-hidden">
+                  <span className="h-2 w-10 shrink-0 rounded-full bg-[var(--foreground)]/30" />
+                  <span className="h-2 w-10 shrink-0 rounded-full bg-[var(--foreground)]/30" />
+                  <span className="h-2 w-10 shrink-0 rounded-full bg-[var(--foreground)]/30" />
                 </div>
                 <span className="h-6 w-16 shrink-0 rounded-full bg-[var(--foreground)]/25" />
               </div>
@@ -75,9 +144,7 @@ export function ResizableHeaderMorph() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/resizable-header-pills.tsx
+++ b/apps/docs/src/components/learn/resizable-header-pills.tsx
@@ -30,18 +30,33 @@ const CSS = `
 .rhp-static .rhp-underline { animation: none; transform: translateX(${PITCH * 2}px); }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "hoverPill" | "underline";
+}[] = [
   {
     name: "Hover pill",
     desc: "layoutId span, fills the item under the pointer",
-    swatch: "bg-[var(--foreground)]/12",
+    kind: "hoverPill",
   },
   {
     name: "Active underline",
     desc: "separate layoutId — tracks the clicked link only",
-    swatch: "bg-[var(--foreground)]",
+    kind: "underline",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "underline") {
+    return (
+      <span className="h-0.5 w-8 rounded-full bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-2 w-8 rounded-full bg-[var(--foreground)]/12 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function ResizableHeaderPills() {
   return (
@@ -77,9 +92,7 @@ export function ResizableHeaderPills() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/scroll-progress-anatomy.tsx
+++ b/apps/docs/src/components/learn/scroll-progress-anatomy.tsx
@@ -27,17 +27,19 @@ const LEGEND = [
   {
     name: "Bar",
     desc: "scaleX(progress), origin-left",
-    swatch: "bg-[var(--foreground)]/60",
+    swatch: "h-1 w-8 rounded-full bg-[var(--foreground)]/70",
   },
   {
     name: "Pin",
     desc: "fixed · or sticky with container",
-    swatch: "bg-[var(--muted)]",
+    swatch:
+      "h-3 w-8 rounded-md border border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset",
   },
   {
     name: "A11y",
     desc: 'role="progressbar"',
-    swatch: "bg-[var(--card)] ring-1 ring-fd-border ring-inset",
+    swatch:
+      "h-1 w-8 rounded-full bg-[var(--foreground)]/70 ring-1 ring-[var(--foreground)]/40 ring-inset",
   },
 ] as const;
 
@@ -71,9 +73,7 @@ export function ScrollProgressAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <span className={`${item.swatch}`} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/scroll-progress-circle.tsx
+++ b/apps/docs/src/components/learn/scroll-progress-circle.tsx
@@ -28,23 +28,43 @@ const CSS = `
 .spc-static .spc-arc { animation: none; stroke-dashoffset: ${CIRC * 0.25}; }
 `;
 
-const LEGEND = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "bar" | "track" | "pin";
+}[] = [
   {
     name: "Ring",
     desc: "strokeDashoffset from progress",
-    swatch: "bg-[var(--foreground)]/60",
+    kind: "bar",
   },
   {
     name: "showAfter",
     desc: "visible when raw progress > threshold",
-    swatch: "bg-[var(--muted)]",
+    kind: "track",
   },
   {
     name: "Enter",
     desc: "AnimatePresence spring 520/32",
-    swatch: "bg-[var(--card)] ring-1 ring-fd-border ring-inset",
+    kind: "pin",
   },
-] as const;
+];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "bar") {
+    return (
+      <span className="h-1 w-8 rounded-full bg-[var(--foreground)]/60 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "track") {
+    return (
+      <span className="h-1 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="size-3 rounded-full border border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function ScrollProgressCircle() {
   return (
@@ -119,9 +139,7 @@ export function ScrollProgressCircle() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/scroll-progress-spring.tsx
+++ b/apps/docs/src/components/learn/scroll-progress-spring.tsx
@@ -29,23 +29,43 @@ const CSS = `
 .sps-static .sps-spring { animation: none; transform: scaleX(0.65); }
 `;
 
-const LEGEND = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "raw" | "spring" | "reduced";
+}[] = [
   {
     name: "Raw",
     desc: "scrollYProgress — jumps with scroll",
-    swatch: "bg-[var(--foreground)]/30",
+    kind: "raw",
   },
   {
     name: "Spring",
     desc: "stiffness 120 · damping 24",
-    swatch: "bg-[var(--foreground)]/70",
+    kind: "spring",
   },
   {
     name: "Reduced",
     desc: "stiffness 1000 · damping 100",
-    swatch: "bg-[var(--muted)]",
+    kind: "reduced",
   },
-] as const;
+];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "spring") {
+    return (
+      <span className="h-1 w-8 rounded-full bg-[var(--foreground)]/70 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "reduced") {
+    return (
+      <span className="h-1 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-1 w-8 rounded-full bg-[var(--foreground)]/30 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function ScrollProgressSpring() {
   return (
@@ -81,9 +101,7 @@ export function ScrollProgressSpring() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/scroll-reveal-anatomy.tsx
+++ b/apps/docs/src/components/learn/scroll-reveal-anatomy.tsx
@@ -43,17 +43,20 @@ const LEGEND = [
   {
     name: "Offset",
     desc: "OFFSET[direction] × distance",
-    swatch: "bg-[var(--muted)]",
+    swatch:
+      "size-3 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset",
   },
   {
     name: "Blur",
     desc: "blur(10px) → blur(0) when enabled",
-    swatch: "bg-[var(--foreground)]/40",
+    swatch:
+      "h-3 w-8 rounded-md bg-[var(--card)] opacity-60 ring-1 ring-fd-border ring-inset",
   },
   {
     name: "Plate",
     desc: "children wrapped in motion.div",
-    swatch: "bg-[var(--card)] ring-1 ring-fd-border ring-inset",
+    swatch:
+      "h-3 w-8 rounded-md border border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset",
   },
 ] as const;
 
@@ -106,9 +109,7 @@ export function ScrollRevealAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <span className={item.swatch} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/scroll-reveal-skew.tsx
+++ b/apps/docs/src/components/learn/scroll-reveal-skew.tsx
@@ -31,23 +31,43 @@ const CSS = `
 .srv-static .srv-vel   { animation: none; transform: scaleX(0.5); }
 `;
 
-const LEGEND = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "offset" | "blur" | "plate";
+}[] = [
   {
     name: "Velocity",
     desc: "useVelocity(scrollY)",
-    swatch: "bg-[var(--foreground)]/40",
+    kind: "offset",
   },
   {
     name: "Spring",
     desc: "smoothVelocity · same 32/320/0.9",
-    swatch: "bg-[var(--muted)]",
+    kind: "blur",
   },
   {
     name: "skewY",
     desc: "mapped to ±6° · clamp true",
-    swatch: "bg-[var(--card)] ring-1 ring-fd-border ring-inset",
+    kind: "plate",
   },
-] as const;
+];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "plate") {
+    return (
+      <span className="h-3 w-8 rounded-md border border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "blur") {
+    return (
+      <span className="h-3 w-8 rounded-md bg-[var(--card)] opacity-60 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="size-3 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function ScrollRevealSkew() {
   return (
@@ -79,9 +99,7 @@ export function ScrollRevealSkew() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/scroll-reveal-spring.tsx
+++ b/apps/docs/src/components/learn/scroll-reveal-spring.tsx
@@ -47,23 +47,43 @@ const CSS = `
 }
 `;
 
-const LEGEND = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "plate" | "offset" | "blur";
+}[] = [
   {
     name: "In view",
     desc: "useInView once · amount 0.3",
-    swatch: "bg-[var(--foreground)]/50",
+    kind: "plate",
   },
   {
     name: "Spring",
     desc: "damping 32 · stiffness 320 · mass 0.9",
-    swatch: "bg-[var(--muted)]",
+    kind: "offset",
   },
   {
     name: "Hidden",
     desc: "opacity 0 + offset + blur(10px)",
-    swatch: "bg-[var(--card)] ring-1 ring-fd-border ring-inset",
+    kind: "blur",
   },
-] as const;
+];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "plate") {
+    return (
+      <span className="h-3 w-8 rounded-md border border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "offset") {
+    return (
+      <span className="size-3 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-3 w-8 rounded-md bg-[var(--card)] opacity-60 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function ScrollRevealSpring() {
   return (
@@ -96,9 +116,7 @@ export function ScrollRevealSpring() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/scroll-stack-anatomy.tsx
+++ b/apps/docs/src/components/learn/scroll-stack-anatomy.tsx
@@ -22,17 +22,20 @@ const LEGEND: { name: string; desc: string; swatch: string }[] = [
   {
     name: "Front card",
     desc: "index N-1, sticky top: pinTop, scale 1",
-    swatch: "bg-[var(--card)] ring-1 ring-fd-border ring-inset",
+    swatch:
+      "h-3 w-8 rounded-md border border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset",
   },
   {
     name: "Buried card",
     desc: "same pinTop, dimmed + scaled toward baseScale",
-    swatch: "bg-[var(--muted)]",
+    swatch:
+      "h-3 w-8 rounded-md bg-[var(--muted)] ring-1 ring-fd-border ring-inset",
   },
   {
     name: "Peek",
     desc: "translateY = index × peek — the sliver that shows below",
-    swatch: "bg-[var(--foreground)]/30",
+    swatch:
+      "h-3 w-4 rounded-md bg-[var(--muted)] ring-1 ring-fd-border ring-inset",
   },
 ];
 
@@ -67,7 +70,7 @@ export function ScrollStackAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span className={`h-1.5 w-8 rounded-full ${item.swatch}`} />
+                <span className={`${item.swatch}`} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/scroll-stack-bury.tsx
+++ b/apps/docs/src/components/learn/scroll-stack-bury.tsx
@@ -78,23 +78,43 @@ const CSS = `
 }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "buried" | "mid" | "front";
+}[] = [
   {
     name: "Back (depth 2)",
     desc: "scale 0.86 · brightness 0.84 · blur 4px",
-    swatch: "bg-[var(--muted)]",
+    kind: "buried",
   },
   {
     name: "Mid (depth 1)",
     desc: "scale 0.93 · brightness 0.92 · blur 2px",
-    swatch: "bg-[var(--foreground)]/25",
+    kind: "mid",
   },
   {
     name: "Front (depth 0)",
     desc: "stays at scale 1 — never buries",
-    swatch: "bg-[var(--card)] ring-1 ring-fd-border ring-inset",
+    kind: "front",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "buried") {
+    return (
+      <span className="h-3 w-8 rounded-md bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "mid") {
+    return (
+      <span className="h-3 w-8 rounded-md border border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-3 w-8 rounded-md border border-fd-border bg-[var(--card)] shadow-sm ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function ScrollStackBury() {
   return (
@@ -135,7 +155,7 @@ export function ScrollStackBury() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span className={`h-1.5 w-8 rounded-full ${item.swatch}`} />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/scroll-text-reveal-anatomy.tsx
+++ b/apps/docs/src/components/learn/scroll-text-reveal-anatomy.tsx
@@ -35,23 +35,44 @@ const SLOTS: { id: string; opacity: number; blur: number }[] = [
   { id: "s4", opacity: 0.15, blur: 6 },
 ];
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "dim" | "lit" | "slice";
+}[] = [
   {
     name: "Dim",
     desc: "reveal 0 — opacity dimOpacity, blur 6px",
-    swatch: "bg-[var(--foreground)]/15",
+    kind: "dim",
   },
   {
     name: "Lit",
     desc: "reveal 1 — opacity 1, blur 0",
-    swatch: "bg-[var(--foreground)]",
+    kind: "lit",
   },
   {
     name: "Slice",
     desc: "segment i owns progress [i/n, (i+1)/n]",
-    swatch: "bg-[var(--foreground)]/45",
+    kind: "slice",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "slice") {
+    return (
+      <span className="relative h-1 w-8 overflow-hidden rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset">
+        <span className="absolute inset-y-0 left-0 w-1/2 rounded-full bg-[var(--foreground)]/55" />
+      </span>
+    );
+  }
+  return (
+    <span
+      className={`h-2 w-8 rounded-full bg-[var(--foreground)] ring-1 ring-fd-border ring-inset ${
+        kind === "dim" ? "opacity-15" : ""
+      }`}
+    />
+  );
+}
 
 export function ScrollTextRevealAnatomy() {
   return (
@@ -103,9 +124,7 @@ export function ScrollTextRevealAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ring-1 ring-fd-border ring-inset ${item.swatch}`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/scroll-text-reveal-latch.tsx
+++ b/apps/docs/src/components/learn/scroll-text-reveal-latch.tsx
@@ -75,18 +75,32 @@ const CSS = `
 const REV = ["strl-rev0", "strl-rev1", "strl-rev2", "strl-rev3"] as const;
 const LAT = ["strl-lat0", "strl-lat1", "strl-lat2", "strl-lat3"] as const;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "dim" | "lit";
+}[] = [
   {
     name: "Scrub",
     desc: "reveal tracks raw progress — dims on scroll-up",
-    swatch: "bg-[var(--foreground)]/30",
+    kind: "dim",
   },
   {
     name: "Latch",
     desc: "Math.max(prev, v) — stays lit once revealed",
-    swatch: "bg-[var(--foreground)]",
+    kind: "lit",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  return (
+    <span
+      className={`h-2 w-8 rounded-full bg-[var(--foreground)] ring-1 ring-fd-border ring-inset ${
+        kind === "dim" ? "opacity-15" : ""
+      }`}
+    />
+  );
+}
 
 function SlotRow({ classes }: { classes: readonly string[] }) {
   return (
@@ -141,9 +155,7 @@ export function ScrollTextRevealLatch() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ring-1 ring-fd-border ring-inset ${item.swatch}`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/scroll-text-reveal-scrub.tsx
+++ b/apps/docs/src/components/learn/scroll-text-reveal-scrub.tsx
@@ -64,23 +64,44 @@ const SEG_CLASS = [
   "strs-s4",
 ] as const;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "slice" | "dim" | "lit";
+}[] = [
   {
     name: "Progress",
     desc: "scrollYProgress 0 → 1 → 0",
-    swatch: "bg-[var(--foreground)]/55",
+    kind: "slice",
   },
   {
     name: "Opacity",
     desc: "dimOpacity → 1 per slice",
-    swatch: "bg-[var(--foreground)]/30",
+    kind: "dim",
   },
   {
     name: "Blur",
     desc: "blur(6px) → blur(0) in sync",
-    swatch: "bg-[var(--foreground)]/15",
+    kind: "lit",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "slice") {
+    return (
+      <span className="relative h-1 w-8 overflow-hidden rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset">
+        <span className="absolute inset-y-0 left-0 w-1/2 rounded-full bg-[var(--foreground)]/55" />
+      </span>
+    );
+  }
+  return (
+    <span
+      className={`h-2 w-8 rounded-full bg-[var(--foreground)] ring-1 ring-fd-border ring-inset ${
+        kind === "dim" ? "opacity-30" : "opacity-15"
+      }`}
+    />
+  );
+}
 
 export function ScrollTextRevealScrub() {
   return (
@@ -116,9 +137,7 @@ export function ScrollTextRevealScrub() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ring-1 ring-fd-border ring-inset ${item.swatch}`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/scroll-timeline-anatomy.tsx
+++ b/apps/docs/src/components/learn/scroll-timeline-anatomy.tsx
@@ -21,17 +21,20 @@ const LEGEND: { name: string; desc: string; swatch: string }[] = [
   {
     name: "Rail",
     desc: "one line, height = measured track height",
-    swatch: "bg-[var(--muted)]",
+    swatch:
+      "h-4 w-0.5 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset",
   },
   {
     name: "Node",
     desc: "sticky dot, stays put while its entry is in view",
-    swatch: "bg-[var(--card)] ring-1 ring-fd-border ring-inset",
+    swatch:
+      "size-3 rounded-full bg-[var(--card)] ring-2 ring-fd-border ring-inset",
   },
   {
     name: "Card",
     desc: "content, fades + slides up once on enter",
-    swatch: "bg-[var(--foreground)]/30",
+    swatch:
+      "h-3 w-8 rounded-md border border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset",
   },
 ];
 
@@ -69,7 +72,7 @@ export function ScrollTimelineAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span className={`h-1.5 w-8 rounded-full ${item.swatch}`} />
+                <span className={item.swatch} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/scroll-timeline-scrub.tsx
+++ b/apps/docs/src/components/learn/scroll-timeline-scrub.tsx
@@ -27,6 +27,34 @@ const CSS = `
 
 const NODES = [0.12, 0.5, 0.88];
 
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "rail" | "progress";
+}[] = [
+  {
+    name: "Base rail",
+    desc: "fixed line, always full height",
+    kind: "rail",
+  },
+  {
+    name: "Progress fill",
+    desc: "scaleY overlay, grows with scroll",
+    kind: "progress",
+  },
+];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "progress") {
+    return (
+      <span className="h-4 w-0.5 rounded-full bg-[var(--primary)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-4 w-0.5 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+  );
+}
+
 export function ScrollTimelineScrub() {
   return (
     <ScrollScene label="The motion" note="scaleY, origin-top — not height">
@@ -58,24 +86,17 @@ export function ScrollTimelineScrub() {
           </p>
 
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Base rail
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                fixed line, always full height
-              </dd>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--primary)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Progress fill
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                scaleY overlay, grows with scroll
-              </dd>
-            </div>
+            {LEGEND.map((item) => (
+              <div key={item.name} className="flex flex-col gap-1.5">
+                <LegendSwatch kind={item.kind} />
+                <dt className="font-medium text-[13px] text-fd-foreground">
+                  {item.name}
+                </dt>
+                <dd className="text-[12px] text-fd-muted-foreground">
+                  {item.desc}
+                </dd>
+              </div>
+            ))}
           </dl>
         </div>
       )}

--- a/apps/docs/src/components/learn/scroll-timeline-spring.tsx
+++ b/apps/docs/src/components/learn/scroll-timeline-spring.tsx
@@ -29,6 +29,34 @@ const CSS = `
 .stlsp-static .stlsp-spring { animation: none; transform: scaleY(1); }
 `;
 
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "raw" | "spring";
+}[] = [
+  {
+    name: "scrollYProgress",
+    desc: "matches the scroll position exactly, every event",
+    kind: "raw",
+  },
+  {
+    name: "Spring-smoothed",
+    desc: "lags slightly, settles instead of snapping",
+    kind: "spring",
+  },
+];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "spring") {
+    return (
+      <span className="h-4 w-0.5 rounded-full bg-[var(--foreground)]/70 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-4 w-0.5 rounded-full bg-[var(--foreground)]/45 ring-1 ring-fd-border ring-inset" />
+  );
+}
+
 export function ScrollTimelineSpring() {
   return (
     <ScrollScene label="Why a spring" note="raw scroll vs. smoothed">
@@ -64,24 +92,17 @@ export function ScrollTimelineSpring() {
           </p>
 
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/45 ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                scrollYProgress
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                matches the scroll position exactly, every event
-              </dd>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/70 ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Spring-smoothed
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                lags slightly, settles instead of snapping
-              </dd>
-            </div>
+            {LEGEND.map((item) => (
+              <div key={item.name} className="flex flex-col gap-1.5">
+                <LegendSwatch kind={item.kind} />
+                <dt className="font-medium text-[13px] text-fd-foreground">
+                  {item.name}
+                </dt>
+                <dd className="text-[12px] text-fd-muted-foreground">
+                  {item.desc}
+                </dd>
+              </div>
+            ))}
           </dl>
         </div>
       )}

--- a/apps/docs/src/components/learn/segmented-control-anatomy.tsx
+++ b/apps/docs/src/components/learn/segmented-control-anatomy.tsx
@@ -33,17 +33,20 @@ const LEGEND: { name: string; desc: string; swatch: string }[] = [
   {
     name: "Track",
     desc: 'role="tablist" — bg-muted, rounded, p-1',
-    swatch: "bg-[var(--muted)]",
+    swatch:
+      "h-3 w-8 rounded-md bg-[var(--muted)] ring-1 ring-fd-border ring-inset",
   },
   {
     name: "Segment buttons",
     desc: 'one role="tab" per option',
-    swatch: "bg-[var(--foreground)]/30",
+    swatch:
+      "h-1.5 w-8 rounded-full bg-[var(--foreground)]/30 ring-1 ring-fd-border ring-inset",
   },
   {
     name: "Sliding pill",
     desc: "bg-background, absolute inset-0 of the active tab",
-    swatch: "bg-[var(--background)]",
+    swatch:
+      "h-3 w-8 rounded-md bg-[var(--background)] shadow-sm ring-1 ring-fd-border ring-inset",
   },
 ];
 
@@ -82,9 +85,7 @@ export function SegmentedControlAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <span className={item.swatch} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/shimmer-layers.tsx
+++ b/apps/docs/src/components/learn/shimmer-layers.tsx
@@ -33,23 +33,43 @@ const CSS = `
 .sl-static .sl-spark { animation: none; transform: rotate(35deg); }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "spark" | "cut" | "label";
+}[] = [
   {
     name: "Spark",
     desc: "conic gradient, blurred, spinning",
-    swatch: "bg-[var(--foreground)]/70",
+    kind: "spark",
   },
   {
     name: "Cut",
     desc: "solid inset that hides the middle",
-    swatch: "border-2 border-[var(--foreground)]/50 bg-[var(--card)]",
+    kind: "cut",
   },
   {
     name: "Label",
     desc: "text, always on top",
-    swatch: "bg-transparent",
+    kind: "label",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "cut") {
+    return (
+      <span className="h-3 w-8 rounded-[9px] border-2 border-[var(--foreground)]/50 bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "label") {
+    return (
+      <span className="h-2 w-6 rounded-full bg-[var(--foreground)]/40 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-3 w-8 rounded-md bg-[var(--foreground)]/70 blur-[1px] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 function ButtonStage({
   spark,
@@ -144,9 +164,7 @@ export function ShimmerLayers() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ring-1 ring-fd-border ring-inset ${item.swatch}`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/slide-anatomy.tsx
+++ b/apps/docs/src/components/learn/slide-anatomy.tsx
@@ -43,22 +43,26 @@ const LEGEND: { name: string; desc: string; swatch: string }[] = [
   {
     name: "Track",
     desc: "rounded-full border, bg-muted",
-    swatch: "bg-[var(--muted)]",
+    swatch:
+      "h-3 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset",
   },
   {
     name: "Fill",
     desc: "trails thumb, width = x + thumb",
-    swatch: "bg-[var(--foreground)]/20",
+    swatch:
+      "h-2 w-8 rounded-full bg-[var(--foreground)]/20 ring-1 ring-fd-border ring-inset",
   },
   {
     name: "Thumb",
     desc: "draggable, x is a motion value",
-    swatch: "bg-[var(--foreground)]",
+    swatch:
+      "size-3 rounded-full bg-[var(--foreground)] ring-1 ring-fd-border ring-inset",
   },
   {
     name: "Label",
     desc: "fades over first 60% of travel",
-    swatch: "bg-[var(--foreground)]/40",
+    swatch:
+      "h-1.5 w-8 rounded-full bg-[var(--foreground)]/25 ring-1 ring-fd-border ring-inset",
   },
 ];
 
@@ -118,9 +122,7 @@ export function SlideAnatomy() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5 sm:grid-cols-4">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <span className={item.swatch} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/slide-threshold.tsx
+++ b/apps/docs/src/components/learn/slide-threshold.tsx
@@ -71,23 +71,43 @@ const CSS = `
 .st-static .st-icon-check      { animation: none; opacity: 1; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "fill" | "thumb" | "threshold";
+}[] = [
   {
     name: "Falls short",
     desc: "released below 216px → spring(500,40) back to 0",
-    swatch: "bg-[var(--foreground)]/20",
+    kind: "fill",
   },
   {
     name: "Past the line",
     desc: "released past 216px → confirm() springs to maxX",
-    swatch: "bg-[var(--foreground)]",
+    kind: "thumb",
   },
   {
     name: "Threshold",
     desc: "maxX × 0.9 = 216px",
-    swatch: "bg-[var(--foreground)]/40",
+    kind: "threshold",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "thumb") {
+    return (
+      <span className="size-3 rounded-full bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "threshold") {
+    return (
+      <span className="h-3 w-0.5 rounded-full bg-[var(--foreground)]/40 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-2 w-8 rounded-full bg-[var(--foreground)]/20 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function SlideThreshold() {
   return (
@@ -164,9 +184,7 @@ export function SlideThreshold() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/source-citations-anatomy.tsx
+++ b/apps/docs/src/components/learn/source-citations-anatomy.tsx
@@ -29,17 +29,20 @@ const LEGEND = [
   {
     name: "Wrapper",
     desc: "relative · owns both pill and card",
-    swatch: "border border-dashed border-[var(--foreground)]/40 bg-transparent",
+    swatch:
+      "h-3 w-8 rounded-md border border-dashed border-[var(--foreground)]/40 bg-transparent ring-1 ring-fd-border ring-inset",
   },
   {
     name: "Pill",
     desc: "numbered <a> — the anchor",
-    swatch: "bg-[var(--muted)]",
+    swatch:
+      "size-3 rounded-[5px] bg-[var(--muted)] ring-1 ring-fd-border ring-inset",
   },
   {
     name: "Card + caret",
     desc: "left-1/2 −translate-x-1/2 · centered on pill",
-    swatch: "bg-[var(--popover)]",
+    swatch:
+      "h-3 w-8 rounded-md bg-[var(--popover)] ring-1 ring-fd-border ring-inset",
   },
 ] as const;
 
@@ -166,9 +169,7 @@ export function SourceCitationsAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ring-1 ring-fd-border ring-inset ${item.swatch}`}
-                />
+                <span className={item.swatch} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/source-citations-list.tsx
+++ b/apps/docs/src/components/learn/source-citations-list.tsx
@@ -78,23 +78,55 @@ const EXTRA: { titleW: string; hostW: string; delay: string }[] = [
   { titleW: "w-32", hostW: "w-12", delay: "70ms" },
 ];
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "row" | "stagger" | "toggle";
+}[] = [
   {
     name: "Row",
     desc: "chip · title · host, fades up on mount",
-    swatch: "bg-[var(--card)]",
+    kind: "row",
   },
   {
     name: "Stagger",
     desc: "delay min(i, previewCount) × 0.05s",
-    swatch: "bg-[var(--foreground)]/40",
+    kind: "stagger",
   },
   {
     name: "+N more",
     desc: "toggles the rows past previewCount",
-    swatch: "bg-[var(--foreground)]/70",
+    kind: "toggle",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "stagger") {
+    return (
+      <span className="flex flex-col gap-0.5">
+        <span className="h-1 w-6 rounded-full bg-[var(--foreground)]/40" />
+        <span className="ml-1.5 h-1 w-5 rounded-full bg-[var(--foreground)]/25" />
+      </span>
+    );
+  }
+  if (kind === "toggle") {
+    return (
+      <span className="inline-flex items-center gap-0.5">
+        <span className="h-1 w-4 rounded-full bg-[var(--foreground)]/70" />
+        <span className="size-1.5 rotate-180 border-[var(--foreground)]/70 border-t border-r" />
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 rounded-lg border border-transparent px-0.5 py-0.5">
+      <span className="size-2 shrink-0 rounded bg-[var(--muted)]" />
+      <span className="flex flex-col gap-0.5">
+        <span className="h-1 w-4 rounded-full bg-[var(--foreground)]/40" />
+        <span className="h-0.5 w-2.5 rounded-full bg-[var(--foreground)]/20" />
+      </span>
+    </span>
+  );
+}
 
 export function SourceCitationsList() {
   return (
@@ -156,9 +188,7 @@ export function SourceCitationsList() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/source-citations-tooltip.tsx
+++ b/apps/docs/src/components/learn/source-citations-tooltip.tsx
@@ -20,23 +20,45 @@ const CSS = `
 .sct-static .sct-card { animation: none; opacity: 1; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "opacity" | "scale" | "y";
+}[] = [
   {
     name: "opacity",
     desc: "0 → 1, tied to the same spring",
-    swatch: "bg-[var(--foreground)]/25",
+    kind: "opacity",
   },
   {
     name: "scale",
     desc: "0.96 → 1, a hair of overshoot near 1.015",
-    swatch: "bg-[var(--foreground)]/55",
+    kind: "scale",
   },
   {
     name: "y",
     desc: "6px → 0, mass 0.9 keeps it from bouncing",
-    swatch: "bg-[var(--foreground)]",
+    kind: "y",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "scale") {
+    return (
+      <span className="h-4 w-7 origin-center scale-[0.96] rounded-lg border border-fd-border bg-[var(--popover)] opacity-80 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "y") {
+    return (
+      <span className="relative h-4 w-7">
+        <span className="absolute inset-x-0 top-1 h-3.5 w-full rounded-lg border border-fd-border bg-[var(--popover)] ring-1 ring-fd-border ring-inset" />
+      </span>
+    );
+  }
+  return (
+    <span className="h-4 w-7 rounded-lg border border-fd-border bg-[var(--popover)] opacity-40 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function SourceCitationsTooltip() {
   return (
@@ -74,9 +96,7 @@ export function SourceCitationsTooltip() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/spin-viewer-anatomy.tsx
+++ b/apps/docs/src/components/learn/spin-viewer-anatomy.tsx
@@ -36,17 +36,19 @@ const LEGEND: { name: string; desc: string; swatch: string }[] = [
     name: "frames[]",
     desc: "ordered image URLs, preloaded once on mount",
     swatch:
-      "border-2 border-dashed border-[var(--foreground)]/50 bg-transparent",
+      "h-3 w-8 rounded-md border-2 border-dashed border-[var(--foreground)]/50 bg-transparent ring-1 ring-fd-border ring-inset",
   },
   {
     name: "index",
     desc: "React state — which frame is current",
-    swatch: "bg-[var(--foreground)]/30",
+    swatch:
+      "size-2 rounded-full bg-[var(--foreground)]/50 ring-1 ring-fd-border ring-inset",
   },
   {
     name: "img src",
     desc: "frames[index], swapped — never interpolated",
-    swatch: "bg-[var(--foreground)]",
+    swatch:
+      "size-2.5 rounded-full bg-[var(--foreground)] ring-1 ring-fd-border ring-inset",
   },
 ];
 
@@ -97,7 +99,7 @@ export function SpinViewerAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span className={`h-1.5 w-8 rounded-full ${item.swatch}`} />
+                <span className={item.swatch} />
                 <dt className="font-medium font-mono text-[12px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/spin-viewer-drag.tsx
+++ b/apps/docs/src/components/learn/spin-viewer-drag.tsx
@@ -39,6 +39,39 @@ const CSS = `
 
 const TICKS = Array.from({ length: TICKS_N }, (_, i) => i);
 
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "pointer" | "frame";
+}[] = [
+  {
+    name: "Pointer",
+    desc: "dx tracked from onPointerDown's clientX",
+    kind: "pointer",
+  },
+  {
+    name: "Frame",
+    desc: "index += stepped, wrapped mod frame count",
+    kind: "frame",
+  },
+];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "frame") {
+    return (
+      <span className="relative flex h-4 w-4 items-end justify-center">
+        <span className="absolute inset-x-1 top-0 rounded-full border border-[var(--foreground)]/15" />
+        <span className="h-3 w-0.5 origin-bottom rounded-full bg-[var(--foreground)]/70" />
+      </span>
+    );
+  }
+  return (
+    <span className="grid size-3 place-items-center rounded-full border border-fd-border bg-[var(--foreground)] ring-1 ring-fd-border ring-inset">
+      <span className="size-1 rounded-full bg-[var(--background)]" />
+    </span>
+  );
+}
+
 export function SpinViewerDrag() {
   return (
     <ScrollScene label="The drag" note="dx ÷ sensitivity, rounded — that's it">
@@ -102,24 +135,17 @@ export function SpinViewerDrag() {
           </div>
 
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/30 ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Pointer
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                {"dx tracked from onPointerDown's clientX"}
-              </dd>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Frame
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                index += stepped, wrapped mod frame count
-              </dd>
-            </div>
+            {LEGEND.map((item) => (
+              <div key={item.name} className="flex flex-col gap-1.5">
+                <LegendSwatch kind={item.kind} />
+                <dt className="font-medium text-[13px] text-fd-foreground">
+                  {item.name}
+                </dt>
+                <dd className="text-[12px] text-fd-muted-foreground">
+                  {item.desc}
+                </dd>
+              </div>
+            ))}
           </dl>
         </div>
       )}

--- a/apps/docs/src/components/learn/spotlight-card-anatomy.tsx
+++ b/apps/docs/src/components/learn/spotlight-card-anatomy.tsx
@@ -25,17 +25,20 @@ const LEGEND = [
   {
     name: "Glow",
     desc: "radial at var(--x)/var(--y), opacity 0→100 on group-hover",
-    swatch: "bg-[var(--foreground)]/25",
+    swatch:
+      "h-3 w-8 rounded-md border border-fd-border bg-[var(--card)] [background:radial-gradient(circle_at_30%_40%,rgba(0,0,0,0.28),transparent_65%),var(--card)] ring-1 ring-fd-border ring-inset",
   },
   {
     name: "Border",
     desc: "same gradient, masked to 1px ring (mask-composite exclude)",
-    swatch: "bg-transparent ring-1 ring-[var(--foreground)]/50 ring-inset",
+    swatch:
+      "h-3 w-8 rounded-md border border-[var(--foreground)]/35 bg-transparent ring-1 ring-fd-border ring-inset",
   },
   {
     name: "Content",
     desc: "relative z-raised — sits above both glow layers",
-    swatch: "bg-[var(--card)]",
+    swatch:
+      "h-3 w-8 rounded-md bg-[var(--muted)]/85 ring-1 ring-fd-border ring-inset",
   },
 ] as const;
 
@@ -89,9 +92,7 @@ export function SpotlightCardAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <span className={item.swatch} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/spotlight-card-border.tsx
+++ b/apps/docs/src/components/learn/spotlight-card-border.tsx
@@ -73,23 +73,45 @@ const CSS = `
 }
 `;
 
-const LEGEND = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "fill" | "ring" | "center";
+}[] = [
   {
     name: "Fill glow",
     desc: "full-area radial at the same --x/--y",
-    swatch: "bg-[var(--foreground)]/20",
+    kind: "fill",
   },
   {
     name: "Ring mask",
     desc: "inset-0 · p-px · mask-composite: exclude",
-    swatch: "bg-transparent ring-1 ring-[var(--foreground)]/55 ring-inset",
+    kind: "ring",
   },
   {
     name: "Moving center",
     desc: "only --x/--y change — layer stays put",
-    swatch: "bg-[var(--muted)]",
+    kind: "center",
   },
-] as const;
+];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "ring") {
+    return (
+      <span className="grid h-5 w-7 place-items-center rounded-xl bg-[radial-gradient(circle_at_80%_30%,color-mix(in_oklab,var(--foreground)_55%,transparent),transparent_65%)] p-px ring-1 ring-fd-border ring-inset [mask:linear-gradient(#fff_0_0)_content-box,linear-gradient(#fff_0_0)] [mask-composite:exclude]" />
+    );
+  }
+  if (kind === "center") {
+    return (
+      <span className="relative h-5 w-7 rounded-xl border border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset">
+        <span className="absolute top-1 right-1 size-1.5 rounded-full bg-[var(--muted)]" />
+      </span>
+    );
+  }
+  return (
+    <span className="h-5 w-7 rounded-xl bg-[radial-gradient(circle_at_80%_30%,color-mix(in_oklab,var(--foreground)_18%,transparent),transparent_65%)] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function SpotlightCardBorder() {
   return (
@@ -126,9 +148,7 @@ export function SpotlightCardBorder() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/spotlight-card-follow.tsx
+++ b/apps/docs/src/components/learn/spotlight-card-follow.tsx
@@ -64,23 +64,43 @@ const CSS = `
 }
 `;
 
-const LEGEND = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "glow" | "cursor" | "fade";
+}[] = [
   {
     name: "Glow layer",
     desc: "inset-0 radial at --x/--y · defaults 50%/50%",
-    swatch: "bg-[var(--foreground)]/30",
+    kind: "glow",
   },
   {
     name: "setProperty",
     desc: "direct DOM write on pointer move — zero re-renders",
-    swatch: "bg-[var(--muted)]",
+    kind: "cursor",
   },
   {
     name: "Hover fade",
     desc: "opacity 0→100, 400ms ease (group-hover)",
-    swatch: "bg-transparent ring-1 ring-[var(--foreground)]/40 ring-inset",
+    kind: "fade",
   },
-] as const;
+];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "cursor") {
+    return (
+      <span className="size-2.5 rounded-full bg-[var(--foreground)]/55 ring-4 ring-[var(--foreground)]/10 ring-inset" />
+    );
+  }
+  if (kind === "fade") {
+    return (
+      <span className="h-5 w-7 rounded-xl border border-fd-border bg-[var(--card)] opacity-40 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-5 w-7 rounded-xl bg-[radial-gradient(circle_at_70%_40%,color-mix(in_oklab,var(--foreground)_28%,transparent),transparent_65%)] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function SpotlightCardFollow() {
   return (
@@ -118,9 +138,7 @@ export function SpotlightCardFollow() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/spotlight-reveal-anatomy.tsx
+++ b/apps/docs/src/components/learn/spotlight-reveal-anatomy.tsx
@@ -23,17 +23,20 @@ const LEGEND = [
   {
     name: "Reveal",
     desc: "absolute inset-0 underneath — the hidden layer",
-    swatch: "bg-[var(--foreground)]/70",
+    swatch:
+      "h-3 w-8 rounded-md bg-[var(--foreground)]/80 ring-1 ring-fd-border ring-inset",
   },
   {
     name: "Cover",
     desc: "children on top, punched by the radial mask",
-    swatch: "bg-[var(--card)]",
+    swatch:
+      "h-3 w-8 rounded-md border border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset",
   },
   {
     name: "Together",
     desc: "mask hole follows --x/--y on the cover",
-    swatch: "bg-[var(--muted)]",
+    swatch:
+      "relative h-3 w-8 overflow-hidden rounded-md border border-fd-border ring-1 ring-fd-border ring-inset",
   },
 ] as const;
 
@@ -102,9 +105,22 @@ export function SpotlightRevealAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                {item.name === "Together" ? (
+                  <span className={item.swatch}>
+                    <span className="absolute inset-0 bg-[var(--foreground)]/80" />
+                    <span
+                      className="absolute inset-0 bg-[var(--card)]"
+                      style={{
+                        maskImage:
+                          "radial-gradient(circle 6px at 55% 45%, transparent 0, transparent 4px, #000 6px)",
+                        WebkitMaskImage:
+                          "radial-gradient(circle 6px at 55% 45%, transparent 0, transparent 4px, #000 6px)",
+                      }}
+                    />
+                  </span>
+                ) : (
+                  <span className={item.swatch} />
+                )}
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/spotlight-reveal-follow.tsx
+++ b/apps/docs/src/components/learn/spotlight-reveal-follow.tsx
@@ -35,23 +35,45 @@ const CSS = `
 const MASK =
   "radial-gradient(circle 40px at 50% 50%, transparent 0, transparent 18px, #000 40px)";
 
-const LEGEND = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "drift" | "follow" | "pinned";
+}[] = [
   {
     name: "Idle drift",
     desc: "ellipse when !hovering && !pinned",
-    swatch: "bg-[var(--foreground)]/25",
+    kind: "drift",
   },
   {
     name: "Eased follow",
     desc: "cur += (target − cur) × 0.16 per frame",
-    swatch: "bg-[var(--muted)]",
+    kind: "follow",
   },
   {
     name: "Pinned",
     desc: "click toggles — target freezes until unpin",
-    swatch: "bg-[var(--foreground)]/55",
+    kind: "pinned",
   },
-] as const;
+];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "follow") {
+    return (
+      <span className="relative h-5 w-7 overflow-hidden rounded-lg border border-fd-border bg-[var(--foreground)]/80 ring-1 ring-fd-border ring-inset">
+        <span className="absolute top-1/2 left-1/2 h-1 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-[var(--background)]/40" />
+      </span>
+    );
+  }
+  if (kind === "pinned") {
+    return (
+      <span className="size-2 rounded-full bg-[var(--foreground)]/50 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-5 w-7 rounded-lg border border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function SpotlightRevealFollow() {
   return (
@@ -97,9 +119,7 @@ export function SpotlightRevealFollow() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/spotlight-reveal-mask.tsx
+++ b/apps/docs/src/components/learn/spotlight-reveal-mask.tsx
@@ -24,18 +24,38 @@ const HARD =
 const SOFT =
   "radial-gradient(circle 48px at 50% 50%, transparent 0, transparent 22px, #000 48px)";
 
-const LEGEND = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "hard" | "soft";
+}[] = [
   {
     name: "Hard edge",
     desc: "softness → 0 · inner ≈ radius",
-    swatch: "bg-[var(--foreground)]/80",
+    kind: "hard",
   },
   {
     name: "Soft feather",
     desc: "softness 0.55 · inner = radius × 0.45",
-    swatch: "bg-[var(--foreground)]/35",
+    kind: "soft",
   },
-] as const;
+];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  const mask =
+    kind === "hard"
+      ? "radial-gradient(circle 6px at 50% 50%, transparent 0, transparent 5px, #000 6px)"
+      : "radial-gradient(circle 6px at 50% 50%, transparent 0, transparent 2px, #000 6px)";
+  return (
+    <span className="relative h-5 w-7 overflow-hidden rounded-lg border border-fd-border ring-1 ring-fd-border ring-inset">
+      <span className="absolute inset-0 bg-[var(--foreground)]/75" />
+      <span
+        className="absolute inset-0 bg-[var(--card)]"
+        style={{ maskImage: mask, WebkitMaskImage: mask }}
+      />
+    </span>
+  );
+}
 
 export function SpotlightRevealMask() {
   return (
@@ -78,9 +98,7 @@ export function SpotlightRevealMask() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/stack-badge-anatomy.tsx
+++ b/apps/docs/src/components/learn/stack-badge-anatomy.tsx
@@ -17,18 +17,33 @@ const CSS = `
 .sba-static .sba-chip { opacity: 1; animation: none; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "icon" | "label";
+}[] = [
   {
     name: "Icon token",
     desc: "24×24 mono SVG, currentColor",
-    swatch: "bg-[var(--foreground)]/50",
+    kind: "icon",
   },
   {
     name: "Label token",
     desc: "font-medium text, same row",
-    swatch: "bg-[var(--foreground)]/25",
+    kind: "label",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "icon") {
+    return (
+      <span className="size-3 rounded-[5px] bg-[var(--foreground)]/50 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/25 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function StackBadgeAnatomy() {
   return (
@@ -58,9 +73,7 @@ export function StackBadgeAnatomy() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/stack-badge-stagger.tsx
+++ b/apps/docs/src/components/learn/stack-badge-stagger.tsx
@@ -43,18 +43,39 @@ function chipStyle(index: number): CSSProperties {
   } as CSSProperties;
 }
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "stagger" | "glow";
+}[] = [
   {
     name: "Stagger in",
     desc: "delay index × 40ms · spring 320/32/0.9",
-    swatch: "bg-[var(--foreground)]/25",
+    kind: "stagger",
   },
   {
     name: "Hover glow",
     desc: "y −3px snappy 520/32 · glow 240ms",
-    swatch: "bg-[var(--foreground)]/50",
+    kind: "glow",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "glow") {
+    return (
+      <span className="relative inline-flex h-3.5 w-8 items-center gap-1 rounded-full border border-transparent bg-[var(--muted)] px-1.5 shadow-[0_4px_10px_-6px_var(--foreground)] ring-1 ring-fd-border ring-inset">
+        <span className="size-1.5 shrink-0 rounded-[3px] bg-[var(--foreground)]/50" />
+        <span className="h-1 w-3 rounded-full bg-[var(--foreground)]/25" />
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex h-3.5 w-8 items-center gap-1 rounded-full border border-transparent bg-[var(--muted)] px-1.5 ring-1 ring-fd-border ring-inset">
+      <span className="size-1.5 shrink-0 rounded-[3px] bg-[var(--foreground)]/50" />
+      <span className="h-1 w-3 rounded-full bg-[var(--foreground)]/25" />
+    </span>
+  );
+}
 
 export function StackBadgeStagger() {
   return (
@@ -88,9 +109,7 @@ export function StackBadgeStagger() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/stepper-progress.tsx
+++ b/apps/docs/src/components/learn/stepper-progress.tsx
@@ -78,7 +78,7 @@ export function StepperProgress() {
 
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/30 ring-1 ring-fd-border ring-inset" />
+              <span className="size-3 rounded-full border border-[var(--foreground)]/25 bg-[var(--foreground)]/30" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Circle
               </dt>
@@ -87,7 +87,7 @@ export function StepperProgress() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/60 ring-1 ring-fd-border ring-inset" />
+              <span className="h-4 w-px bg-[var(--foreground)]/60" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Connector
               </dt>
@@ -96,7 +96,7 @@ export function StepperProgress() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
+              <span className="size-3 rounded-full bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Check
               </dt>

--- a/apps/docs/src/components/learn/sticky-scroll-anatomy.tsx
+++ b/apps/docs/src/components/learn/sticky-scroll-anatomy.tsx
@@ -18,18 +18,20 @@ const LEGEND: { name: string; desc: string; swatch: string }[] = [
   {
     name: "List",
     desc: "scrolls; each item dims when it isn't active",
-    swatch: "bg-[var(--foreground)]/25",
+    swatch:
+      "h-1.5 w-8 rounded-full bg-[var(--foreground)]/30 ring-1 ring-fd-border ring-inset",
   },
   {
     name: "Center line",
     desc: "rootMargin -50%/-50% — the one trigger line",
     swatch:
-      "border-t-2 border-dashed border-[var(--foreground)]/50 bg-transparent",
+      "h-0 w-8 border-t-2 border-dashed border-[var(--foreground)]/40 bg-transparent",
   },
   {
     name: "Panel",
     desc: "sticky, crossfades to match the active item",
-    swatch: "bg-[var(--foreground)]",
+    swatch:
+      "relative h-3 w-8 rounded-md border border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset",
   },
 ];
 
@@ -79,7 +81,13 @@ export function StickyScrollAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span className={`h-1.5 w-8 rounded-full ${item.swatch}`} />
+                {item.name === "Panel" ? (
+                  <span className={item.swatch}>
+                    <span className="absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 rounded-sm bg-[var(--foreground)]" />
+                  </span>
+                ) : (
+                  <span className={item.swatch} />
+                )}
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/sticky-scroll-io.tsx
+++ b/apps/docs/src/components/learn/sticky-scroll-io.tsx
@@ -24,6 +24,36 @@ const CSS = `
 .ssio-static .ssio-h1 { animation: none; opacity: 1; }
 `;
 
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "idle" | "crossing";
+}[] = [
+  {
+    name: "Idle",
+    desc: "not intersecting — index unchanged",
+    kind: "idle",
+  },
+  {
+    name: "Crossing",
+    desc: "intersecting — setActive(index) fires",
+    kind: "crossing",
+  },
+];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "crossing") {
+    return (
+      <span className="relative h-3.5 w-8 overflow-hidden rounded-lg bg-[var(--muted)] ring-1 ring-fd-border ring-inset">
+        <span className="absolute inset-0 bg-[var(--foreground)]/70" />
+      </span>
+    );
+  }
+  return (
+    <span className="h-3.5 w-8 rounded-lg bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+  );
+}
+
 export function StickyScrollIo() {
   return (
     <ScrollScene label="The trigger" note="one line, whichever item crosses it">
@@ -58,24 +88,17 @@ export function StickyScrollIo() {
           </p>
 
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Idle
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                not intersecting — index unchanged
-              </dd>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/70 ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Crossing
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                intersecting — setActive(index) fires
-              </dd>
-            </div>
+            {LEGEND.map((item) => (
+              <div key={item.name} className="flex flex-col gap-1.5">
+                <LegendSwatch kind={item.kind} />
+                <dt className="font-medium text-[13px] text-fd-foreground">
+                  {item.name}
+                </dt>
+                <dd className="text-[12px] text-fd-muted-foreground">
+                  {item.desc}
+                </dd>
+              </div>
+            ))}
           </dl>
         </div>
       )}

--- a/apps/docs/src/components/learn/store-badge-anatomy.tsx
+++ b/apps/docs/src/components/learn/store-badge-anatomy.tsx
@@ -21,18 +21,36 @@ const CSS = `
 .stba-static .stba-shell { opacity: 1; animation: none; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "icon" | "label";
+}[] = [
   {
     name: "Icon slot",
     desc: "iconSize = height × 0.52",
-    swatch: "bg-[var(--foreground)]/45",
+    kind: "icon",
   },
   {
     name: "Two-line label",
     desc: "caption (0.17h) + name (0.3h), stacked",
-    swatch: "bg-[var(--foreground)]/25",
+    kind: "label",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "icon") {
+    return (
+      <span className="size-3 rounded-[6px] bg-[var(--foreground)]/45 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="flex h-3 w-8 flex-col justify-center gap-0.5">
+      <span className="h-1 w-5 rounded-full bg-[var(--foreground)]/40 ring-1 ring-fd-border ring-inset" />
+      <span className="h-1.5 w-7 rounded-full bg-[var(--foreground)]/80 ring-1 ring-fd-border ring-inset" />
+    </span>
+  );
+}
 
 export function StoreBadgeAnatomy() {
   return (
@@ -64,9 +82,7 @@ export function StoreBadgeAnatomy() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/store-badge-sheen.tsx
+++ b/apps/docs/src/components/learn/store-badge-sheen.tsx
@@ -22,18 +22,35 @@ const CSS = `
 .stbs-static .stbs-sheen { animation: none; opacity: 0; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "lift" | "sheen";
+}[] = [
   {
     name: "Lift",
     desc: "translateY −2px, 200ms cubic-bezier(0.22,1,0.36,1)",
-    swatch: "bg-[var(--foreground)]/25",
+    kind: "lift",
   },
   {
     name: "Sheen",
     desc: "skewed strip, −130% → 130%, 700ms ease-out",
-    swatch: "bg-[var(--foreground)]/60",
+    kind: "sheen",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "sheen") {
+    return (
+      <span className="relative h-4 w-8 overflow-hidden rounded-xl bg-black/80 ring-1 ring-fd-border ring-inset">
+        <span className="absolute inset-0 [background:linear-gradient(105deg,transparent_20%,rgba(255,255,255,0.45)_50%,transparent_80%)] [transform:skewX(-12deg)_scaleX(1.4)]" />
+      </span>
+    );
+  }
+  return (
+    <span className="h-4 w-8 rounded-xl bg-black/80 ring-1 ring-white/20 ring-inset" />
+  );
+}
 
 export function StoreBadgeSheen() {
   return (
@@ -63,9 +80,7 @@ export function StoreBadgeSheen() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/swipe-deck-anatomy.tsx
+++ b/apps/docs/src/components/learn/swipe-deck-anatomy.tsx
@@ -30,18 +30,33 @@ function cardStyle(rank: number): CSSProperties {
   } as CSSProperties;
 }
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "front" | "behind";
+}[] = [
   {
     name: "Front card",
     desc: "rank 0 — the only one that's draggable",
-    swatch: "bg-[var(--foreground)]",
+    kind: "front",
   },
   {
     name: "Behind ranks",
     desc: "scale 1 − rank×0.05, y rank×16 · spring 320/32/0.9",
-    swatch: "bg-[var(--foreground)]/30",
+    kind: "behind",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "front") {
+    return (
+      <span className="h-4 w-5 rounded-2xl border border-[var(--foreground)]/60 bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-4 w-5 rounded-2xl border border-fd-border bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function SwipeDeckAnatomy() {
   return (
@@ -71,9 +86,7 @@ export function SwipeDeckAnatomy() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/swipe-deck-fling.tsx
+++ b/apps/docs/src/components/learn/swipe-deck-fling.tsx
@@ -20,18 +20,33 @@ const CSS = `
 .swdf-static .swdf-card { animation: none; transform: none; opacity: 1; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "front" | "behind";
+}[] = [
   {
-    name: "Drag → rotate",
-    desc: "x [−320,0,320] maps to rotate [−18°,0,18°]",
-    swatch: "bg-[var(--foreground)]",
+    name: "Front card",
+    desc: "drag → rotate · x maps to ±18°",
+    kind: "front",
   },
   {
-    name: "Exit spring",
-    desc: "stiffness 60 / damping 16, seeded with release velocity",
-    swatch: "bg-[var(--foreground)]/30",
+    name: "Behind card",
+    desc: "exit spring 60/16 seeded with velocity",
+    kind: "behind",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "front") {
+    return (
+      <span className="h-4 w-5 rounded-md border border-[var(--foreground)]/60 bg-[var(--card)] shadow-sm" />
+    );
+  }
+  return (
+    <span className="h-4 w-5 rounded-md border border-fd-border bg-[var(--muted)]" />
+  );
+}
 
 export function SwipeDeckFling() {
   return (
@@ -55,9 +70,7 @@ export function SwipeDeckFling() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/tab-bar-anatomy.tsx
+++ b/apps/docs/src/components/learn/tab-bar-anatomy.tsx
@@ -34,23 +34,43 @@ const CSS = `
 .tb-a-static .tb-a-label { opacity: 1; animation: none; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "blob" | "icon" | "label";
+}[] = [
   {
     name: "Blob",
-    desc: "one bg-primary pill, only under the active tab",
-    swatch: "bg-[var(--foreground)]",
+    desc: "one foreground pill, only under the active tab",
+    kind: "blob",
   },
   {
     name: "Icon",
     desc: "always shown; pops on selection",
-    swatch: "bg-[var(--foreground)]/40",
+    kind: "icon",
   },
   {
     name: "Label",
     desc: "revealed on the active tab only",
-    swatch: "bg-[var(--foreground)]/25",
+    kind: "label",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "blob") {
+    return (
+      <span className="h-3 w-8 rounded-full bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "icon") {
+    return (
+      <span className="size-3 rounded-full bg-[var(--foreground)]/40 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-1.5 w-8 rounded-full bg-[var(--background)]/80 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function TabBarAnatomy() {
   return (
@@ -100,9 +120,7 @@ export function TabBarAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/terminal-anatomy.tsx
+++ b/apps/docs/src/components/learn/terminal-anatomy.tsx
@@ -23,17 +23,20 @@ const LEGEND = [
   {
     name: "Chrome",
     desc: "showChrome — traffic lights + optional title",
-    swatch: "bg-red-500/70",
+    swatch:
+      "size-2.5 rounded-full bg-red-500/80 ring-1 ring-fd-border ring-inset",
   },
   {
     name: "Body",
     desc: "mono 13px, space-y-1, ligatures off",
-    swatch: "bg-[var(--card)]",
+    swatch:
+      "h-3 w-8 rounded-md border border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset",
   },
   {
     name: "Lines",
     desc: "command · output · comment color roles",
-    swatch: "bg-[var(--foreground)]/35",
+    swatch:
+      "h-1.5 w-8 rounded-full bg-[var(--foreground)]/35 ring-1 ring-fd-border ring-inset",
   },
 ] as const;
 
@@ -88,9 +91,7 @@ export function TerminalAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <span className={item.swatch} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/terminal-lifecycle.tsx
+++ b/apps/docs/src/components/learn/terminal-lifecycle.tsx
@@ -39,23 +39,69 @@ const CSS = `
 .tl-static .tl-loop-tag { animation: none; opacity: 0; }
 `;
 
-const LEGEND = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "view" | "loop" | "reduced";
+}[] = [
   {
     name: "startOnView",
     desc: "IO threshold 0.35 → setActive(true), disconnect",
-    swatch: "bg-[var(--muted)]",
+    kind: "view",
   },
   {
     name: "Loop",
     desc: "2s pause, then count=0 / typed=0",
-    swatch: "bg-[var(--foreground)]/35",
+    kind: "loop",
   },
   {
     name: "Reduced",
     desc: "dump lines.length immediately, no caret",
-    swatch: "bg-transparent ring-1 ring-[var(--foreground)]/40 ring-inset",
+    kind: "reduced",
   },
-] as const;
+];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "view") {
+    return (
+      <span className="flex h-7 w-10 flex-col justify-center gap-0.5 rounded-lg border border-dashed border-fd-border bg-[var(--card)] px-1.5 ring-1 ring-fd-border ring-inset">
+        <span className="h-1 w-full rounded-full bg-[var(--foreground)]/40" />
+        <span className="h-1 w-4/5 rounded-full bg-[var(--foreground)]/18" />
+      </span>
+    );
+  }
+  if (kind === "loop") {
+    return (
+      <svg
+        aria-hidden="true"
+        className="size-4 text-fd-muted-foreground"
+        viewBox="0 0 16 16"
+        fill="none"
+      >
+        <path
+          d="M3 8a5 5 0 0 1 8.5-3.5M13 8a5 5 0 0 1-8.5 3.5"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+        />
+        <path
+          d="M11 2.5v2.5H13.5M5 13.5V11H2.5"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    );
+  }
+  return (
+    <span className="flex flex-col gap-0.5">
+      <span className="h-1 w-7 rounded-full bg-[var(--foreground)]/40" />
+      <span className="h-1 w-8 rounded-full bg-[var(--foreground)]/18" />
+      <span className="h-1 w-5 rounded-full bg-[var(--foreground)]/40" />
+    </span>
+  );
+}
 
 export function TerminalLifecycle() {
   return (
@@ -118,9 +164,7 @@ export function TerminalLifecycle() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/terminal-typing.tsx
+++ b/apps/docs/src/components/learn/terminal-typing.tsx
@@ -57,23 +57,46 @@ const CSS = `
 .tt-static .tt-caret { animation: none; opacity: 0; }
 `;
 
-const LEGEND = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "command" | "output" | "caret";
+}[] = [
   {
     name: "Command",
     desc: "typed++ every typingSpeed ms (38)",
-    swatch: "bg-[var(--foreground)]/50",
+    kind: "command",
   },
   {
     name: "Output",
     desc: "lands after delay (default 380ms)",
-    swatch: "bg-[var(--foreground)]/20",
+    kind: "output",
   },
   {
     name: "Caret",
     desc: "animate-pulse on the active command",
-    swatch: "bg-[var(--foreground)]",
+    kind: "caret",
   },
-] as const;
+];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "command") {
+    return (
+      <span className="flex items-center gap-1">
+        <span className="size-2 shrink-0 rounded-sm bg-[var(--foreground)]/45" />
+        <span className="h-1.5 w-6 rounded-full bg-[var(--foreground)]/45" />
+      </span>
+    );
+  }
+  if (kind === "output") {
+    return (
+      <span className="ml-2 h-1.5 w-7 rounded-full bg-[var(--foreground)]/18" />
+    );
+  }
+  return (
+    <span className="inline-block h-3 w-[3px] bg-[var(--foreground)]/70" />
+  );
+}
 
 export function TerminalTyping() {
   return (
@@ -129,9 +152,7 @@ export function TerminalTyping() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/text-animate-anatomy.tsx
+++ b/apps/docs/src/components/learn/text-animate-anatomy.tsx
@@ -24,12 +24,14 @@ const LEGEND: { name: string; desc: string; swatch: string }[] = [
   {
     name: 'by="word"',
     desc: "split(/(\\s+)/) · fewer, wider segments",
-    swatch: "bg-[var(--foreground)]/40",
+    swatch:
+      "h-2 w-10 rounded-full bg-[var(--foreground)]/30 ring-1 ring-fd-border ring-inset",
   },
   {
     name: 'by="character"',
     desc: "[...text] · one segment per glyph",
-    swatch: "bg-[var(--foreground)]/70",
+    swatch:
+      "h-2 w-2 rounded-full bg-[var(--foreground)]/30 ring-1 ring-fd-border ring-inset",
   },
 ];
 
@@ -93,9 +95,7 @@ export function TextAnimateAnatomy() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ring-1 ring-fd-border ring-inset ${item.swatch}`}
-                />
+                <span className={item.swatch} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/text-animate-presets.tsx
+++ b/apps/docs/src/components/learn/text-animate-presets.tsx
@@ -38,18 +38,33 @@ const CSS = `
 }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "blur" | "slide";
+}[] = [
   {
     name: "blurInUp",
     desc: "opacity + blur(10px) + y:20 → rest",
-    swatch: "bg-[var(--foreground)]/40",
+    kind: "blur",
   },
   {
     name: "slideUp",
     desc: "opacity + y:20 → rest · no filter",
-    swatch: "bg-[var(--foreground)]/70",
+    kind: "slide",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "blur") {
+    return (
+      <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/30 blur-[2px] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/30 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 function BarRow({ className }: { className: string }) {
   return (
@@ -103,9 +118,7 @@ export function TextAnimatePresets() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ring-1 ring-fd-border ring-inset ${item.swatch}`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/text-animate-stagger.tsx
+++ b/apps/docs/src/components/learn/text-animate-stagger.tsx
@@ -24,18 +24,37 @@ const CSS = `
 .tas-static .tas-bar { opacity: 1; animation: none; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "stagger" | "default";
+}[] = [
   {
     name: "staggerChildren",
     desc: "delay between each segment's start",
-    swatch: "bg-[var(--foreground)]/30",
+    kind: "stagger",
   },
   {
     name: "default stagger",
     desc: "duration / segments.length · or STAGGER_BY_SPLIT",
-    swatch: "bg-[var(--foreground)]/70",
+    kind: "default",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "stagger") {
+    return (
+      <span className="flex flex-col gap-1">
+        <span className="h-1.5 w-6 rounded-full bg-[var(--foreground)]/30" />
+        <span className="h-1.5 w-8 translate-x-1 rounded-full bg-[var(--foreground)]/30" />
+        <span className="h-1.5 w-5 translate-x-2 rounded-full bg-[var(--foreground)]/30" />
+      </span>
+    );
+  }
+  return (
+    <span className="h-1.5 w-8 rounded-full bg-[var(--foreground)]/30 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 const WIDTHS = [40, 28, 52, 24, 44, 36];
 
@@ -77,9 +96,7 @@ export function TextAnimateStagger() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ring-1 ring-fd-border ring-inset ${item.swatch}`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/text-scramble-anatomy.tsx
+++ b/apps/docs/src/components/learn/text-scramble-anatomy.tsx
@@ -25,17 +25,19 @@ const LEGEND: { name: string; desc: string; swatch: string }[] = [
   {
     name: "From",
     desc: "frame < start — previous glyph, done",
-    swatch: "bg-[var(--foreground)]/25",
+    swatch:
+      "size-2.5 rounded-sm bg-[var(--foreground)]/25 ring-1 ring-fd-border ring-inset",
   },
   {
     name: "Scrambling",
     desc: "start ≤ frame < end — random from pool",
-    swatch: "bg-primary",
+    swatch: "size-2.5 rounded-sm bg-primary ring-1 ring-fd-border ring-inset",
   },
   {
     name: "Resolved",
     desc: "frame ≥ end — locked to `to`",
-    swatch: "bg-[var(--foreground)]/70",
+    swatch:
+      "size-2.5 rounded-sm bg-[var(--foreground)]/70 ring-1 ring-fd-border ring-inset",
   },
 ];
 
@@ -108,9 +110,7 @@ export function TextScrambleAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ring-1 ring-fd-border ring-inset ${item.swatch}`}
-                />
+                <span className={item.swatch} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/text-scramble-cycle.tsx
+++ b/apps/docs/src/components/learn/text-scramble-cycle.tsx
@@ -42,18 +42,37 @@ const CSS = `
 }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "unresolved" | "resolved";
+}[] = [
   {
     name: "Unresolved",
     desc: "random pool glyph + text-primary, 120ms color",
-    swatch: "bg-primary",
+    kind: "unresolved",
   },
   {
     name: "Resolved",
     desc: "locked `to` — inherits foreground",
-    swatch: "bg-[var(--foreground)]/60",
+    kind: "resolved",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "unresolved") {
+    return (
+      <span className="inline-flex w-[1.1ch] justify-center font-mono text-sm text-primary">
+        ░
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex w-[1.1ch] justify-center font-mono text-sm text-[var(--foreground)]">
+      ░
+    </span>
+  );
+}
 
 export function TextScrambleCycle() {
   return (
@@ -91,9 +110,7 @@ export function TextScrambleCycle() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ring-1 ring-fd-border ring-inset ${item.swatch}`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/text-scramble-trigger.tsx
+++ b/apps/docs/src/components/learn/text-scramble-trigger.tsx
@@ -52,23 +52,54 @@ const CSS = `
 .tst-static .tst-hover-ring { animation: none; opacity: 1; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "mount" | "in-view" | "hover";
+}[] = [
   {
     name: "mount",
     desc: "first effect — run(text) immediately",
-    swatch: "bg-[var(--foreground)]/50",
+    kind: "mount",
   },
   {
     name: "in-view",
     desc: "IO threshold 0.4, then disconnect",
-    swatch: "border border-dashed border-[var(--foreground)]/45 bg-transparent",
+    kind: "in-view",
   },
   {
     name: "hover",
     desc: "onPointerEnter sets started + run",
-    swatch: "bg-[var(--foreground)]/20 ring-1 ring-[var(--foreground)]/40",
+    kind: "hover",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "mount") {
+    return (
+      <span className="flex h-4 items-end gap-0.5">
+        <span className="h-2 w-1.5 rounded-sm bg-[var(--foreground)]/45" />
+        <span className="h-3 w-1.5 rounded-sm bg-[var(--foreground)]/45" />
+        <span className="h-2.5 w-1.5 rounded-sm bg-[var(--foreground)]/45" />
+      </span>
+    );
+  }
+  if (kind === "in-view") {
+    return (
+      <span className="relative flex h-7 w-10 items-center justify-center overflow-hidden rounded-md border border-fd-border bg-[var(--card)]">
+        <span className="pointer-events-none absolute inset-x-0 top-[30%] bottom-[30%] border-y border-dashed border-[var(--foreground)]/25" />
+        <span className="relative h-1 w-5 rounded-full bg-[var(--foreground)]/35" />
+      </span>
+    );
+  }
+  return (
+    <span className="relative flex size-7 items-center justify-center">
+      <span className="absolute size-6 rounded-full border border-[var(--foreground)]/30" />
+      <span className="absolute size-4 rounded-full bg-[var(--foreground)]/10" />
+      <span className="relative h-1 w-4 rounded-full bg-[var(--foreground)]/40" />
+    </span>
+  );
+}
 
 const COLUMNS: {
   key: string;
@@ -170,9 +201,7 @@ export function TextScrambleTrigger() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ring-1 ring-fd-border ring-inset ${item.swatch}`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/three-d-marquee-anatomy.tsx
+++ b/apps/docs/src/components/learn/three-d-marquee-anatomy.tsx
@@ -20,18 +20,38 @@ const CSS = `
 .tdma-static .tdma-tile { opacity: 1; animation: none; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "viewport" | "tile";
+}[] = [
   {
-    name: "Perspective",
-    desc: "container: [perspective:1200px]",
-    swatch: "bg-[var(--foreground)]/25",
+    name: "Viewport",
+    desc: "overflow clip · [perspective:1200px]",
+    kind: "viewport",
   },
   {
-    name: "Tilt",
-    desc: "grid: rotateX(55deg) rotateZ(-45deg)",
-    swatch: "bg-[var(--foreground)]/50",
+    name: "Tile grid",
+    desc: "rotateX(55deg) rotateZ(-45deg)",
+    kind: "tile",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "viewport") {
+    return (
+      <span className="flex h-5 w-9 items-center justify-center rounded-sm border border-dashed border-[var(--foreground)]/35">
+        <span className="size-2 rounded-[2px] bg-[var(--foreground)]/15" />
+      </span>
+    );
+  }
+  // Same fill as diagram tiles; slight isometric so it reads as the diamond plane.
+  return (
+    <span className="flex h-5 w-9 items-center justify-center">
+      <span className="size-3.5 rounded-[3px] bg-[var(--foreground)]/25 [transform:rotateX(55deg)_rotateZ(-45deg)]" />
+    </span>
+  );
+}
 
 export function ThreeDMarqueeAnatomy() {
   return (
@@ -42,42 +62,45 @@ export function ThreeDMarqueeAnatomy() {
           <style dangerouslySetInnerHTML={{ __html: CSS }} />
 
           <div
-            className={`relative flex h-52 w-full items-center justify-center overflow-hidden [perspective:1200px] ${reduced ? "tdma-static" : ""}`}
+            className={`relative flex h-52 w-full items-center justify-center overflow-hidden rounded-sm border border-dashed border-[var(--foreground)]/25 [perspective:1200px] ${reduced ? "tdma-static" : ""}`}
           >
-            <div
-              key={cycle}
-              className="grid w-[130%] scale-110 grid-cols-4 gap-2.5 [transform:rotateX(55deg)_rotateZ(-45deg)]"
-              style={{ transformStyle: "preserve-3d" }}
-            >
-              {Array.from({ length: COLS }).map((_, col) => (
-                <div
-                  // biome-ignore lint/suspicious/noArrayIndexKey: columns are positional and static
-                  key={col}
-                  className="flex flex-col gap-2.5"
-                >
-                  {Array.from({ length: ROWS }).map((_, row) => (
-                    <span
-                      // biome-ignore lint/suspicious/noArrayIndexKey: rows are positional and static
-                      key={row}
-                      className="tdma-tile aspect-square w-full rounded-md bg-[var(--foreground)]/25"
-                      style={
-                        {
-                          "--d": `${(col * ROWS + row) * 30}ms`,
-                        } as CSSProperties
-                      }
-                    />
-                  ))}
-                </div>
-              ))}
+            {/* Scale/width on a wrapper — same as the component. Putting
+                scale-* on the rotated grid loses it to the arbitrary
+                [transform:…] and the plane underfills the clip (diamond). */}
+            <div className="w-[140%] scale-110">
+              <div
+                key={cycle}
+                className="grid w-full grid-cols-4 gap-2.5 [transform:rotateX(55deg)_rotateZ(-45deg)]"
+                style={{ transformStyle: "preserve-3d" }}
+              >
+                {Array.from({ length: COLS }).map((_, col) => (
+                  <div
+                    // biome-ignore lint/suspicious/noArrayIndexKey: columns are positional and static
+                    key={col}
+                    className="flex flex-col gap-2.5"
+                  >
+                    {Array.from({ length: ROWS }).map((_, row) => (
+                      <span
+                        // biome-ignore lint/suspicious/noArrayIndexKey: rows are positional and static
+                        key={row}
+                        className="tdma-tile aspect-square w-full rounded-md bg-[var(--foreground)]/25"
+                        style={
+                          {
+                            "--d": `${(col * ROWS + row) * 30}ms`,
+                          } as CSSProperties
+                        }
+                      />
+                    ))}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
 
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/three-d-marquee-bob.tsx
+++ b/apps/docs/src/components/learn/three-d-marquee-bob.tsx
@@ -23,18 +23,38 @@ const CSS = `
 .tdmb-static .tdmb-col-2, .tdmb-static .tdmb-col-3 { animation: none; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "tile" | "alt";
+}[] = [
   {
     name: "Column loop",
     desc: "y [0,∓40,0], ease [0.65,0,0.35,1]",
-    swatch: "bg-[var(--foreground)]/50",
+    kind: "tile",
   },
   {
     name: "Alternating direction",
     desc: "colIndex % 2 === 0 ? up-first : down-first",
-    swatch: "bg-[var(--foreground)]/25",
+    kind: "alt",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "alt") {
+    return (
+      <span className="flex items-center gap-0.5">
+        <span className="size-2.5 rounded-[3px] bg-[var(--foreground)]/25 [transform:rotateX(55deg)_rotateZ(-45deg)]" />
+        <span className="size-2.5 translate-y-1 rounded-[3px] bg-[var(--foreground)]/25 [transform:rotateX(55deg)_rotateZ(-45deg)]" />
+      </span>
+    );
+  }
+  return (
+    <span className="flex h-5 w-7 items-center justify-center">
+      <span className="size-3.5 rounded-[3px] bg-[var(--foreground)]/25 [transform:rotateX(55deg)_rotateZ(-45deg)]" />
+    </span>
+  );
+}
 
 export function ThreeDMarqueeBob() {
   return (
@@ -48,38 +68,38 @@ export function ThreeDMarqueeBob() {
           <style dangerouslySetInnerHTML={{ __html: CSS }} />
 
           <div
-            className={`relative flex h-52 w-full items-center justify-center overflow-hidden [perspective:1200px] ${reduced ? "tdmb-static" : ""}`}
+            className={`relative flex h-52 w-full items-center justify-center overflow-hidden rounded-sm border border-dashed border-[var(--foreground)]/25 [perspective:1200px] ${reduced ? "tdmb-static" : ""}`}
           >
-            <div
-              key={cycle}
-              className="grid w-[130%] scale-110 grid-cols-4 gap-2.5 [transform:rotateX(55deg)_rotateZ(-45deg)]"
-              style={{ transformStyle: "preserve-3d" }}
-            >
-              {Array.from({ length: COLS }).map((_, col) => (
-                <div
-                  // biome-ignore lint/suspicious/noArrayIndexKey: columns are positional and static
-                  key={col}
-                  className={`tdmb-col-${col} flex flex-col gap-2.5`}
-                  style={{ "--dur": `${2.4 + col * 0.4}s` } as CSSProperties}
-                >
-                  {Array.from({ length: ROWS }).map((_, row) => (
-                    <span
-                      // biome-ignore lint/suspicious/noArrayIndexKey: rows are positional and static
-                      key={row}
-                      className="aspect-square w-full rounded-md bg-[var(--foreground)]/25"
-                    />
-                  ))}
-                </div>
-              ))}
+            <div className="w-[140%] scale-110">
+              <div
+                key={cycle}
+                className="grid w-full grid-cols-4 gap-2.5 [transform:rotateX(55deg)_rotateZ(-45deg)]"
+                style={{ transformStyle: "preserve-3d" }}
+              >
+                {Array.from({ length: COLS }).map((_, col) => (
+                  <div
+                    // biome-ignore lint/suspicious/noArrayIndexKey: columns are positional and static
+                    key={col}
+                    className={`tdmb-col-${col} flex flex-col gap-2.5`}
+                    style={{ "--dur": `${2.4 + col * 0.4}s` } as CSSProperties}
+                  >
+                    {Array.from({ length: ROWS }).map((_, row) => (
+                      <span
+                        // biome-ignore lint/suspicious/noArrayIndexKey: rows are positional and static
+                        key={row}
+                        className="aspect-square w-full rounded-md bg-[var(--foreground)]/25"
+                      />
+                    ))}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
 
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/tilt-card-anatomy.tsx
+++ b/apps/docs/src/components/learn/tilt-card-anatomy.tsx
@@ -26,17 +26,19 @@ const LEGEND: { name: string; desc: string; swatch: string }[] = [
   {
     name: "Card (z 0)",
     desc: "rotateX/Y from the spring-smoothed pointer",
-    swatch: "bg-[var(--card)]",
+    swatch:
+      "h-3 w-8 rounded-2xl border border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset",
   },
   {
     name: "Content (translateZ 40px)",
     desc: "children float toward the viewer for parallax",
-    swatch: "bg-[var(--muted)]",
+    swatch:
+      "h-3 w-8 rounded-2xl border border-white/10 bg-[var(--muted)] ring-1 ring-fd-border ring-inset",
   },
   {
     name: "Glare (topmost)",
     desc: "radial highlight centered on the pointer",
-    swatch: "bg-white/70",
+    swatch: "h-3 w-8 rounded-2xl bg-white/70 ring-1 ring-fd-border ring-inset",
   },
 ];
 
@@ -90,9 +92,7 @@ export function TiltCardAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <span className={item.swatch} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/tilt-card-spring.tsx
+++ b/apps/docs/src/components/learn/tilt-card-spring.tsx
@@ -29,6 +29,38 @@ const CSS = `
 .tcs-glare-anim { animation: tcs-glare 4s cubic-bezier(0.34,1.4,0.64,1) infinite; }
 `;
 
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "tilt" | "glare";
+}[] = [
+  {
+    name: "Card tilt",
+    desc: "rotateX/rotateY, spring mass 0.1 · stiffness 170 · damping 12",
+    kind: "tilt",
+  },
+  {
+    name: "Glare",
+    desc: "same sx/sy, mapped to a radial-gradient position",
+    kind: "glare",
+  },
+];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "glare") {
+    return (
+      <span className="relative h-4 w-6 overflow-hidden rounded-lg border border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset">
+        <span className="tcs-glare pointer-events-none absolute inset-0 opacity-80" />
+      </span>
+    );
+  }
+  return (
+    <span className="relative flex h-4 w-6 items-center justify-center rounded-lg border border-fd-border bg-[var(--card)] shadow-sm ring-1 ring-fd-border ring-inset">
+      <span className="h-0.5 w-3 rounded-full bg-[var(--foreground)]/30" />
+    </span>
+  );
+}
+
 export function TiltCardSpring() {
   return (
     <ScrollScene label="The tilt" note="rotateX/Y and glare, one signal">
@@ -58,24 +90,17 @@ export function TiltCardSpring() {
           </p>
 
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Card tilt
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                rotateX/rotateY, spring mass 0.1 · stiffness 170 · damping 12
-              </dd>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-white/70 ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Glare
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                same sx/sy, mapped to a radial-gradient position
-              </dd>
-            </div>
+            {LEGEND.map((item) => (
+              <div key={item.name} className="flex flex-col gap-1.5">
+                <LegendSwatch kind={item.kind} />
+                <dt className="font-medium text-[13px] text-fd-foreground">
+                  {item.name}
+                </dt>
+                <dd className="text-[12px] text-fd-muted-foreground">
+                  {item.desc}
+                </dd>
+              </div>
+            ))}
           </dl>
         </div>
       )}

--- a/apps/docs/src/components/learn/toast-anatomy.tsx
+++ b/apps/docs/src/components/learn/toast-anatomy.tsx
@@ -21,17 +21,20 @@ const LEGEND: { name: string; desc: string; swatch: string }[] = [
   {
     name: "Front",
     desc: "index 0 · y 0 · scale 1",
-    swatch: "bg-[var(--card)]",
+    swatch:
+      "h-3 w-8 rounded-md border border-border bg-[var(--card)] ring-1 ring-fd-border ring-inset",
   },
   {
     name: "Peek 1",
     desc: "index 1 · y −16 · scale 0.95",
-    swatch: "bg-[var(--foreground)]/25",
+    swatch:
+      "h-3 w-8 rounded-md border border-border bg-[var(--foreground)]/15 ring-1 ring-fd-border ring-inset",
   },
   {
     name: "Peek 2",
     desc: "index 2 · y −32 · scale 0.90",
-    swatch: "bg-[var(--foreground)]/15",
+    swatch:
+      "h-3 w-8 rounded-md border border-border bg-[var(--foreground)]/10 ring-1 ring-fd-border ring-inset",
   },
 ];
 
@@ -81,9 +84,7 @@ export function ToastAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <span className={item.swatch} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/toast-expand.tsx
+++ b/apps/docs/src/components/learn/toast-expand.tsx
@@ -20,18 +20,36 @@ const CSS = `
 .te-static .te-fill { animation: none; transform: scaleX(0); transform-origin: left; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "collapsed" | "expanded";
+}[] = [
   {
     name: "Collapsed",
     desc: "y = dir × index × PEEK, timers run",
-    swatch: "bg-[var(--foreground)]/20",
+    kind: "collapsed",
   },
   {
     name: "Expanded",
     desc: "hover → real offsets, timers pause",
-    swatch: "bg-[var(--card)]",
+    kind: "expanded",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "expanded") {
+    return (
+      <span className="flex h-4 w-9 flex-col justify-center gap-1 rounded-xl border border-border bg-[var(--card)] p-1 shadow-sm ring-1 ring-fd-border ring-inset">
+        <span className="h-0.5 w-2/5 rounded-full bg-[var(--foreground)]/35" />
+        <span className="h-px w-full rounded-full bg-[var(--foreground)]/10" />
+      </span>
+    );
+  }
+  return (
+    <span className="h-3 w-8 rounded-xl border border-border bg-[var(--foreground)]/15 ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function ToastExpand() {
   return (
@@ -67,9 +85,7 @@ export function ToastExpand() {
           <dl className="grid w-full max-w-[380px] grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/toast-swipe.tsx
+++ b/apps/docs/src/components/learn/toast-swipe.tsx
@@ -26,23 +26,44 @@ const CSS = `
 .tsw-static .tsw-card { animation: none; transform: translateX(0); opacity: 0.35; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "card" | "threshold" | "dismissed";
+}[] = [
   {
     name: "Card",
     desc: 'drag="x", elastic 0.6',
-    swatch: "bg-[var(--card)]",
+    kind: "card",
   },
   {
     name: "Threshold",
     desc: "|offset.x| > 80",
-    swatch: "bg-[var(--foreground)]/40",
+    kind: "threshold",
   },
   {
     name: "Dismissed",
     desc: "no spring back, just exits",
-    swatch: "bg-[var(--foreground)]/15",
+    kind: "dismissed",
   },
 ];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "threshold") {
+    return <span className="h-4 w-px bg-[var(--foreground)]/35" />;
+  }
+  if (kind === "dismissed") {
+    return (
+      <span className="flex h-4 w-8 flex-col justify-center gap-1 rounded-xl border border-border bg-[var(--card)] p-1 opacity-35 shadow-sm" />
+    );
+  }
+  return (
+    <span className="flex h-4 w-8 flex-col justify-center gap-1 rounded-xl border border-border bg-[var(--card)] p-1 shadow-sm ring-1 ring-fd-border ring-inset">
+      <span className="h-0.5 w-2/5 rounded-full bg-[var(--foreground)]/35" />
+      <span className="h-0.5 w-3/5 rounded-full bg-[var(--foreground)]/20" />
+    </span>
+  );
+}
 
 export function ToastSwipe() {
   return (
@@ -76,9 +97,7 @@ export function ToastSwipe() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/topographic-drift-anatomy.tsx
+++ b/apps/docs/src/components/learn/topographic-drift-anatomy.tsx
@@ -96,7 +96,7 @@ export function TopographicDriftAnatomy() {
 
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span className="h-0 w-8 border-t border-[var(--foreground)]/10 bg-transparent ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Grid
               </dt>
@@ -105,7 +105,7 @@ export function TopographicDriftAnatomy() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span className="size-2 rounded-full bg-[var(--foreground)]/50 ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Field
               </dt>
@@ -114,7 +114,7 @@ export function TopographicDriftAnatomy() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span className="h-0 w-8 border-t border-dashed border-[var(--foreground)]/25 bg-transparent ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Levels
               </dt>

--- a/apps/docs/src/components/learn/topographic-drift-drift.tsx
+++ b/apps/docs/src/components/learn/topographic-drift-drift.tsx
@@ -23,6 +23,52 @@ const CSS = `
 .tdd-static .tdd-map { animation: none; }
 `;
 
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "offset" | "lifecycle";
+}[] = [
+  {
+    name: "z-offset",
+    desc: "z += 0.0015 × speed",
+    kind: "offset",
+  },
+  {
+    name: "Lifecycle",
+    desc: "IO · visibility · reduced freeze",
+    kind: "lifecycle",
+  },
+];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "lifecycle") {
+    return (
+      <span className="h-8 w-12 rounded-2xl border border-fd-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 32 12"
+      className="h-3 w-8 text-[var(--foreground)]"
+      fill="none"
+    >
+      <path
+        d="M0 6 Q8 2 16 6 T32 6"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        opacity={0.75}
+      />
+      <path
+        d="M0 9 Q8 6 16 9 T32 9"
+        stroke="currentColor"
+        strokeWidth="1"
+        opacity={0.45}
+      />
+    </svg>
+  );
+}
+
 export function TopographicDriftDrift() {
   return (
     <ScrollScene label="Drift" note="z += 0.0015 × speed each frame">
@@ -78,24 +124,23 @@ export function TopographicDriftDrift() {
           </p>
 
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                z-offset
-              </dt>
-              <dd className="font-mono text-[12px] text-fd-muted-foreground">
-                z += 0.0015 × speed
-              </dd>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Lifecycle
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                IO · visibility · reduced freeze
-              </dd>
-            </div>
+            {LEGEND.map((item) => (
+              <div key={item.name} className="flex flex-col gap-1.5">
+                <LegendSwatch kind={item.kind} />
+                <dt className="font-medium text-[13px] text-fd-foreground">
+                  {item.name}
+                </dt>
+                <dd
+                  className={
+                    item.kind === "offset"
+                      ? "font-mono text-[12px] text-fd-muted-foreground"
+                      : "text-[12px] text-fd-muted-foreground"
+                  }
+                >
+                  {item.desc}
+                </dd>
+              </div>
+            ))}
           </dl>
         </div>
       )}

--- a/apps/docs/src/components/learn/topographic-drift-march.tsx
+++ b/apps/docs/src/components/learn/topographic-drift-march.tsx
@@ -26,6 +26,57 @@ const CSS = `
 .tdm-static .tdm-line { animation: none; stroke-dashoffset: 0; opacity: 1; }
 `;
 
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "cases" | "alpha";
+}[] = [
+  {
+    name: "Cases",
+    desc: "16 configs · skip 0 and 15",
+    kind: "cases",
+  },
+  {
+    name: "Alpha",
+    desc: "0.1 + 0.25×(1−|0.5−level|×2)",
+    kind: "alpha",
+  },
+];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "cases") {
+    return (
+      <span className="relative flex size-7 items-center justify-center">
+        <span className="absolute inset-0 rounded-sm border border-[var(--foreground)]/20" />
+        <span className="absolute top-0 left-0 size-1.5 rounded-full bg-[var(--foreground)]" />
+        <span className="absolute top-0 right-0 size-1.5 rounded-full bg-[var(--foreground)]" />
+        <span className="absolute h-px w-4 bg-[var(--foreground)]" />
+      </span>
+    );
+  }
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 32 16"
+      className="h-4 w-8 text-[var(--foreground)]"
+      fill="none"
+    >
+      <path
+        d="M0 12 C8 8, 12 6, 20 8 S28 4, 32 6"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        opacity={0.75}
+      />
+      <path
+        d="M0 14 C8 11, 12 9, 20 11 S28 8, 32 10"
+        stroke="currentColor"
+        strokeWidth="1.1"
+        opacity={0.4}
+      />
+    </svg>
+  );
+}
+
 export function TopographicDriftMarch() {
   return (
     <ScrollScene label="Marching squares" note="4-bit mask · 16 edge cases">
@@ -138,24 +189,23 @@ export function TopographicDriftMarch() {
           </p>
 
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Cases
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                16 configs · skip 0 and 15
-              </dd>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Alpha
-              </dt>
-              <dd className="font-mono text-[12px] text-fd-muted-foreground">
-                0.1 + 0.25×(1−|0.5−level|×2)
-              </dd>
-            </div>
+            {LEGEND.map((item) => (
+              <div key={item.name} className="flex flex-col gap-1.5">
+                <LegendSwatch kind={item.kind} />
+                <dt className="font-medium text-[13px] text-fd-foreground">
+                  {item.name}
+                </dt>
+                <dd
+                  className={
+                    item.kind === "alpha"
+                      ? "font-mono text-[12px] text-fd-muted-foreground"
+                      : "text-[12px] text-fd-muted-foreground"
+                  }
+                >
+                  {item.desc}
+                </dd>
+              </div>
+            ))}
           </dl>
         </div>
       )}

--- a/apps/docs/src/components/learn/voice-orb-amp-split.tsx
+++ b/apps/docs/src/components/learn/voice-orb-amp-split.tsx
@@ -28,18 +28,33 @@ const CSS = `
 .voas-static .voas-scale { transform: scale(1.05); }
 `;
 
-const LEGEND = [
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "wrapper" | "inner";
+}[] = [
   {
     name: "Wrapper",
     desc: "inline scale(--amp)",
-    swatch: "bg-[var(--foreground)]/25",
+    kind: "wrapper",
   },
   {
     name: "Inner",
     desc: "animate-voice-orb-spin",
-    swatch: "bg-[var(--muted)]",
+    kind: "inner",
   },
-] as const;
+];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "wrapper") {
+    return (
+      <span className="relative size-7 rounded-full bg-[conic-gradient(from_0deg,var(--foreground)_0%,transparent_40%,var(--foreground)_70%,transparent_100%)] opacity-40 blur-[2px]" />
+    );
+  }
+  return (
+    <span className="size-4 rounded-full border border-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function VoiceOrbAmpSplit() {
   return (
@@ -89,9 +104,7 @@ export function VoiceOrbAmpSplit() {
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/voice-orb-anatomy.tsx
+++ b/apps/docs/src/components/learn/voice-orb-anatomy.tsx
@@ -21,17 +21,20 @@ const LEGEND = [
   {
     name: "Corona",
     desc: "conic spin · amp scale",
-    swatch: "bg-[var(--foreground)]/20",
+    swatch:
+      "size-3 rounded-full bg-[var(--foreground)]/15 blur-[2px] ring-1 ring-fd-border ring-inset",
   },
   {
     name: "Core",
     desc: "breathe + amp swell",
-    swatch: "bg-[var(--card)]",
+    swatch:
+      "size-3 rounded-full border border-border bg-[var(--card)] ring-1 ring-fd-border ring-inset",
   },
   {
     name: "Ring",
     desc: "listening only",
-    swatch: "bg-transparent ring-1 ring-[var(--ring)]",
+    swatch:
+      "size-3 rounded-full border border-[var(--ring)]/60 bg-transparent ring-1 ring-fd-border ring-inset",
   },
 ] as const;
 
@@ -69,9 +72,7 @@ export function VoiceOrbAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <span className={item.swatch} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/voice-orb-states.tsx
+++ b/apps/docs/src/components/learn/voice-orb-states.tsx
@@ -49,19 +49,46 @@ const CSS = `
 .vos-static .vos-core-swell { animation: none; }
 `;
 
-const LEGEND = [
-  { name: "Idle", desc: "amp → 0 · breathe only", swatch: "bg-[var(--muted)]" },
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "idle" | "listening" | "speaking";
+}[] = [
+  {
+    name: "Idle",
+    desc: "amp → 0 · breathe only",
+    kind: "idle",
+  },
   {
     name: "Listening",
     desc: "ring duration ∝ amp",
-    swatch: "bg-[var(--foreground)]/20",
+    kind: "listening",
   },
   {
     name: "Speaking",
     desc: "core + corona swell",
-    swatch: "bg-[var(--card)]",
+    kind: "speaking",
   },
-] as const;
+];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "listening") {
+    return (
+      <span className="size-3 rounded-full border border-[var(--ring)] ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  if (kind === "speaking") {
+    return (
+      <span className="relative flex size-3 items-center justify-center">
+        <span className="absolute inset-0 scale-125 rounded-full bg-[var(--foreground)]/10 blur-[2px]" />
+        <span className="relative size-3 rounded-full border border-border bg-[var(--card)] shadow-sm" />
+      </span>
+    );
+  }
+  return (
+    <span className="size-3 rounded-full border border-border bg-[var(--card)] ring-1 ring-fd-border ring-inset" />
+  );
+}
 
 export function VoiceOrbStates() {
   return (
@@ -95,9 +122,7 @@ export function VoiceOrbStates() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span
-                  className={`h-1.5 w-8 rounded-full ${item.swatch} ring-1 ring-fd-border ring-inset`}
-                />
+                <LegendSwatch kind={item.kind} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/warp-starfield-anatomy.tsx
+++ b/apps/docs/src/components/learn/warp-starfield-anatomy.tsx
@@ -83,7 +83,7 @@ export function WarpStarfieldAnatomy() {
 
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span className="size-2 rounded-full bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Project
               </dt>
@@ -92,7 +92,7 @@ export function WarpStarfieldAnatomy() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span className="size-1.5 rounded-full bg-[var(--foreground)]/35 ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Recycle
               </dt>
@@ -101,7 +101,7 @@ export function WarpStarfieldAnatomy() {
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
+              <span className="size-3 rounded-full border border-[var(--foreground)]/10 bg-transparent ring-1 ring-fd-border ring-inset" />
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Budget
               </dt>

--- a/apps/docs/src/components/learn/warp-starfield-parallax.tsx
+++ b/apps/docs/src/components/learn/warp-starfield-parallax.tsx
@@ -36,6 +36,34 @@ const DOTS = Array.from({ length: 20 }, (_, i) => ({
   top: 14 + ((i * 53) % 72),
 }));
 
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "lerp" | "center";
+}[] = [
+  {
+    name: "Lerp",
+    desc: "pointer.x += (tx − x) × 0.06",
+    kind: "lerp",
+  },
+  {
+    name: "Center",
+    desc: "cx = w/2 + x × parallax",
+    kind: "center",
+  },
+];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "center") {
+    return (
+      <span className="size-3 rounded-full border-2 border-[var(--foreground)]/45 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="size-1.5 rounded-full bg-[var(--foreground)]/55 ring-1 ring-fd-border ring-inset" />
+  );
+}
+
 export function WarpStarfieldParallax() {
   return (
     <ScrollScene label="Parallax" note="lerp 0.06 · parallax=30">
@@ -76,24 +104,17 @@ export function WarpStarfieldParallax() {
           </p>
 
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Lerp
-              </dt>
-              <dd className="font-mono text-[12px] text-fd-muted-foreground">
-                {"pointer.x += (tx − x) × 0.06"}
-              </dd>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Center
-              </dt>
-              <dd className="font-mono text-[12px] text-fd-muted-foreground">
-                {"cx = w/2 + x × parallax"}
-              </dd>
-            </div>
+            {LEGEND.map((item) => (
+              <div key={item.name} className="flex flex-col gap-1.5">
+                <LegendSwatch kind={item.kind} />
+                <dt className="font-medium text-[13px] text-fd-foreground">
+                  {item.name}
+                </dt>
+                <dd className="font-mono text-[12px] text-fd-muted-foreground">
+                  {item.desc}
+                </dd>
+              </div>
+            ))}
           </dl>
         </div>
       )}

--- a/apps/docs/src/components/learn/warp-starfield-warp.tsx
+++ b/apps/docs/src/components/learn/warp-starfield-warp.tsx
@@ -33,6 +33,37 @@ const CSS = `
 .wsw-static .wsw-d { animation: none; opacity: 0.8; transform: none; }
 `;
 
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "cruise" | "hyperspace";
+}[] = [
+  {
+    name: "Cruise",
+    desc: "arc + fill · warp=false",
+    kind: "cruise",
+  },
+  {
+    name: "Hyperspace",
+    desc: "stroke previous → current projection",
+    kind: "hyperspace",
+  },
+];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "hyperspace") {
+    return (
+      <span
+        className="block h-px w-7 origin-left bg-[var(--foreground)]/70"
+        style={{ transform: "rotate(-24deg)" }}
+      />
+    );
+  }
+  return (
+    <span className="size-1.5 rounded-full bg-[var(--foreground)] ring-1 ring-fd-border ring-inset" />
+  );
+}
+
 export function WarpStarfieldWarp() {
   return (
     <ScrollScene label="Warp" note="points · or prev→curr strokes">
@@ -99,24 +130,17 @@ export function WarpStarfieldWarp() {
           </p>
 
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Cruise
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                arc + fill · warp=false
-              </dd>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Hyperspace
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                stroke previous → current projection
-              </dd>
-            </div>
+            {LEGEND.map((item) => (
+              <div key={item.name} className="flex flex-col gap-1.5">
+                <LegendSwatch kind={item.kind} />
+                <dt className="font-medium text-[13px] text-fd-foreground">
+                  {item.name}
+                </dt>
+                <dd className="text-[12px] text-fd-muted-foreground">
+                  {item.desc}
+                </dd>
+              </div>
+            ))}
           </dl>
         </div>
       )}

--- a/apps/docs/src/components/learn/world-map-anatomy.tsx
+++ b/apps/docs/src/components/learn/world-map-anatomy.tsx
@@ -28,17 +28,20 @@ const LEGEND: { name: string; desc: string; swatch: string }[] = [
   {
     name: "Dots",
     desc: "static SVG grid, drawn once with currentColor",
-    swatch: "bg-[var(--muted-foreground)]/40",
+    swatch:
+      "size-2 rounded-full bg-[var(--muted-foreground)]/40 ring-1 ring-fd-border ring-inset",
   },
   {
     name: "Pin",
     desc: "one per arc endpoint, deduped by coordinate",
-    swatch: "bg-[var(--foreground)]/60",
+    swatch:
+      "size-3 rounded-full bg-[var(--foreground)] ring-1 ring-fd-border ring-inset",
   },
   {
     name: "Arc",
     desc: "quadratic Bézier bow between two pins",
-    swatch: "bg-[var(--primary)]",
+    swatch:
+      "h-0.5 w-8 rounded-full bg-[var(--primary)] ring-1 ring-fd-border ring-inset",
   },
 ];
 
@@ -109,7 +112,7 @@ export function WorldMapAnatomy() {
           <dl className="grid w-full grid-cols-3 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (
               <div key={item.name} className="flex flex-col gap-1.5">
-                <span className={`h-1.5 w-8 rounded-full ${item.swatch}`} />
+                <span className={item.swatch} />
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>

--- a/apps/docs/src/components/learn/world-map-draw.tsx
+++ b/apps/docs/src/components/learn/world-map-draw.tsx
@@ -30,6 +30,37 @@ const CSS = `
 .wmd-static .wmd-seg { opacity: 1; animation: none; }
 `;
 
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "track" | "reveal";
+}[] = [
+  {
+    name: "Track",
+    desc: "the full arc, always faintly visible",
+    kind: "track",
+  },
+  {
+    name: "Reveal",
+    desc: "travels start pin → end pin, then loops",
+    kind: "reveal",
+  },
+];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "reveal") {
+    return (
+      <span className="relative flex items-center gap-1">
+        <span className="size-1.5 rounded-full bg-[var(--foreground)]" />
+        <span className="h-[2.5px] w-5 rounded-full bg-[var(--primary)]" />
+      </span>
+    );
+  }
+  return (
+    <span className="h-[2px] w-8 rounded-full bg-[var(--muted-foreground)]/25 ring-1 ring-fd-border ring-inset" />
+  );
+}
+
 export function WorldMapDraw() {
   return (
     <ScrollScene label="The draw-in" note="pathLength 0→1, staggered per arc">
@@ -81,24 +112,17 @@ export function WorldMapDraw() {
           </p>
 
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--muted-foreground)]/25 ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Track
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                the full arc, always faintly visible
-              </dd>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--primary)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Reveal
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                travels start pin → end pin, then loops
-              </dd>
-            </div>
+            {LEGEND.map((item) => (
+              <div key={item.name} className="flex flex-col gap-1.5">
+                <LegendSwatch kind={item.kind} />
+                <dt className="font-medium text-[13px] text-fd-foreground">
+                  {item.name}
+                </dt>
+                <dd className="text-[12px] text-fd-muted-foreground">
+                  {item.desc}
+                </dd>
+              </div>
+            ))}
           </dl>
         </div>
       )}

--- a/apps/docs/src/components/learn/world-map-pulse.tsx
+++ b/apps/docs/src/components/learn/world-map-pulse.tsx
@@ -18,6 +18,34 @@ const CSS = `
 .wmp-static .wmp-ripple { animation: none; opacity: 0; }
 `;
 
+const LEGEND: {
+  name: string;
+  desc: string;
+  kind: "pin" | "ripple";
+}[] = [
+  {
+    name: "Pin",
+    desc: "the static core circle, never animates",
+    kind: "pin",
+  },
+  {
+    name: "Ripple",
+    desc: "a second circle, scale + fade, infinite",
+    kind: "ripple",
+  },
+];
+
+function LegendSwatch({ kind }: { kind: (typeof LEGEND)[number]["kind"] }) {
+  if (kind === "ripple") {
+    return (
+      <span className="size-3 rounded-full bg-[var(--primary)]/40 ring-1 ring-fd-border ring-inset" />
+    );
+  }
+  return (
+    <span className="size-3 rounded-full bg-[var(--primary)] ring-1 ring-fd-border ring-inset" />
+  );
+}
+
 export function WorldMapPulse() {
   return (
     <ScrollScene label="The pulse" note="scale 1→3 · opacity .6→0, looping">
@@ -52,24 +80,17 @@ export function WorldMapPulse() {
           </div>
 
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--primary)] ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Pin
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                the static core circle, never animates
-              </dd>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <span className="h-1.5 w-8 rounded-full bg-[var(--primary)]/40 ring-1 ring-fd-border ring-inset" />
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                Ripple
-              </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                a second circle, scale + fade, infinite
-              </dd>
-            </div>
+            {LEGEND.map((item) => (
+              <div key={item.name} className="flex flex-col gap-1.5">
+                <LegendSwatch kind={item.kind} />
+                <dt className="font-medium text-[13px] text-fd-foreground">
+                  {item.name}
+                </dt>
+                <dd className="text-[12px] text-fd-muted-foreground">
+                  {item.desc}
+                </dd>
+              </div>
+            ))}
           </dl>
         </div>
       )}


### PR DESCRIPTION
## Description

Design polish across two Learn deep-dive scenes and two component shadows. The Orbit Carousel "anatomy" and "orbit" scenes had legend rows that didn't line up with the cards they described and swatches that referenced abstract opacity ramps not present in the diagram; this reworks both so each legend label sits directly under its plate and each swatch mirrors a concrete diagram piece (pointer · active plate · flick ghost). Also dims the docs Border Beam and softens Mega Menu panel/drawer shadows from `shadow-2xl` to `shadow-lg`.

## Type of change

- [x] 🎨 Style / design polish
- [x] 📝 Docs

## Changes made

- **orbit-carousel-anatomy**: legend columns now mirror the five card slots left→right (positioned by the same x offsets as the cards, not a `grid-cols-3` that drifts off the arc); widened radius/angle so gaps clear the labels; swatch opacity tracks each slot.
- **orbit-carousel-orbit**: added a flick-overshoot "ghost" plate + `occ-ghost` keyframes; legend swatches now match concrete pieces (pointer dot, filled active plate, dashed ghost) instead of opacity ramps; unified animation duration via `DUR`.
- **border-beam** (docs): beam color `text-fd-primary/35` → `text-fd-foreground/20`.
- **mega-menu**: panel + mobile drawer shadow `shadow-2xl` → `shadow-lg`.
- Rebuilt registry (`mega-menu.json`, `index.json`).

## How to test

1. `pnpm dev` in `apps/docs`.
2. Open the Orbit Carousel docs page → Learn tab; scroll to the anatomy and orbit scenes and confirm each legend label sits under its card and swatches match the diagram.
3. Check the Mega Menu component page — panel/drawer shadow is softer.

## Screenshots / recordings

_Visual change — before/after of the Orbit Carousel Learn scenes recommended._

## Checklist

- [x] `pnpm check` passes (Biome — warnings only, all pre-existing `<img>` hints)
- [x] Commits follow Conventional Commits
- [x] Self-reviewed the diff; no stray logs or dead code

### Component / registry PRs only

- [x] Ran `pnpm build:registry`
- [x] Animations use `transform`/`opacity`/`filter` only (no layout/paint props)
