### PR TITLE
feat(combobox): creatable rows (creatable, onCreate, creating)

### DIFF
--- a/apps/docs/content/docs/components/navigation/combobox/index.mdx
+++ b/apps/docs/content/docs/components/navigation/combobox/index.mdx
@@ -3,7 +3,7 @@ title: Combobox
 description: A type-ahead autocomplete with staggered result reveal, highlighted matches, keyboard navigation, and an async loading state.
 ---
 
-import { ComboboxDemo, ComboboxAsyncDemo } from "@/components/demos/combobox-demo";
+import { ComboboxDemo, ComboboxAsyncDemo, ComboboxCreatableDemo } from "@/components/demos/combobox-demo";
 
 <ComponentPreview
   story="navigation-combobox"
@@ -95,6 +95,38 @@ export function DisabledPicker() {
   <ComboboxDemo disabled />
 </ComponentPreview>
 
+### Creatable
+
+Set `creatable` to offer the typed value as an “Add …” row when it isn’t already an
+option. It commits a synthetic option by default, or pass `onCreate` to persist the
+new value yourself (with `creating` for an in-flight spinner).
+
+<ComponentPreview
+  code={`"use client";
+import { Combobox } from "@/components/godui/combobox";
+import { useState } from "react";
+
+const people = [
+  { label: "Ada Lovelace", value: "ada" },
+  { label: "Grace Hopper", value: "grace" },
+];
+
+export function LabelPicker() {
+  const [value, setValue] = useState("");
+  return (
+    <Combobox
+      creatable
+      options={people}
+      value={value}
+      onChange={setValue}
+      placeholder="Pick or type a new one…"
+    />
+  );
+}`}
+>
+  <ComboboxCreatableDemo />
+</ComponentPreview>
+
 ## Props
 
 | Prop | Type | Default | Description |
@@ -107,3 +139,6 @@ export function DisabledPicker() {
 | `emptyMessage` | `string` | `"No results"` | Shown when nothing matches |
 | `disabled` | `boolean` | `false` | Disables the input and prevents opening the listbox |
 | `onChange` | `(value, option) => void` | — | Called on selection |
+| `creatable` | `boolean` | `false` | Offer an “Add …” row for a typed value with no match |
+| `onCreate` | `(label) => void \| Promise<void>` | — | Persist a created value instead of a synthetic option |
+| `creating` | `boolean` | `false` | Spinner + disabled state on the create row |

--- a/apps/docs/src/components/demos/combobox-demo.tsx
+++ b/apps/docs/src/components/demos/combobox-demo.tsx
@@ -100,3 +100,23 @@ export function ComboboxAsyncDemo() {
     </div>
   );
 }
+
+export function ComboboxCreatableDemo() {
+  const [value, setValue] = useState("");
+
+  return (
+    <div className="flex h-80 w-full max-w-sm flex-col gap-3 pt-2">
+      <span className="font-medium text-foreground text-sm">Label</span>
+      <Combobox
+        creatable
+        options={PEOPLE}
+        value={value}
+        onChange={setValue}
+        placeholder="Pick a teammate or type a new label…"
+      />
+      <p className="text-muted-foreground text-xs">
+        Type something with no match to get an “Add …” row.
+      </p>
+    </div>
+  );
+}

--- a/apps/storybook/src/stories/combobox.stories.tsx
+++ b/apps/storybook/src/stories/combobox.stories.tsx
@@ -1,5 +1,6 @@
 import { Combobox, type ComboboxOption } from "@godui/components";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import * as React from "react";
 import { fn } from "storybook/test";
 import { action, hidden, text, toggle } from "../playground/argtypes";
 
@@ -51,4 +52,20 @@ export const Playground: Story = {};
 
 export const Disabled: Story = {
   args: { disabled: true },
+};
+
+/** Creatable: a typed value with no match becomes an "Add …" row. */
+export const Creatable: Story = {
+  render: (args) => {
+    const [value, setValue] = React.useState("");
+    return (
+      <Combobox
+        {...args}
+        creatable
+        value={value}
+        onChange={(v) => setValue(v)}
+        placeholder="Pick or type a new one…"
+      />
+    );
+  },
 };

--- a/packages/components/src/combobox/combobox.test.tsx
+++ b/packages/components/src/combobox/combobox.test.tsx
@@ -66,6 +66,29 @@ describe("Combobox", () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
+  it("creatable: Enter selects the highlighted match, not the create row", async () => {
+    const onChange = vi.fn();
+    const onCreate = vi.fn();
+    render(
+      <Combobox
+        options={options}
+        creatable
+        onChange={onChange}
+        onCreate={onCreate}
+      />,
+    );
+    const input = screen.getByRole("combobox");
+    await userEvent.click(input);
+    // "Ban" partially matches "Banana" and is also creatable (no exact match).
+    await userEvent.type(input, "Ban");
+    await userEvent.keyboard("{Enter}");
+    expect(onChange).toHaveBeenCalledWith(
+      "banana",
+      expect.objectContaining({ value: "banana" }),
+    );
+    expect(onCreate).not.toHaveBeenCalled();
+  });
+
   it("selects the active option with the keyboard", async () => {
     const onChange = vi.fn();
     render(<Combobox options={options} onChange={onChange} />);

--- a/packages/components/src/combobox/combobox.test.tsx
+++ b/packages/components/src/combobox/combobox.test.tsx
@@ -34,6 +34,38 @@ describe("Combobox", () => {
     );
   });
 
+  it("creatable: commits a typed value that is not an option", async () => {
+    const onChange = vi.fn();
+    render(<Combobox options={options} creatable onChange={onChange} />);
+    const input = screen.getByRole("combobox");
+    await userEvent.click(input);
+    await userEvent.type(input, "Mango");
+    await userEvent.click(screen.getByRole("option", { name: /Mango/ }));
+    expect(onChange).toHaveBeenCalledWith(
+      "Mango",
+      expect.objectContaining({ value: "Mango" }),
+    );
+  });
+
+  it("creatable: onCreate persists the typed value instead of committing it", async () => {
+    const onCreate = vi.fn();
+    const onChange = vi.fn();
+    render(
+      <Combobox
+        options={options}
+        creatable
+        onCreate={onCreate}
+        onChange={onChange}
+      />,
+    );
+    const input = screen.getByRole("combobox");
+    await userEvent.click(input);
+    await userEvent.type(input, "Mango");
+    await userEvent.click(screen.getByRole("option", { name: /Mango/ }));
+    expect(onCreate).toHaveBeenCalledWith("Mango");
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   it("selects the active option with the keyboard", async () => {
     const onChange = vi.fn();
     render(<Combobox options={options} onChange={onChange} />);

--- a/packages/components/src/combobox/combobox.tsx
+++ b/packages/components/src/combobox/combobox.tsx
@@ -34,8 +34,6 @@ export type ComboboxProps = Omit<
   creating?: boolean;
 };
 
-const CREATE_SENTINEL = "__combobox_create__";
-
 function highlight(label: string, query: string) {
   if (!query) return label;
   const idx = label.toLowerCase().indexOf(query.toLowerCase());
@@ -152,13 +150,20 @@ const Combobox = React.forwardRef<HTMLDivElement, ComboboxProps>(
         (o) => o.label.toLowerCase() === trimmedQuery.toLowerCase(),
       );
     const createRow: ComboboxOption = {
-      value: CREATE_SENTINEL,
+      value: trimmedQuery,
       label: trimmedQuery,
       description: creating ? "Adding…" : "Add new",
     };
+    // Create row goes last so the default highlight (and Enter) prefer a real
+    // match over creating.
     const results: ComboboxOption[] = canCreate
-      ? [createRow, ...matches]
+      ? [...matches, createRow]
       : matches;
+
+    // Keep the active index in range as the result list changes size.
+    React.useEffect(() => {
+      setActive((a) => Math.min(a, Math.max(0, results.length - 1)));
+    }, [results.length]);
 
     const runCreate = async () => {
       if (creating) return;
@@ -173,7 +178,9 @@ const Combobox = React.forwardRef<HTMLDivElement, ComboboxProps>(
     };
 
     const commit = (opt: ComboboxOption) => {
-      if (opt.value === CREATE_SENTINEL) {
+      // Identity check (not a magic value) so a real option whose value happens
+      // to match the query can't be mistaken for the create row.
+      if (opt === createRow) {
         void runCreate();
         return;
       }
@@ -280,16 +287,16 @@ const Combobox = React.forwardRef<HTMLDivElement, ComboboxProps>(
               )}
               {results.map((opt, i) => {
                 const isActive = i === active;
-                const isCreate = opt.value === CREATE_SENTINEL;
+                const isCreate = opt === createRow;
                 const isSelected = !isCreate && opt.value === value;
                 return (
                   <motion.li
-                    key={opt.value}
+                    key={isCreate ? "__create_row__" : opt.value}
                     initial={reduceMotion ? false : { opacity: 0, y: 4 }}
                     animate={{ opacity: 1, y: 0 }}
                     transition={{ delay: reduceMotion ? 0 : i * 0.02 }}
                     role="option"
-                    aria-label={opt.label}
+                    aria-label={isCreate ? `Add ${opt.label}` : opt.label}
                     aria-selected={isSelected}
                     onMouseEnter={() => setActive(i)}
                     onClick={() => commit(opt)}

--- a/packages/components/src/combobox/combobox.tsx
+++ b/packages/components/src/combobox/combobox.tsx
@@ -24,7 +24,17 @@ export type ComboboxProps = Omit<
   /** Disable the input and prevent opening the listbox. */
   disabled?: boolean;
   onChange?: (value: string, option: ComboboxOption) => void;
+  /** Offer the typed value as an "Add …" row when it isn't already an option, so
+   *  free entry works alongside the suggestions. */
+  creatable?: boolean;
+  /** Persist a newly-typed value instead of committing a synthetic option.
+   *  Receives the trimmed label. */
+  onCreate?: (label: string) => void | Promise<void>;
+  /** Spinner + disabled state on the create row while a create is in flight. */
+  creating?: boolean;
 };
+
+const CREATE_SENTINEL = "__combobox_create__";
 
 function highlight(label: string, query: string) {
   if (!query) return label;
@@ -66,6 +76,9 @@ const Combobox = React.forwardRef<HTMLDivElement, ComboboxProps>(
       emptyMessage = "No results",
       disabled = false,
       onChange,
+      creatable = false,
+      onCreate,
+      creating = false,
       className,
       ...props
     },
@@ -123,13 +136,47 @@ const Combobox = React.forwardRef<HTMLDivElement, ComboboxProps>(
       return () => clearTimeout(t);
     }, [query, onSearch, open]);
 
-    const results = onSearch
+    const matches = onSearch
       ? asyncResults
       : allOptions.filter((o) =>
           o.label.toLowerCase().includes(query.toLowerCase()),
         );
 
+    // Creatable: offer the typed value as a "create" row when it isn't already
+    // an option, so free entry works alongside the suggestions.
+    const trimmedQuery = query.trim();
+    const canCreate =
+      creatable &&
+      trimmedQuery.length > 0 &&
+      !matches.some(
+        (o) => o.label.toLowerCase() === trimmedQuery.toLowerCase(),
+      );
+    const createRow: ComboboxOption = {
+      value: CREATE_SENTINEL,
+      label: trimmedQuery,
+      description: creating ? "Adding…" : "Add new",
+    };
+    const results: ComboboxOption[] = canCreate
+      ? [createRow, ...matches]
+      : matches;
+
+    const runCreate = async () => {
+      if (creating) return;
+      if (onCreate) {
+        await onCreate(trimmedQuery);
+        setQuery("");
+        setOpen(false);
+      } else {
+        // No handler: commit the typed value as a synthetic option.
+        commit({ value: trimmedQuery, label: trimmedQuery });
+      }
+    };
+
     const commit = (opt: ComboboxOption) => {
+      if (opt.value === CREATE_SENTINEL) {
+        void runCreate();
+        return;
+      }
       if (!isControlled) setInternal(opt.value);
       onChange?.(opt.value, opt);
       setQuery("");
@@ -153,14 +200,23 @@ const Combobox = React.forwardRef<HTMLDivElement, ComboboxProps>(
             aria-controls={listboxId}
             aria-autocomplete="list"
             disabled={disabled}
-            value={open ? query : (selectedOption?.label ?? query)}
+            value={
+              open
+                ? query
+                : (selectedOption?.label ?? (creatable ? (value ?? "") : query))
+            }
             placeholder={placeholder}
             onChange={(e) => {
               setQuery(e.target.value);
               setActive(0);
               setOpen(true);
             }}
-            onFocus={() => setOpen(true)}
+            onFocus={() => {
+              // Creatable fields are editable text: seed the query with the
+              // current value so focusing lets you edit rather than start blank.
+              if (creatable && !query && value) setQuery(value);
+              setOpen(true);
+            }}
             onKeyDown={(e) => {
               if (e.key === "ArrowDown") {
                 e.preventDefault();
@@ -224,7 +280,8 @@ const Combobox = React.forwardRef<HTMLDivElement, ComboboxProps>(
               )}
               {results.map((opt, i) => {
                 const isActive = i === active;
-                const isSelected = opt.value === value;
+                const isCreate = opt.value === CREATE_SENTINEL;
+                const isSelected = !isCreate && opt.value === value;
                 return (
                   <motion.li
                     key={opt.value}
@@ -241,7 +298,9 @@ const Combobox = React.forwardRef<HTMLDivElement, ComboboxProps>(
                     }`}
                   >
                     <span className="flex-1">
-                      <span className="block text-foreground">
+                      <span
+                        className={`block ${isCreate ? "text-primary" : "text-foreground"}`}
+                      >
                         {highlight(opt.label, query)}
                       </span>
                       {opt.description && (
@@ -250,6 +309,7 @@ const Combobox = React.forwardRef<HTMLDivElement, ComboboxProps>(
                         </span>
                       )}
                     </span>
+                    {isCreate && creating && Spinner}
                     {isSelected && (
                       <svg
                         aria-hidden="true"


### PR DESCRIPTION
## Summary

Adds an opt-in **creatable** mode. When the typed query doesn't match an option, the list offers an **"Add …"** row so free entry works alongside the suggestions. Additive — default behaviour is unchanged.

- `creatable` — enable the create row
- `onCreate(label)` — persist the new value yourself; without it, the typed value is committed as a synthetic option
- `creating` — show a spinner + disable the create row while a create is in flight

## Included

- Component: create row, `onCreate`/`creating`, focus seeds the query with the current value so a value is editable
- Storybook: **Creatable** story
- Docs: a "Creatable" example + props
- Tests: synthetic commit, and `onCreate` persists (without firing `onChange`)

## Notes

Presentational only — no new dependencies, no business logic.