### PR TITLE
fix(components): fix goo metaball merge on Safari

### DIFF
--- a/apps/docs/src/components/learn/gooey-filter.tsx
+++ b/apps/docs/src/components/learn/gooey-filter.tsx
@@ -37,27 +37,6 @@ export function GooeyFilter() {
           {/* biome-ignore lint/security/noDangerouslySetInnerHtml: static keyframes, no user input */}
           <style dangerouslySetInnerHTML={{ __html: CSS }} />
 
-          <svg
-            aria-hidden="true"
-            className="pointer-events-none absolute size-0"
-          >
-            <defs>
-              <filter id={FILTER_ID}>
-                <feGaussianBlur
-                  in="SourceGraphic"
-                  stdDeviation="6"
-                  result="blur"
-                />
-                <feColorMatrix
-                  in="blur"
-                  mode="matrix"
-                  values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 20 -10"
-                  result="goo"
-                />
-              </filter>
-            </defs>
-          </svg>
-
           <div className="grid w-full grid-cols-2 gap-6">
             <div className="flex flex-col items-center gap-3">
               <div className="relative flex h-[120px] w-full items-center justify-center">
@@ -70,12 +49,67 @@ export function GooeyFilter() {
             </div>
 
             <div className="flex flex-col items-center gap-3">
-              <div
-                className="relative flex h-[120px] w-full items-center justify-center"
-                style={{ filter: `url(#${FILTER_ID})` }}
-              >
-                <div className="gf-a absolute size-14 rounded-full bg-black/55" />
-                <div className="gf-b absolute size-14 rounded-full bg-black/55" />
+              {/* Native SVG (circles inside the filtered <g>) — Safari composites
+                  a transform-animated HTML child onto its own layer, escaping an
+                  HTML `filter: url()`, so the metaballs never merge there. SVG
+                  shapes stay inside the filter and fuse on every engine. */}
+              <div className="relative flex h-[120px] w-full items-center justify-center">
+                <svg
+                  aria-hidden="true"
+                  className="pointer-events-none overflow-visible"
+                  width={120}
+                  height={120}
+                  viewBox="-60 -60 120 120"
+                >
+                  <defs>
+                    <filter
+                      id={FILTER_ID}
+                      x="-50%"
+                      y="-50%"
+                      width="200%"
+                      height="200%"
+                      colorInterpolationFilters="sRGB"
+                    >
+                      <feGaussianBlur
+                        in="SourceGraphic"
+                        stdDeviation="6"
+                        result="blur"
+                      />
+                      <feColorMatrix
+                        in="blur"
+                        mode="matrix"
+                        values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 20 -10"
+                        result="goo"
+                      />
+                    </filter>
+                  </defs>
+                  <g
+                    filter={`url(#${FILTER_ID})`}
+                    fill="#000"
+                    fillOpacity={0.55}
+                  >
+                    <circle
+                      className="gf-a"
+                      cx={0}
+                      cy={0}
+                      r={28}
+                      style={{
+                        transformBox: "fill-box",
+                        transformOrigin: "center",
+                      }}
+                    />
+                    <circle
+                      className="gf-b"
+                      cx={0}
+                      cy={0}
+                      r={28}
+                      style={{
+                        transformBox: "fill-box",
+                        transformOrigin: "center",
+                      }}
+                    />
+                  </g>
+                </svg>
               </div>
               <p className="font-mono text-[11px] text-fd-muted-foreground">
                 after goo filter

--- a/apps/docs/src/components/learn/gooey-stack-filter.tsx
+++ b/apps/docs/src/components/learn/gooey-stack-filter.tsx
@@ -65,11 +65,52 @@ const STEPS: { cls: string; name: string; desc: string }[] = [
 ];
 
 function Pair({ filtered }: { filtered?: boolean }) {
+  // Filtered pair is native SVG (rects inside the filtered <g>): Safari
+  // composites a transform-animated HTML child onto its own layer, which
+  // escapes an HTML `filter: url()`, so the silhouettes never neck together
+  // there. SVG shapes stay inside the filter and fuse on every engine.
+  if (filtered) {
+    return (
+      <svg
+        aria-hidden="true"
+        className="pointer-events-none mx-auto overflow-visible"
+        width={96}
+        height={128}
+        viewBox="0 0 96 128"
+      >
+        <defs>
+          <filter
+            id={FILTER_ID}
+            x="-50%"
+            y="-50%"
+            width="200%"
+            height="200%"
+            colorInterpolationFilters="sRGB"
+          >
+            <feGaussianBlur
+              in="SourceGraphic"
+              stdDeviation="10"
+              result="blur"
+            />
+            <feColorMatrix
+              in="blur"
+              mode="matrix"
+              values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 80 -40"
+              result="goo"
+            />
+          </filter>
+        </defs>
+        <g filter={`url(#${FILTER_ID})`} fill="#000" fillOpacity={0.55}>
+          {/* Anchor — fixed at the bottom. */}
+          <rect x={0} y={80} width={96} height={48} rx={14} />
+          {/* Upper card — starts apart, crawls down into the anchor. */}
+          <rect className="gsf-a" x={0} y={0} width={96} height={48} rx={14} />
+        </g>
+      </svg>
+    );
+  }
   return (
-    <div
-      className="relative mx-auto h-[128px] w-24"
-      style={filtered ? { filter: `url(#${FILTER_ID})` } : undefined}
-    >
+    <div className="relative mx-auto h-[128px] w-24">
       {/* Anchor — fixed at the bottom. */}
       <div className="absolute inset-x-0 bottom-0 h-12 rounded-[14px] bg-black/55" />
       {/* Upper card — starts apart, crawls down into the anchor. */}
@@ -90,27 +131,6 @@ export function GooeyStackFilter() {
         >
           {/* biome-ignore lint/security/noDangerouslySetInnerHtml: static keyframes, no user input */}
           <style dangerouslySetInnerHTML={{ __html: CSS }} />
-
-          <svg
-            aria-hidden="true"
-            className="pointer-events-none absolute size-0"
-          >
-            <defs>
-              <filter id={FILTER_ID}>
-                <feGaussianBlur
-                  in="SourceGraphic"
-                  stdDeviation="10"
-                  result="blur"
-                />
-                <feColorMatrix
-                  in="blur"
-                  mode="matrix"
-                  values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 80 -40"
-                  result="goo"
-                />
-              </filter>
-            </defs>
-          </svg>
 
           <div className="grid w-full grid-cols-2 gap-6">
             <div className="flex flex-col items-center gap-3">

--- a/apps/docs/src/components/learn/gooey-stack-nearness.tsx
+++ b/apps/docs/src/components/learn/gooey-stack-nearness.tsx
@@ -97,41 +97,58 @@ export function GooeyStackNearness() {
           {/* biome-ignore lint/security/noDangerouslySetInnerHtml: static keyframes, no user input */}
           <style dangerouslySetInnerHTML={{ __html: CSS }} />
 
-          <svg
-            aria-hidden="true"
-            className="pointer-events-none absolute size-0"
-          >
-            <defs>
-              <filter id={FILTER_ID}>
-                <feGaussianBlur
-                  in="SourceGraphic"
-                  stdDeviation="10"
-                  result="blur"
-                />
-                <feColorMatrix
-                  in="blur"
-                  mode="matrix"
-                  values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 80 -40"
-                  result="goo"
-                />
-              </filter>
-            </defs>
-          </svg>
-
           <div
             key={cycle}
             className={`relative h-[132px] w-[132px] ${reduced ? "gsn-static" : ""}`}
           >
-            {/* Goo layer — real filter, opacity gated by nearness band-pass. */}
-            <div
-              className="gsn-goo absolute inset-0"
-              style={{ filter: `url(#${FILTER_ID})` }}
+            {/* Goo layer — native SVG (rects inside the filtered <g>), opacity
+                gated by the nearness band-pass. SVG rather than filtered HTML
+                because Safari composites a transform-animated HTML child onto
+                its own layer, escaping an HTML `filter: url()` so the
+                silhouettes never neck; SVG shapes stay inside the filter. */}
+            <svg
+              aria-hidden="true"
+              className="gsn-goo pointer-events-none absolute inset-0 overflow-visible"
+              viewBox="0 0 132 132"
             >
-              <div className="absolute inset-x-0 bottom-0 h-12 rounded-[14px] bg-[var(--foreground)]/55" />
-              <div className="gsn-upper absolute inset-x-0 top-0">
-                <div className="h-12 rounded-[14px] bg-[var(--foreground)]/55" />
-              </div>
-            </div>
+              <defs>
+                <filter
+                  id={FILTER_ID}
+                  x="-50%"
+                  y="-50%"
+                  width="200%"
+                  height="200%"
+                  colorInterpolationFilters="sRGB"
+                >
+                  <feGaussianBlur
+                    in="SourceGraphic"
+                    stdDeviation="10"
+                    result="blur"
+                  />
+                  <feColorMatrix
+                    in="blur"
+                    mode="matrix"
+                    values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 80 -40"
+                    result="goo"
+                  />
+                </filter>
+              </defs>
+              <g
+                filter={`url(#${FILTER_ID})`}
+                fill="var(--foreground)"
+                fillOpacity={0.55}
+              >
+                <rect x={0} y={84} width={132} height={48} rx={14} />
+                <rect
+                  className="gsn-upper"
+                  x={0}
+                  y={0}
+                  width={132}
+                  height={48}
+                  rx={14}
+                />
+              </g>
+            </svg>
             {/* Native crisp cards — opposite opacity curve. */}
             <div className="gsn-native absolute inset-x-0 bottom-0 h-12 rounded-[14px] border border-[var(--foreground)]/50 bg-[var(--card)]" />
             <div className="gsn-upper absolute inset-x-0 top-0">

--- a/apps/docs/src/components/learn/liquid-metaballs-cursor.tsx
+++ b/apps/docs/src/components/learn/liquid-metaballs-cursor.tsx
@@ -52,13 +52,18 @@ export function LiquidMetaballsCursor() {
         >
           {/* biome-ignore lint/security/noDangerouslySetInnerHtml: static keyframes, no user input */}
           <style dangerouslySetInnerHTML={{ __html: CSS }} />
+          {/* Goo filter lives on the blob <g> inside an SVG overlay, not on the
+              card element: Safari composites the transform-animated HTML blob
+              onto its own layer, which escapes an HTML `filter: url()` so the
+              discs never merge there. SVG shapes stay inside the filter and
+              fuse on every engine (and the card's border/bg stay crisp). */}
           <div
             className="lmc-el relative flex h-36 w-full items-center justify-center overflow-hidden rounded-2xl border border-fd-border bg-[var(--card)]"
-            style={{ "--d": "0ms", filter: "url(#lmg-goo2)" } as CSSProperties}
+            style={{ "--d": "0ms" } as CSSProperties}
           >
             <svg
               aria-hidden="true"
-              className="pointer-events-none absolute size-0"
+              className="pointer-events-none absolute inset-0 h-full w-full"
             >
               <defs>
                 <filter id="lmg-goo2">
@@ -74,9 +79,21 @@ export function LiquidMetaballsCursor() {
                   />
                 </filter>
               </defs>
+              <g filter="url(#lmg-goo2)" fill="var(--foreground)">
+                <circle cx="50%" cy="50%" r={28} fillOpacity={0.7} />
+                <circle
+                  className="lmc-c"
+                  cx="50%"
+                  cy="50%"
+                  r={24}
+                  fillOpacity={0.65}
+                  style={{
+                    transformBox: "fill-box",
+                    transformOrigin: "center",
+                  }}
+                />
+              </g>
             </svg>
-            <div className="absolute size-14 rounded-full bg-[var(--foreground)]/70" />
-            <div className="lmc-c absolute size-12 rounded-full bg-[var(--foreground)]/65" />
           </div>
           <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
             {LEGEND.map((item) => (

--- a/apps/docs/src/components/learn/liquid-metaballs-goo.tsx
+++ b/apps/docs/src/components/learn/liquid-metaballs-goo.tsx
@@ -66,26 +66,6 @@ export function LiquidMetaballsGoo() {
         >
           {/* biome-ignore lint/security/noDangerouslySetInnerHtml: static keyframes, no user input */}
           <style dangerouslySetInnerHTML={{ __html: CSS }} />
-          <svg
-            aria-hidden="true"
-            className="pointer-events-none absolute size-0"
-          >
-            <defs>
-              <filter id="lmg-goo">
-                <feGaussianBlur
-                  in="SourceGraphic"
-                  stdDeviation="8"
-                  result="blur"
-                />
-                <feColorMatrix
-                  in="blur"
-                  mode="matrix"
-                  values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 20 -9"
-                  result="goo"
-                />
-              </filter>
-            </defs>
-          </svg>
           <div className="grid w-full grid-cols-2 gap-5">
             <div
               className="lmg-el flex flex-col items-center gap-2"
@@ -103,12 +83,59 @@ export function LiquidMetaballsGoo() {
               className="lmg-el flex flex-col items-center gap-2"
               style={{ "--d": "100ms" } as CSSProperties}
             >
-              <div
-                className="relative flex h-28 w-full items-center justify-center"
-                style={{ filter: "url(#lmg-goo)" }}
-              >
-                <div className="lmg-a absolute size-12 rounded-full bg-[var(--foreground)]/75" />
-                <div className="lmg-b absolute size-12 rounded-full bg-[var(--foreground)]/75" />
+              {/* Native SVG (circles in the filtered <g>): Safari composites a
+                  transform-animated HTML child onto its own layer, escaping an
+                  HTML `filter: url()` so the metaballs never merge there. */}
+              <div className="relative flex h-28 w-full items-center justify-center">
+                <svg
+                  aria-hidden="true"
+                  className="pointer-events-none overflow-visible"
+                  width={120}
+                  height={112}
+                  viewBox="-60 -56 120 112"
+                >
+                  <defs>
+                    <filter id="lmg-goo">
+                      <feGaussianBlur
+                        in="SourceGraphic"
+                        stdDeviation="8"
+                        result="blur"
+                      />
+                      <feColorMatrix
+                        in="blur"
+                        mode="matrix"
+                        values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 20 -9"
+                        result="goo"
+                      />
+                    </filter>
+                  </defs>
+                  <g
+                    filter="url(#lmg-goo)"
+                    fill="var(--foreground)"
+                    fillOpacity={0.75}
+                  >
+                    <circle
+                      className="lmg-a"
+                      cx={0}
+                      cy={0}
+                      r={24}
+                      style={{
+                        transformBox: "fill-box",
+                        transformOrigin: "center",
+                      }}
+                    />
+                    <circle
+                      className="lmg-b"
+                      cx={0}
+                      cy={0}
+                      r={24}
+                      style={{
+                        transformBox: "fill-box",
+                        transformOrigin: "center",
+                      }}
+                    />
+                  </g>
+                </svg>
               </div>
               <span className="font-mono text-[11px] text-fd-muted-foreground">
                 gooeyness=16

--- a/packages/components/src/gooey-fab/gooey-fab.tsx
+++ b/packages/components/src/gooey-fab/gooey-fab.tsx
@@ -106,10 +106,29 @@ const GooeyFab = React.forwardRef<HTMLDivElement, GooeyFabProps>(
         style={{ width: trigger, height: trigger }}
         {...props}
       >
-        {/* Goo filter — fuses overlapping blobs into liquid metaballs. */}
-        <svg aria-hidden="true" className="pointer-events-none absolute size-0">
+        {/* Blob layer — solid circles fused by the goo filter. Rendered as
+            native SVG (circles inside the filtered <g>) rather than filtered
+            HTML: Safari promotes a transform-animated HTML child to its own
+            compositing layer, which escapes an HTML `filter: url()` and breaks
+            the merge. SVG shapes stay inside the filter, so it fuses on every
+            engine. Origin is the container center; satellites overflow it. */}
+        <svg
+          aria-hidden="true"
+          className="pointer-events-none absolute left-0 top-0"
+          style={{ overflow: "visible" }}
+          width={trigger}
+          height={trigger}
+          viewBox={`${-trigger / 2} ${-trigger / 2} ${trigger} ${trigger}`}
+        >
           <defs>
-            <filter id={filterId}>
+            <filter
+              id={filterId}
+              x="-400%"
+              y="-400%"
+              width="900%"
+              height="900%"
+              colorInterpolationFilters="sRGB"
+            >
               <feGaussianBlur
                 in="SourceGraphic"
                 stdDeviation="6"
@@ -119,50 +138,48 @@ const GooeyFab = React.forwardRef<HTMLDivElement, GooeyFabProps>(
                 in="blur"
                 mode="matrix"
                 values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 20 -10"
-                result="goo"
               />
             </filter>
           </defs>
+          <g
+            className="fill-primary"
+            filter={reduce ? undefined : `url(#${filterId})`}
+          >
+            <circle cx={0} cy={0} r={trigger / 2} />
+            {actions.map((action, i) => {
+              const target = offsetFor(direction, step * (i + 1));
+              return (
+                <motion.circle
+                  key={action.label}
+                  cx={0}
+                  cy={0}
+                  r={sat / 2}
+                  style={{
+                    transformBox: "fill-box",
+                    transformOrigin: "center",
+                  }}
+                  initial={false}
+                  animate={
+                    open
+                      ? { x: target.x, y: target.y, scale: 1, opacity: 1 }
+                      : { x: 0, y: 0, scale: 0.2, opacity: 0 }
+                  }
+                  transition={
+                    reduce
+                      ? { duration: 0.15 }
+                      : {
+                          type: "spring",
+                          stiffness: 170,
+                          damping: 12,
+                          mass: 0.1,
+                          delay: open ? i * 0.04 : (actions.length - i) * 0.02,
+                        }
+                  }
+                />
+              );
+            })}
+          </g>
         </svg>
-
-        {/* Blob layer: solid circles that merge under the goo filter. */}
-        <div
-          aria-hidden="true"
-          className="pointer-events-none absolute inset-0 grid place-items-center"
-          style={reduce ? undefined : { filter: `url(#${filterId})` }}
-        >
-          <div
-            className="rounded-full bg-primary"
-            style={{ width: trigger, height: trigger }}
-          />
-          {actions.map((action, i) => {
-            const target = offsetFor(direction, step * (i + 1));
-            return (
-              <motion.div
-                key={action.label}
-                className="absolute rounded-full bg-primary"
-                style={{ width: sat, height: sat }}
-                initial={false}
-                animate={
-                  open
-                    ? { x: target.x, y: target.y, scale: 1, opacity: 1 }
-                    : { x: 0, y: 0, scale: 0.2, opacity: 0 }
-                }
-                transition={
-                  reduce
-                    ? { duration: 0.15 }
-                    : {
-                        type: "spring",
-                        stiffness: 170,
-                        damping: 12,
-                        mass: 0.1,
-                        delay: open ? i * 0.04 : (actions.length - i) * 0.02,
-                      }
-                }
-              />
-            );
-          })}
-        </div>
 
         {/* Control layer: sharp, clickable icon buttons over the blobs. */}
         <div className="absolute inset-0 grid place-items-center">

--- a/packages/components/src/gooey-stack/gooey-stack.tsx
+++ b/packages/components/src/gooey-stack/gooey-stack.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import {
-  motion,
-  useMotionValue,
-  useReducedMotion,
-  useSpring,
-  useTransform,
-} from "framer-motion";
+import { motion, useReducedMotion } from "framer-motion";
 import * as React from "react";
 
 export type GooeyStackProps = Omit<
@@ -38,26 +32,18 @@ export type GooeyStackProps = Omit<
   radius?: number;
 };
 
-// SPRING.smooth — surfaces / morph (see motion/tokens.ts).
+// SPRING.liquid — slow, no-overshoot morph so the goo neck stays readable as
+// it forms and releases (a snappier spring blows through the merge too fast to
+// see). See motion/tokens.ts.
 const SPRING = {
   type: "spring",
-  stiffness: 320,
-  damping: 32,
-  mass: 0.9,
+  stiffness: 130,
+  damping: 24,
+  mass: 1.2,
 } as const;
 
 const clamp = (v: number, lo: number, hi: number) =>
   Math.min(hi, Math.max(lo, v));
-
-// How much the cards are *necking* at a given gap: a band-pass that is 0 at both
-// rest ends (fanned out, or fully merged) and peaks while surfaces are close.
-const nearnessAt = (
-  g: number,
-  expandedGap: number,
-  collapsedGap: number,
-): number =>
-  clamp((expandedGap - g) / Math.max(1, expandedGap - 4), 0, 1) *
-  clamp((g - collapsedGap) / 20, 0, 1);
 
 const GooeyStack = React.forwardRef<HTMLDivElement, GooeyStackProps>(
   (
@@ -122,25 +108,15 @@ const GooeyStack = React.forwardRef<HTMLDivElement, GooeyStackProps>(
     // silhouettes neck together via the goo filter.
     const merge = clamp(-g / -Math.min(collapsedGap, -1), 0, 1);
 
-    // Cross-fade the crisp native surface (rest → pixel-perfect borders) with the
-    // soft goo-fused surface (mid-transition → the liquid neck). This MUST follow
-    // the *live* animating gap, not the target `g` — at both endpoints necking is
-    // 0, so deriving it from `g` alone would make the goo never appear during the
-    // toggle. Spring a motion value toward `g` and read necking off it live.
-    const gapTarget = useMotionValue(g);
-    React.useEffect(() => {
-      gapTarget.set(g);
-    }, [g, gapTarget]);
-    const gapSpring = useSpring(gapTarget, {
-      stiffness: 320,
-      damping: 32,
-      mass: 0.9,
-    });
-    const nearness = useTransform(gapSpring, (live) =>
-      nearnessAt(live, expandedGap, collapsedGap),
-    );
-    const gooOpacity = useTransform(nearness, (v) => (reduce ? 0 : v));
-    const nativeOpacity = useTransform(nearness, (v) => (reduce ? 1 : 1 - v));
+    // The goo SVG surface is the SOLE visible card surface whenever motion is
+    // allowed: it renders every card's fill + border itself, always opaque, and
+    // fuses them into the liquid neck as they approach. There is deliberately no
+    // second (native) bordered surface underneath, because a goo filter dilates
+    // its output more on WebKit than on Blink — so any always-opaque native card
+    // beneath the goo would show a mismatched ghost/double border on Safari
+    // wherever the two edges failed to coincide. One border source = no double.
+    // The native `<div>` cards below are shown ONLY under prefers-reduced-motion
+    // (goo hidden), where there is no filter and they are the crisp fallback.
 
     // Target transform for card `i`. rank = distance from the anchor.
     const stateOf = (i: number) => {
@@ -180,44 +156,33 @@ const GooeyStack = React.forwardRef<HTMLDivElement, GooeyStackProps>(
         {/* Goo filter — fuses the card silhouettes into liquid metaballs. */}
         <svg aria-hidden="true" className="pointer-events-none absolute size-0">
           <defs>
-            <filter id={filterId}>
+            <filter
+              id={filterId}
+              x="-50%"
+              y="-50%"
+              width="200%"
+              height="200%"
+              colorInterpolationFilters="sRGB"
+            >
               <feGaussianBlur
                 in="SourceGraphic"
                 stdDeviation={gooeyness}
                 result="blur"
               />
-              {/* Hard-edged contour of the blur (razor-steep threshold), so the
-                  fused shape has a crisp edge with almost no anti-aliasing. */}
+              {/* Fused silhouette: razor-steep threshold at the α=0.5 level. That
+                  level set sits on the ORIGINAL edge for a straight run (so the
+                  card sides keep their native width) and only bulges where two
+                  cards' blur halos overlap — i.e. the concave liquid neck. One
+                  crisp shape, hard edge, almost no anti-aliasing. */}
               <feColorMatrix
                 in="blur"
                 mode="matrix"
                 values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 80 -40"
                 result="goo"
               />
-              {/* Border: offset the fused shape outward with a *small isotropic*
-                  blur + threshold. A Gaussian is radially symmetric, so the ring
-                  stays round and constant-width at corners and the neck — unlike
-                  box morphology (square corners) or a band off the main blur
-                  (width tracks curvature). */}
-              <feGaussianBlur in="goo" stdDeviation="1.2" result="edge" />
-              <feColorMatrix
-                in="edge"
-                mode="matrix"
-                values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 26 -9"
-                result="grown"
-              />
-              <feFlood
-                style={{ floodColor: "var(--border)" }}
-                result="borderColor"
-              />
-              <feComposite
-                in="borderColor"
-                in2="grown"
-                operator="in"
-                result="borderLayer"
-              />
-              {/* Fill: flat theme card color, masked by `goo` — uniform, opaque,
-                  never darkened by blur anti-aliasing. */}
+              {/* Fill the whole fused shape with the card color. On the straight
+                  sides this lands exactly on the native cards; across the gap it
+                  paints the connecting neck. */}
               <feFlood
                 style={{ floodColor: "var(--card)" }}
                 result="cardColor"
@@ -228,60 +193,46 @@ const GooeyStack = React.forwardRef<HTMLDivElement, GooeyStackProps>(
                 operator="in"
                 result="fillLayer"
               />
+              {/* One continuous outline tracing the ENTIRE fused silhouette —
+                  card sides AND the neck curves — as a single uniform stroke, so
+                  the border flows from card into neck with no seam. Built as an
+                  INNER 1px ring (goo minus a 1px-eroded goo) so it sits exactly
+                  where a CSS border-box border sits: coincident with the native
+                  side borders (no double line), continuous around the waist. */}
+              <feGaussianBlur in="goo" stdDeviation="1.1" result="edge" />
+              <feColorMatrix
+                in="edge"
+                mode="matrix"
+                values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 50 -41"
+                result="eroded"
+              />
+              <feComposite in="goo" in2="eroded" operator="out" result="ring" />
+              <feFlood
+                style={{ floodColor: "var(--border)" }}
+                result="borderColor"
+              />
+              <feComposite
+                in="borderColor"
+                in2="ring"
+                operator="in"
+                result="borderLayer"
+              />
               <feMerge result="surface">
-                <feMergeNode in="borderLayer" />
                 <feMergeNode in="fillLayer" />
+                <feMergeNode in="borderLayer" />
               </feMerge>
-              {/* Re-introduce sub-pixel anti-aliasing. The steep threshold above
-                  makes a crisp shape but with a hard, aliased (stair-stepped)
-                  edge; a tiny blur smooths the edge back to pixel-perfect without
-                  softening the shape. */}
-              <feGaussianBlur in="surface" stdDeviation="0.5" />
+              {/* Sub-pixel anti-aliasing back after the steep thresholds. */}
+              <feGaussianBlur in="surface" stdDeviation="0.4" />
             </filter>
           </defs>
         </svg>
 
-        {/* Merge surface (behind): full-size silhouettes fuse under the goo
-            filter into the liquid neck + border. Only faded in while the cards
-            are necking (`nearness`), so its soft filtered edge is never seen at
-            rest — the crisp native surface below covers it there. */}
-        <motion.div
-          aria-hidden="true"
-          className="pointer-events-none absolute inset-0"
-          style={{
-            opacity: gooOpacity,
-            filter: reduce ? undefined : `url(#${filterId})`,
-          }}
-        >
-          {items.map((_, i) => {
-            const s = stateOf(i);
-            return (
-              <motion.div
-                // biome-ignore lint/suspicious/noArrayIndexKey: index identifies a stable card slot
-                key={i}
-                className="absolute inset-x-0 bg-card"
-                style={{
-                  bottom: bottomOf(i),
-                  height: heights[i] || undefined,
-                  borderRadius: radius,
-                  zIndex: i,
-                }}
-                initial={false}
-                animate={{ y: s.y, scale: s.scale, opacity: s.silOpacity }}
-                transition={transition}
-              />
-            );
-          })}
-        </motion.div>
-
-        {/* Native surface: real DOM cards with CSS borders — pixel-perfect at
-            every zoom. Shown at rest; cross-faded out (`1 - nearness`) into the
-            goo surface above while cards neck, so borders stay crisp at rest and
-            fuse seamlessly during the merge. */}
-        <motion.div
-          className="absolute inset-0"
-          style={{ opacity: nativeOpacity }}
-        >
+        {/* Reduced-motion fallback surface: real DOM cards with crisp CSS
+            borders. Shown ONLY when motion is off (the goo surface is hidden
+            then), so it never coexists with the goo — no double border. When
+            motion is on it is fully transparent and the goo below carries every
+            card's fill + border as the single source. */}
+        <div className="absolute inset-0" style={{ opacity: reduce ? 1 : 0 }}>
           {items.map((_, i) => {
             const s = stateOf(i);
             return (
@@ -301,7 +252,58 @@ const GooeyStack = React.forwardRef<HTMLDivElement, GooeyStackProps>(
               />
             );
           })}
-        </motion.div>
+        </div>
+
+        {/* Card surface (the single source of every card's fill + border): the
+            full-size silhouettes fuse under the goo filter into card-color fill
+            + one continuous outline tracing the whole fused shape (card sides
+            AND the neck waist). Always fully opaque, so it is the ONLY bordered
+            surface on screen — nothing underneath to double against. At rest the
+            rects are separate → two crisp rounded cards; as the gap shrinks they
+            neck into one liquid shape.
+
+            Rendered as native SVG rects (not filtered HTML divs): Safari
+            composites a transform-animated HTML child onto its own compositing
+            layer, which escapes an HTML `filter: url()` so the cards never neck
+            together there. SVG shapes stay inside the filter and fuse on every
+            engine. Hidden entirely under prefers-reduced-motion (the native
+            fallback above shows instead). */}
+        <motion.svg
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 overflow-visible [transform:translateZ(0)]"
+          width="100%"
+          height="100%"
+          style={{ opacity: reduce ? 0 : 1 }}
+        >
+          <g filter={reduce ? undefined : `url(#${filterId})`}>
+            {items.map((_, i) => {
+              const s = stateOf(i);
+              // Rest-position top edge (SVG y is top-down); `y` below then
+              // slides it exactly like the native card's translateY. No `scale`
+              // here: it only bites once the silhouette has faded out, and
+              // `transform-box: fill-box` (needed to scale about center)
+              // flickers the filtered border in WebKit — so the goo surface
+              // translates only, keeping the border rock-steady on every engine.
+              const top =
+                (expandedTotal || 0) - bottomOf(i) - (heights[i] ?? 0);
+              return (
+                <motion.rect
+                  // biome-ignore lint/suspicious/noArrayIndexKey: index identifies a stable card slot
+                  key={i}
+                  x={0}
+                  y={top}
+                  width="100%"
+                  height={heights[i] || 0}
+                  rx={radius}
+                  fill="#000"
+                  initial={false}
+                  animate={{ y: s.y, opacity: s.silOpacity }}
+                  transition={transition}
+                />
+              );
+            })}
+          </g>
+        </motion.svg>
 
         {/* Content: children on top of whichever surface is showing. Stays crisp
             and readable — only recedes/frosts, never cross-faded by the neck. */}

--- a/packages/components/src/motion/tokens.ts
+++ b/packages/components/src/motion/tokens.ts
@@ -61,6 +61,9 @@ export const FLOW_SPEED = {
 export const SPRING = {
   /** Underdamped morph for surfaces — dialogs, shared-layout transitions. */
   smooth: { type: "spring", stiffness: 320, damping: 32, mass: 0.9 },
+  /** Slow, no-overshoot morph for liquid/metaball merges that need to stay
+   * readable as they form and release — gooey stack. */
+  liquid: { type: "spring", stiffness: 130, damping: 24, mass: 1.2 },
   /** Crisp height/collapse — accordion. */
   crisp: { type: "spring", stiffness: 500, damping: 40 },
   /** Snappy pop for menus and popovers — dropdown. */


### PR DESCRIPTION
## Description

Goo/metaball surfaces (blur + `feColorMatrix` alpha-punch) never fused on **Safari** — Chrome/Edge were fine. Safari composites a transform-animated child (framer-motion `will-change`) onto its own layer *outside* an HTML `filter: url()`, so the filter never sees the moved blobs together. This fixes the merge across the Gooey FAB, Gooey Stack, and their Learn scenes by rendering the fusing shapes as native SVG, and reworks Gooey Stack's border architecture so it can't ghost/double on WebKit.

## Type of change

- [x] 🐛 Bug fix (non-breaking change fixing an issue)
- [x] ♻️ Refactor (no functional change)

## Changes made

- Render fusing shapes as native SVG (`<circle>`/`<rect>` inside `<g filter>`) instead of transform-animated filtered HTML — SVG shapes are never individually GPU-composited, so the filter fuses on every engine. Applied to `gooey-fab`, `gooey-stack`, and Learn scenes `gooey-filter`, `gooey-stack-filter`, `gooey-stack-nearness`, `liquid-metaballs-goo`, `liquid-metaballs-cursor`.
- `gooey-stack`: make the goo SVG the **sole** card surface (fill + one continuous outline). A goo filter dilates more on WebKit than Blink, so an always-opaque native card beneath the goo double-bordered on Safari; one border source removes the class of bug. Native `<div>` cards remain only as the reduced-motion fallback.
- Add `SPRING.liquid` motion token (slow, no-overshoot) so the merge stays readable.

## How to test

1. `pnpm dev` → open the Gooey Stack "the filter" Learn scene and the Gooey FAB in **Safari**; shapes now merge into a liquid blob (previously stayed separate).
2. Storybook: `layout-gooeystack--playground`, drag `gap` negative — cards neck into one continuous single-bordered liquid outline; no double/ghost border on Safari.

## Screenshots / recordings

Verified via Playwright (Chromium + WebKit) at fixed gaps; before = separate shapes / doubled border on Safari, after = single continuous merge. (Ask if you want the capture frames attached.)

## Checklist

- [x] `pnpm check` passes (Biome lint + format)
- [x] `pnpm test` passes (400 passing)
- [x] Commits follow Conventional Commits
- [x] Self-reviewed the diff; no stray logs, dead code, or commented-out blocks

### Component / registry PRs only

- [x] Animations use `transform`/`opacity`/`filter` only (no layout/paint props)
- [ ] No `registry.json` / story / docs changes needed (behavior-preserving rendering fix)