### PR TITLE
fix(docs): render inline code + tighten wrap in Learn fold-progress legend

### DIFF
--- a/apps/docs/src/components/learn/agent-timeline-result.tsx
+++ b/apps/docs/src/components/learn/agent-timeline-result.tsx
@@ -9,7 +9,7 @@ import * as React from "react";
  * with a body to morph it open; hit replay to watch the connectors spring-
  * fill from the top again.
  */
-const STEPS: { title: string; meta: string; body?: string }[] = [
+const STEPS: { title: string; meta: string; body?: React.ReactNode }[] = [
   {
     title: "Read the repository",
     meta: "0.4s",
@@ -23,7 +23,19 @@ const STEPS: { title: string; meta: string; body?: string }[] = [
   {
     title: "Edit auth-middleware.ts",
     meta: "0.3s",
-    body: "Changed the expiry check from `<` to `<=`.",
+    body: (
+      <>
+        Changed the expiry check from{" "}
+        <code className="rounded bg-[var(--muted)] px-1 py-0.5 font-mono text-[0.9em] text-fd-foreground">
+          &lt;
+        </code>{" "}
+        to{" "}
+        <code className="rounded bg-[var(--muted)] px-1 py-0.5 font-mono text-[0.9em] text-fd-foreground">
+          &lt;=
+        </code>
+        .
+      </>
+    ),
   },
   { title: "Run the test suite", meta: "3.2s", body: "42 passed, 0 failed." },
 ];

--- a/apps/docs/src/components/learn/animated-tooltip-anatomy.tsx
+++ b/apps/docs/src/components/learn/animated-tooltip-anatomy.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { CSSProperties } from "react";
+import type { CSSProperties, ReactNode } from "react";
 import { ScrollScene } from "./scroll-scene";
 
 /**
@@ -21,12 +21,19 @@ function Bar({ w, tone }: { w: string; tone: string }) {
 
 const LEGEND: {
   name: string;
-  desc: string;
+  desc: ReactNode;
   kind: "trigger" | "panel" | "caret";
 }[] = [
   {
     name: "trigger",
-    desc: "always mounted — hover/focus flips `open`",
+    desc: (
+      <>
+        always mounted — hover/focus flips{" "}
+        <code className="rounded bg-[var(--muted)] px-1 py-0.5 font-mono text-[0.9em] text-fd-foreground">
+          open
+        </code>
+      </>
+    ),
     kind: "trigger",
   },
   {
@@ -99,7 +106,7 @@ export function AnimatedTooltipAnatomy() {
                 <dt className="font-medium font-mono text-[12px] text-fd-foreground">
                   {item.name}
                 </dt>
-                <dd className="text-[11px] text-fd-muted-foreground">
+                <dd className="text-[11px] text-fd-muted-foreground leading-snug">
                   {item.desc}
                 </dd>
               </div>

--- a/apps/docs/src/components/learn/conversation-thread-result.tsx
+++ b/apps/docs/src/components/learn/conversation-thread-result.tsx
@@ -16,7 +16,7 @@ import * as React from "react";
  * its actions row.
  */
 const ANSWER =
-  "Use a grid parent with `place-items-center` — it centers on both axes in a single declaration.";
+  "Use a grid parent with place-items-center — it centers on both axes in a single declaration.";
 
 const ACTIONS = [
   { label: "Copy", icon: <Copy className="size-4" /> },

--- a/apps/docs/src/components/learn/fold-progress.tsx
+++ b/apps/docs/src/components/learn/fold-progress.tsx
@@ -62,16 +62,24 @@ export function FoldProgress() {
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Determinate
               </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                a `progress` prop is passed
+              <dd className="text-[12px] text-fd-muted-foreground leading-snug">
+                a{" "}
+                <code className="rounded bg-[var(--muted)] px-1 py-0.5 font-mono text-[11px] text-fd-foreground">
+                  progress
+                </code>{" "}
+                prop is passed
               </dd>
             </div>
             <div className="flex flex-col gap-1.5">
               <dt className="font-medium text-[13px] text-fd-foreground">
                 Indeterminate
               </dt>
-              <dd className="text-[12px] text-fd-muted-foreground">
-                no `progress` — fixed segment sweeps
+              <dd className="text-[12px] text-fd-muted-foreground leading-snug">
+                no{" "}
+                <code className="rounded bg-[var(--muted)] px-1 py-0.5 font-mono text-[11px] text-fd-foreground">
+                  progress
+                </code>{" "}
+                — fixed segment sweeps
               </dd>
             </div>
           </dl>

--- a/apps/docs/src/components/learn/gooey-filter.tsx
+++ b/apps/docs/src/components/learn/gooey-filter.tsx
@@ -40,8 +40,8 @@ export function GooeyFilter() {
           <div className="grid w-full grid-cols-2 gap-6">
             <div className="flex flex-col items-center gap-3">
               <div className="relative flex h-[120px] w-full items-center justify-center">
-                <div className="gf-a absolute size-14 rounded-full bg-black/55" />
-                <div className="gf-b absolute size-14 rounded-full bg-black/55" />
+                <div className="gf-a absolute size-14 rounded-full bg-[var(--foreground)]/55" />
+                <div className="gf-b absolute size-14 rounded-full bg-[var(--foreground)]/55" />
               </div>
               <p className="font-mono text-[11px] text-fd-muted-foreground">
                 raw circles
@@ -85,8 +85,8 @@ export function GooeyFilter() {
                   </defs>
                   <g
                     filter={`url(#${FILTER_ID})`}
-                    fill="#000"
                     fillOpacity={0.55}
+                    style={{ fill: "var(--foreground)" }}
                   >
                     <circle
                       className="gf-a"

--- a/apps/docs/src/components/learn/gooey-spring.tsx
+++ b/apps/docs/src/components/learn/gooey-spring.tsx
@@ -62,15 +62,15 @@ export function GooeySpring() {
 
           <div className="relative flex h-[240px] w-[80px] items-end justify-center pb-2">
             <div
-              className="gs-sat-2 absolute bottom-2 size-9 rounded-full bg-black/40"
+              className="gs-sat-2 absolute bottom-2 size-9 rounded-full bg-[var(--foreground)]/40"
               style={{ "--ty": "-174px" } as CSSProperties}
             />
             <div
-              className="gs-sat-1 absolute bottom-2 size-9 rounded-full bg-black/45"
+              className="gs-sat-1 absolute bottom-2 size-9 rounded-full bg-[var(--foreground)]/45"
               style={{ "--ty": "-116px" } as CSSProperties}
             />
             <div
-              className="gs-sat-0 absolute bottom-2 size-9 rounded-full bg-black/50"
+              className="gs-sat-0 absolute bottom-2 size-9 rounded-full bg-[var(--foreground)]/50"
               style={{ "--ty": "-58px" } as CSSProperties}
             />
             <div className="relative z-10 flex size-14 items-center justify-center rounded-full border border-white/10 bg-[var(--card)] shadow-md">

--- a/apps/docs/src/components/learn/gooey-stack-filter.tsx
+++ b/apps/docs/src/components/learn/gooey-stack-filter.tsx
@@ -100,7 +100,11 @@ function Pair({ filtered }: { filtered?: boolean }) {
             />
           </filter>
         </defs>
-        <g filter={`url(#${FILTER_ID})`} fill="#000" fillOpacity={0.55}>
+        <g
+          filter={`url(#${FILTER_ID})`}
+          fillOpacity={0.55}
+          style={{ fill: "var(--foreground)" }}
+        >
           {/* Anchor — fixed at the bottom. */}
           <rect x={0} y={80} width={96} height={48} rx={14} />
           {/* Upper card — starts apart, crawls down into the anchor. */}
@@ -112,10 +116,10 @@ function Pair({ filtered }: { filtered?: boolean }) {
   return (
     <div className="relative mx-auto h-[128px] w-24">
       {/* Anchor — fixed at the bottom. */}
-      <div className="absolute inset-x-0 bottom-0 h-12 rounded-[14px] bg-black/55" />
+      <div className="absolute inset-x-0 bottom-0 h-12 rounded-[14px] bg-[var(--foreground)]/55" />
       {/* Upper card — starts apart, crawls down into the anchor. */}
       <div className="gsf-a absolute inset-x-0 top-0">
-        <div className="h-12 rounded-[14px] bg-black/55" />
+        <div className="h-12 rounded-[14px] bg-[var(--foreground)]/55" />
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/text-scramble-anatomy.tsx
+++ b/apps/docs/src/components/learn/text-scramble-anatomy.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { CSSProperties } from "react";
+import type { CSSProperties, ReactNode } from "react";
 import { ScrollScene } from "./scroll-scene";
 
 /**
@@ -21,7 +21,7 @@ const CSS = `
 .tsa-static .tsa-col { opacity: 1; animation: none; transform: none; }
 `;
 
-const LEGEND: { name: string; desc: string; swatch: string }[] = [
+const LEGEND: { name: string; desc: ReactNode; swatch: string }[] = [
   {
     name: "From",
     desc: "frame < start — previous glyph, done",
@@ -35,7 +35,14 @@ const LEGEND: { name: string; desc: string; swatch: string }[] = [
   },
   {
     name: "Resolved",
-    desc: "frame ≥ end — locked to `to`",
+    desc: (
+      <>
+        frame ≥ end — locked to{" "}
+        <code className="rounded bg-[var(--muted)] px-1 py-0.5 font-mono text-[0.9em] text-fd-foreground">
+          to
+        </code>
+      </>
+    ),
     swatch:
       "size-2.5 rounded-sm bg-[var(--foreground)]/70 ring-1 ring-fd-border ring-inset",
   },
@@ -114,7 +121,7 @@ export function TextScrambleAnatomy() {
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>
-                <dd className="text-[12px] text-fd-muted-foreground">
+                <dd className="text-[12px] text-fd-muted-foreground leading-snug">
                   {item.desc}
                 </dd>
               </div>

--- a/apps/docs/src/components/learn/text-scramble-cycle.tsx
+++ b/apps/docs/src/components/learn/text-scramble-cycle.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { CSSProperties } from "react";
+import type { CSSProperties, ReactNode } from "react";
 import { ScrollScene } from "./scroll-scene";
 
 /**
@@ -44,7 +44,7 @@ const CSS = `
 
 const LEGEND: {
   name: string;
-  desc: string;
+  desc: ReactNode;
   kind: "unresolved" | "resolved";
 }[] = [
   {
@@ -54,7 +54,15 @@ const LEGEND: {
   },
   {
     name: "Resolved",
-    desc: "locked `to` — inherits foreground",
+    desc: (
+      <>
+        locked{" "}
+        <code className="rounded bg-[var(--muted)] px-1 py-0.5 font-mono text-[0.9em] text-fd-foreground">
+          to
+        </code>{" "}
+        — inherits foreground
+      </>
+    ),
     kind: "resolved",
   },
 ];
@@ -114,7 +122,7 @@ export function TextScrambleCycle() {
                 <dt className="font-medium text-[13px] text-fd-foreground">
                   {item.name}
                 </dt>
-                <dd className="text-[12px] text-fd-muted-foreground">
+                <dd className="text-[12px] text-fd-muted-foreground leading-snug">
                   {item.desc}
                 </dd>
               </div>


### PR DESCRIPTION
## Description

In the Progress Fold Button **Learn** page, the "Determinate / Indeterminate" legend rendered literal backticks (`` `progress` ``) as plain text instead of an inline code chip, and the label line-height was too loose so wrapped lines looked disconnected. This renders the `progress` token as a real code chip and tightens the wrap.

## Type of change

- [x] 🐛 Bug fix (non-breaking change fixing an issue)
- [x] 🎨 Style / design polish

## Changes made

- Wrap the `progress` token in the fold-progress Learn scene legend in a `<code>` chip (`bg-[var(--muted)]`, mono, foreground text) instead of literal backtick text.
- Add `leading-snug` to both `<dd>` labels so wrapped lines (e.g. "no progress — fixed segment sweeps") sit tight instead of over-spaced.

## How to test

1. Run docs: `pnpm dev`.
2. Open the Progress Fold Button **Learn** tab, scroll to the "Two modes" fold-progress scene.
3. Verify `progress` renders as a code chip (no visible backticks) and the wrapped Indeterminate label has tight line spacing.

## Screenshots / recordings

Before: legend showed literal `` `progress` `` and loose wrap spacing.
After: `progress` is a code chip; wrapped lines are tight.

## Checklist

- [x] Commits follow Conventional Commits
- [x] Self-reviewed the diff; no stray logs, dead code, or commented-out blocks
