### PR TITLE
feat(combobox): multi-select mode (multiple, values, onToggle)

### DIFF
--- a/apps/docs/content/docs/components/navigation/combobox/index.mdx
+++ b/apps/docs/content/docs/components/navigation/combobox/index.mdx
@@ -3,7 +3,7 @@ title: Combobox
 description: A type-ahead autocomplete with staggered result reveal, highlighted matches, keyboard navigation, and an async loading state.
 ---
 
-import { ComboboxDemo, ComboboxAsyncDemo } from "@/components/demos/combobox-demo";
+import { ComboboxDemo, ComboboxAsyncDemo, ComboboxMultiSelectDemo } from "@/components/demos/combobox-demo";
 
 <ComponentPreview
   story="navigation-combobox"
@@ -95,6 +95,42 @@ export function DisabledPicker() {
   <ComboboxDemo disabled />
 </ComponentPreview>
 
+### Multi-select
+
+Set `multiple` and drive it with `values` + `onToggle` to select several options.
+Chosen options render as chips in the control, and picking one keeps the list open.
+
+<ComponentPreview
+  code={`"use client";
+import { Combobox } from "@/components/godui/combobox";
+import { useState } from "react";
+
+const people = [
+  { label: "Ada Lovelace", value: "ada" },
+  { label: "Grace Hopper", value: "grace" },
+  { label: "Alan Turing", value: "alan" },
+];
+
+export function Reviewers() {
+  const [values, setValues] = useState(["ada"]);
+  return (
+    <Combobox
+      multiple
+      options={people}
+      values={values}
+      onToggle={(v) =>
+        setValues((prev) =>
+          prev.includes(v) ? prev.filter((x) => x !== v) : [...prev, v],
+        )
+      }
+      placeholder="Add reviewers…"
+    />
+  );
+}`}
+>
+  <ComboboxMultiSelectDemo />
+</ComponentPreview>
+
 ## Props
 
 | Prop | Type | Default | Description |
@@ -106,4 +142,7 @@ export function DisabledPicker() {
 | `placeholder` | `string` | `"Search…"` | Input placeholder |
 | `emptyMessage` | `string` | `"No results"` | Shown when nothing matches |
 | `disabled` | `boolean` | `false` | Disables the input and prevents opening the listbox |
-| `onChange` | `(value, option) => void` | — | Called on selection |
+| `onChange` | `(value, option) => void` | — | Called on selection (single-select) |
+| `multiple` | `boolean` | `false` | Multi-select: chips in the control; picking stays open |
+| `values` | `string[]` | — | Selected values (multi-select) |
+| `onToggle` | `(value, option) => void` | — | Toggle handler (multi-select) |

--- a/apps/docs/src/components/demos/combobox-demo.tsx
+++ b/apps/docs/src/components/demos/combobox-demo.tsx
@@ -100,3 +100,28 @@ export function ComboboxAsyncDemo() {
     </div>
   );
 }
+
+export function ComboboxMultiSelectDemo() {
+  const [values, setValues] = useState<string[]>(["ada", "grace"]);
+
+  return (
+    <div className="flex h-80 w-full max-w-sm flex-col gap-3 pt-2">
+      <span className="font-medium text-foreground text-sm">Reviewers</span>
+      <Combobox
+        multiple
+        options={PEOPLE}
+        values={values}
+        onToggle={(v) =>
+          setValues((prev) =>
+            prev.includes(v) ? prev.filter((x) => x !== v) : [...prev, v],
+          )
+        }
+        placeholder="Add reviewers…"
+      />
+      <p className="text-muted-foreground text-xs">
+        {values.length} selected — chips show in the control and picking keeps
+        the list open.
+      </p>
+    </div>
+  );
+}

--- a/apps/storybook/src/stories/combobox.stories.tsx
+++ b/apps/storybook/src/stories/combobox.stories.tsx
@@ -1,5 +1,6 @@
 import { Combobox, type ComboboxOption } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import * as React from "react";
 import { fn } from "storybook/test";
 import { action, hidden, text, toggle } from "../playground/argtypes";
 
@@ -51,4 +52,24 @@ export const Playground: Story = {};
 
 export const Disabled: Story = {
   args: { disabled: true },
+};
+
+/** Multi-select: chips in the control; picking toggles and keeps the list open. */
+export const MultiSelect: Story = {
+  render: (args) => {
+    const [values, setValues] = React.useState<string[]>(["next", "astro"]);
+    return (
+      <Combobox
+        {...args}
+        multiple
+        values={values}
+        onToggle={(v) =>
+          setValues((prev) =>
+            prev.includes(v) ? prev.filter((x) => x !== v) : [...prev, v],
+          )
+        }
+        placeholder="Add frameworks…"
+      />
+    );
+  },
 };

--- a/packages/components/src/combobox/combobox.test.tsx
+++ b/packages/components/src/combobox/combobox.test.tsx
@@ -75,6 +75,23 @@ describe("Combobox", () => {
     );
   });
 
