### PR TITLE
fix(docs): show MotionScore badge tooltip only on hover of the badge

### DIFF
--- a/apps/docs/src/components/component-badges.tsx
+++ b/apps/docs/src/components/component-badges.tsx
@@ -71,7 +71,7 @@ function Badge({
       <span
         role="tooltip"
         id={id}
-        className={`absolute top-full left-0 z-50 w-72 max-w-[min(18rem,80vw)] pt-2 text-left opacity-0 transition-opacity duration-150 group-hover/badge:opacity-100 group-focus-within/badge:opacity-100 ${href ? "" : "pointer-events-none"}`}
+        className={`pointer-events-none absolute top-full left-0 z-50 w-72 max-w-[min(18rem,80vw)] pt-2 text-left opacity-0 transition-opacity duration-150 group-hover/badge:opacity-100 group-focus-within/badge:opacity-100 ${href ? "group-hover/badge:pointer-events-auto group-focus-within/badge:pointer-events-auto" : ""}`}
       >
         <span className="block rounded-lg border border-border bg-popover px-3 py-2.5 font-normal text-[13px] text-popover-foreground normal-case leading-relaxed tracking-normal shadow-lg">
           <span className="mb-0.5 block font-semibold text-foreground">


### PR DESCRIPTION
## Description

The MotionScore badge tooltip appeared when hovering the empty area *below* the badge, not just on it. Badges with a link (the MotionScore badge) kept their drop-down tooltip pointer-interactive while invisible, so its offscreen box below the pill caught the pointer and tripped the group-hover reveal.

## Type of change

- [x] 🐛 Bug fix (non-breaking change fixing an issue)

## Changes made

- Default the badge tooltip to `pointer-events-none`; enable pointer events only while the badge is hovered or focused (`group-hover/badge:pointer-events-auto`, `group-focus-within/badge:pointer-events-auto`). Interactive link and the `pt-2` hover bridge still work once the badge itself is hovered.

## How to test

1. `pnpm dev` → open `/docs/components/buttons/jelly-button`.
2. Hover just below the "Motion S" badge — no tooltip.
3. Hover the badge — tooltip shows; move down into it and the "Motion Score table" link stays reachable.

## Screenshots / recordings

Verified locally via real hover (headless Chrome, CDP mouse move): idle → tooltip opacity `0`; 24px below the badge → `0` (the bug, now hidden); on the badge → `1`.

## Checklist

- [x] `pnpm check` passes (Biome) on the changed file
- [x] Self-reviewed the diff; no stray logs or dead code