### PR TITLE
fix(docs): keep Learn scene label chip on one line

### DIFF
--- a/apps/docs/src/components/learn/scroll-scene.tsx
+++ b/apps/docs/src/components/learn/scroll-scene.tsx
@@ -98,11 +98,11 @@ export function ScrollScene({
     >
       <BorderBeam play={plays} />
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
-        <span className="inline-flex h-8 items-center rounded-[10px] border border-fd-border bg-[var(--muted)] px-3 font-medium text-[13px] text-[var(--foreground)]">
+        <span className="inline-flex h-8 shrink-0 items-center whitespace-nowrap rounded-[10px] border border-fd-border bg-[var(--muted)] px-3 font-medium text-[13px] text-[var(--foreground)]">
           {label}
         </span>
         {note ? (
-          <span className="font-mono text-fd-muted-foreground text-xs">
+          <span className="min-w-0 text-pretty font-mono text-fd-muted-foreground text-xs leading-snug">
             {note}
           </span>
         ) : null}


### PR DESCRIPTION
## Description

Learn scene header label chips (`ScrollScene`) could wrap to two lines when the note text squeezed them, breaking the fixed-height pill (e.g. "The sheen" splitting across two rows). This keeps the chip on a single line and lets the note wrap cleanly beside it. Affects all Learn scenes since they share `ScrollScene`.

## Type of change

- [x] 🐛 Bug fix (non-breaking change fixing an issue)
- [x] 🎨 Style / design polish

## Changes made

- Label chip: add `shrink-0` + `whitespace-nowrap` so it never wraps and the pill stays intact.
- Note: add `min-w-0`, `text-pretty`, `leading-snug` so it wraps cleanly next to the chip instead of forcing the chip to break; no text hidden.

## How to test

1. `pnpm dev` in `apps/docs`.
2. Open a component Learn tab with a long label + note (e.g. Store Badge sheen) at a narrow width.
3. Confirm the label chip stays on one line and the note wraps below without breaking the pill.

## Checklist

- [x] Self-reviewed the diff; no stray logs, dead code, or commented-out blocks
- [x] Commits follow Conventional Commits