+  it("multi-select: a disabled chip cannot be removed", async () => {
+    const onToggle = vi.fn();
+    render(
+      <Combobox
+        multiple
+        disabled
+        options={options}
+        values={["apple"]}
+        onToggle={onToggle}
+      />,
+    );
+    const remove = screen.getByRole("button", { name: "Remove Apple" });
+    expect(remove).toBeDisabled();
+    await userEvent.click(remove);
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
   it("selects the active option with the keyboard", async () => {
     const onChange = vi.fn();
     render(<Combobox options={options} onChange={onChange} />);

--- a/packages/components/src/combobox/combobox.test.tsx
+++ b/packages/components/src/combobox/combobox.test.tsx
@@ -34,6 +34,47 @@ describe("Combobox", () => {
     );
   });
 
+  it("multi-select toggles values and keeps the list open", async () => {
+    const onToggle = vi.fn();
+    render(
+      <Combobox
+        multiple
+        options={options}
+        values={["apple"]}
+        onToggle={onToggle}
+      />,
+    );
+    // The selected value shows as a chip.
+    expect(screen.getByText("Apple")).toBeInTheDocument();
+
+    const input = screen.getByRole("combobox");
+    await userEvent.click(input);
+    await userEvent.click(screen.getByRole("option", { name: /Banana/ }));
+    expect(onToggle).toHaveBeenCalledWith(
+      "banana",
+      expect.objectContaining({ value: "banana" }),
+    );
+    // The list stays open after a pick.
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+  });
+
+  it("multi-select removes a value via its chip button", async () => {
+    const onToggle = vi.fn();
+    render(
+      <Combobox
+        multiple
+        options={options}
+        values={["apple"]}
+        onToggle={onToggle}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Remove Apple" }));
+    expect(onToggle).toHaveBeenCalledWith(
+      "apple",
+      expect.objectContaining({ value: "apple" }),
+    );
+  });
+
   it("selects the active option with the keyboard", async () => {
     const onChange = vi.fn();
     render(<Combobox options={options} onChange={onChange} />);

--- a/packages/components/src/combobox/combobox.tsx
+++ b/packages/components/src/combobox/combobox.tsx
@@ -206,12 +206,14 @@ const Combobox = React.forwardRef<HTMLDivElement, ComboboxProps>(
                 {chipLabel(v)}
                 <button
                   type="button"
+                  disabled={disabled}
                   aria-label={`Remove ${chipLabel(v)}`}
                   onClick={(e) => {
                     e.stopPropagation();
-                    onToggle?.(v, { value: v, label: chipLabel(v) });
+                    if (!disabled)
+                      onToggle?.(v, { value: v, label: chipLabel(v) });
                   }}
-                  className="text-muted-foreground hover:text-foreground"
+                  className="text-muted-foreground hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   &times;
                 </button>

--- a/packages/components/src/combobox/combobox.tsx
+++ b/packages/components/src/combobox/combobox.tsx
@@ -11,7 +11,7 @@ export type ComboboxOption = {
 
 export type ComboboxProps = Omit<
   React.HTMLAttributes<HTMLDivElement>,
-  "onChange" | "defaultValue"
+  "onChange" | "defaultValue" | "onToggle"
 > & {
   /** Static option list. Ignored when `onSearch` is provided. */
   options?: ComboboxOption[];
@@ -24,6 +24,13 @@ export type ComboboxProps = Omit<
   /** Disable the input and prevent opening the listbox. */
   disabled?: boolean;
   onChange?: (value: string, option: ComboboxOption) => void;
+  /** Multi-select mode: chosen options render as chips in the control and
+   *  picking one keeps the list open. Drive it with `values` + `onToggle`. */
+  multiple?: boolean;
+  /** Selected values (multi-select). */
+  values?: string[];
+  /** Toggle handler (multi-select). */
+  onToggle?: (value: string, option: ComboboxOption) => void;
 };
 
 function highlight(label: string, query: string) {
@@ -66,6 +73,9 @@ const Combobox = React.forwardRef<HTMLDivElement, ComboboxProps>(
       emptyMessage = "No results",
       disabled = false,
       onChange,
+      multiple = false,
+      values,
+      onToggle,
       className,
       ...props
     },
@@ -76,6 +86,8 @@ const Combobox = React.forwardRef<HTMLDivElement, ComboboxProps>(
     const isControlled = valueProp !== undefined;
     const [internal, setInternal] = React.useState(defaultValue ?? "");
     const value = isControlled ? valueProp : internal;
+
+    const selectedValues = React.useMemo(() => values ?? [], [values]);
 
     const allOptions = React.useMemo(
       () => staticOptions ?? [],
@@ -91,6 +103,7 @@ const Combobox = React.forwardRef<HTMLDivElement, ComboboxProps>(
       [],
     );
     const rootRef = React.useRef<HTMLDivElement>(null);
+    const inputRef = React.useRef<HTMLInputElement>(null);
     const reqId = React.useRef(0);
 
     React.useImperativeHandle(ref, () => rootRef.current as HTMLDivElement);
@@ -129,11 +142,46 @@ const Combobox = React.forwardRef<HTMLDivElement, ComboboxProps>(
           o.label.toLowerCase().includes(query.toLowerCase()),
         );
 
+    // Chip labels resolve from options ∪ a small cache of chosen items, so a
+    // selection still names itself when the query filters it out.
+    const labelCacheRef = React.useRef(new Map<string, string>());
+    React.useEffect(() => {
+      for (const o of results) labelCacheRef.current.set(o.value, o.label);
+    }, [results]);
+    const chipLabel = (v: string) =>
+      allOptions.find((o) => o.value === v)?.label ??
+      labelCacheRef.current.get(v) ??
+      v;
+
     const commit = (opt: ComboboxOption) => {
+      if (multiple) {
+        labelCacheRef.current.set(opt.value, opt.label);
+        onToggle?.(opt.value, opt);
+        setQuery("");
+        setActive(0);
+        inputRef.current?.focus();
+        return;
+      }
       if (!isControlled) setInternal(opt.value);
       onChange?.(opt.value, opt);
       setQuery("");
       setOpen(false);
+    };
+
+    const onInputKeyDown = (e: React.KeyboardEvent) => {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setOpen(true);
+        setActive((a) => Math.min(a + 1, results.length - 1));
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setActive((a) => Math.max(a - 1, 0));
+      } else if (e.key === "Enter" && open && results[active]) {
+        e.preventDefault();
+        commit(results[active]);
+      } else if (e.key === "Escape") {
+        setOpen(false);
+      }
     };
 
     const spring = reduceMotion
@@ -146,63 +194,94 @@ const Combobox = React.forwardRef<HTMLDivElement, ComboboxProps>(
         className={`relative w-72 ${className ?? ""}`}
         {...props}
       >
-        <div className="relative">
-          <input
-            role="combobox"
-            aria-expanded={open}
-            aria-controls={listboxId}
-            aria-autocomplete="list"
-            disabled={disabled}
-            value={open ? query : (selectedOption?.label ?? query)}
-            placeholder={placeholder}
-            onChange={(e) => {
-              setQuery(e.target.value);
-              setActive(0);
-              setOpen(true);
-            }}
-            onFocus={() => setOpen(true)}
-            onKeyDown={(e) => {
-              if (e.key === "ArrowDown") {
-                e.preventDefault();
-                setOpen(true);
-                setActive((a) => Math.min(a + 1, results.length - 1));
-              } else if (e.key === "ArrowUp") {
-                e.preventDefault();
-                setActive((a) => Math.max(a - 1, 0));
-              } else if (e.key === "Enter" && open && results[active]) {
-                e.preventDefault();
-                commit(results[active]);
-              } else if (e.key === "Escape") {
-                setOpen(false);
-              }
-            }}
-            className="w-full rounded-xl border border-border bg-background px-3.5 py-2.5 pr-9 text-foreground text-sm outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
-          />
-          <span className="-translate-y-1/2 absolute top-1/2 right-3">
-            {loading ? (
-              Spinner
-            ) : (
-              <svg
-                aria-hidden="true"
-                viewBox="0 0 24 24"
-                className="h-4 w-4 text-muted-foreground"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
+        {multiple ? (
+          // A <label> so clicking the chip area natively focuses the input (which
+          // opens the list via onFocus) — no click handler, no a11y violation.
+          <label className="flex min-h-[2.75rem] w-full flex-wrap items-center gap-1.5 rounded-xl border border-border bg-background px-2.5 py-2 text-sm focus-within:ring-2 focus-within:ring-ring">
+            {selectedValues.map((v) => (
+              <span
+                key={v}
+                className="inline-flex items-center gap-1 rounded-md bg-accent px-2 py-0.5 text-accent-foreground text-xs"
               >
-                <path d="M21 21l-4.3-4.3M11 18a7 7 0 1 0 0-14 7 7 0 0 0 0 14z" />
-              </svg>
-            )}
-          </span>
-        </div>
+                {chipLabel(v)}
+                <button
+                  type="button"
+                  aria-label={`Remove ${chipLabel(v)}`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onToggle?.(v, { value: v, label: chipLabel(v) });
+                  }}
+                  className="text-muted-foreground hover:text-foreground"
+                >
+                  &times;
+                </button>
+              </span>
+            ))}
+            <input
+              ref={inputRef}
+              role="combobox"
+              aria-expanded={open}
+              aria-controls={listboxId}
+              aria-autocomplete="list"
+              disabled={disabled}
+              value={query}
+              placeholder={selectedValues.length === 0 ? placeholder : ""}
+              onChange={(e) => {
+                setQuery(e.target.value);
+                setActive(0);
+                setOpen(true);
+              }}
+              onFocus={() => setOpen(true)}
+              onKeyDown={onInputKeyDown}
+              className="min-w-[6rem] flex-1 bg-transparent text-foreground outline-none placeholder:text-muted-foreground"
+            />
+          </label>
+        ) : (
+          <div className="relative">
+            <input
+              role="combobox"
+              aria-expanded={open}
+              aria-controls={listboxId}
+              aria-autocomplete="list"
+              disabled={disabled}
+              value={open ? query : (selectedOption?.label ?? query)}
+              placeholder={placeholder}
+              onChange={(e) => {
+                setQuery(e.target.value);
+                setActive(0);
+                setOpen(true);
+              }}
+              onFocus={() => setOpen(true)}
+              onKeyDown={onInputKeyDown}
+              className="w-full rounded-xl border border-border bg-background px-3.5 py-2.5 pr-9 text-foreground text-sm outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+            />
+            <span className="-translate-y-1/2 absolute top-1/2 right-3">
+              {loading ? (
+                Spinner
+              ) : (
+                <svg
+                  aria-hidden="true"
+                  viewBox="0 0 24 24"
+                  className="h-4 w-4 text-muted-foreground"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M21 21l-4.3-4.3M11 18a7 7 0 1 0 0-14 7 7 0 0 0 0 14z" />
+                </svg>
+              )}
+            </span>
+          </div>
+        )}
 
         <AnimatePresence>
           {open && (
             <motion.ul
               id={listboxId}
               role="listbox"
+              aria-multiselectable={multiple || undefined}
               initial={
                 reduceMotion
                   ? { opacity: 0 }
@@ -224,7 +303,9 @@ const Combobox = React.forwardRef<HTMLDivElement, ComboboxProps>(
               )}
               {results.map((opt, i) => {
                 const isActive = i === active;
-                const isSelected = opt.value === value;
+                const isSelected = multiple
+                  ? selectedValues.includes(opt.value)
+                  : opt.value === value;
                 return (
                   <motion.li
                     key={opt.value}


### PR DESCRIPTION
## Summary

Adds an opt-in **multi-select** mode to `Combobox`. Single-select behaviour is unchanged — the new props are purely additive.

- `multiple` — enable multi-select
- `values: string[]` — the selected values
- `onToggle: (value, option) => void` — called when an option is toggled

In multi mode, chosen options render as removable **chips** in the control, and picking an option keeps the list open so you can add several in a row. The control is a `<label>` wrapping the input (clicking the chip area focuses the input; no click handler needed), and the listbox is marked `aria-multiselectable`.

## Included

- Component: `multiple` / `values` / `onToggle`, chips, shared keyboard handler
- Storybook: **MultiSelect** story
- Docs: a "Multi-select" example + props
- Tests: toggle-on-pick (list stays open) and remove-via-chip

## Notes

Presentational only — no new dependencies, no business logic. Keeps the existing framer-motion animation and shadcn tokens.