### PR TITLE
feat(combobox): pinnedAction row at the top of the list

### DIFF
--- a/apps/docs/content/docs/components/navigation/combobox/index.mdx
+++ b/apps/docs/content/docs/components/navigation/combobox/index.mdx
@@ -3,7 +3,7 @@ title: Combobox
 description: A type-ahead autocomplete with staggered result reveal, highlighted matches, keyboard navigation, and an async loading state.
 ---
 
-import { ComboboxDemo, ComboboxAsyncDemo } from "@/components/demos/combobox-demo";
+import { ComboboxDemo, ComboboxAsyncDemo, ComboboxPinnedActionDemo } from "@/components/demos/combobox-demo";
 
 <ComponentPreview
   story="navigation-combobox"
@@ -95,6 +95,37 @@ export function DisabledPicker() {
   <ComboboxDemo disabled />
 </ComponentPreview>
 
+### Pinned action
+
+Pass `pinnedAction` to keep a persistent row at the top of the list — a place for a
+“manage” or “create” affordance that’s always reachable, whatever the query.
+
+<ComponentPreview
+  code={`"use client";
+import { Combobox } from "@/components/godui/combobox";
+import { useState } from "react";
+
+const people = [
+  { label: "Ada Lovelace", value: "ada" },
+  { label: "Grace Hopper", value: "grace" },
+];
+
+export function AssigneePicker() {
+  const [value, setValue] = useState("");
+  return (
+    <Combobox
+      options={people}
+      value={value}
+      onChange={setValue}
+      placeholder="Assign to…"
+      pinnedAction={{ label: "Manage team →", onSelect: () => {} }}
+    />
+  );
+}`}
+>
+  <ComboboxPinnedActionDemo />
+</ComponentPreview>
+
 ## Props
 
 | Prop | Type | Default | Description |
@@ -107,3 +138,4 @@ export function DisabledPicker() {
 | `emptyMessage` | `string` | `"No results"` | Shown when nothing matches |
 | `disabled` | `boolean` | `false` | Disables the input and prevents opening the listbox |
 | `onChange` | `(value, option) => void` | — | Called on selection |
+| `pinnedAction` | `ComboboxAction` | — | A persistent row (`{ label, onSelect }`) at the top of the list |

--- a/apps/docs/src/components/demos/combobox-demo.tsx
+++ b/apps/docs/src/components/demos/combobox-demo.tsx
@@ -100,3 +100,23 @@ export function ComboboxAsyncDemo() {
     </div>
   );
 }
+
+export function ComboboxPinnedActionDemo() {
+  const [value, setValue] = useState("");
+
+  return (
+    <div className="flex h-80 w-full max-w-sm flex-col gap-3 pt-2">
+      <span className="font-medium text-foreground text-sm">Assignee</span>
+      <Combobox
+        options={PEOPLE}
+        value={value}
+        onChange={setValue}
+        placeholder="Assign to…"
+        pinnedAction={{ label: "Manage team →", onSelect: () => {} }}
+      />
+      <p className="text-muted-foreground text-xs">
+        A pinned action stays at the top of the list, whatever the query.
+      </p>
+    </div>
+  );
+}

--- a/apps/storybook/src/stories/combobox.stories.tsx
+++ b/apps/storybook/src/stories/combobox.stories.tsx
@@ -52,3 +52,10 @@ export const Playground: Story = {};
 export const Disabled: Story = {
   args: { disabled: true },
 };
+
+/** A persistent action pinned to the top of the list. */
+export const PinnedAction: Story = {
+  args: {
+    pinnedAction: { label: "Manage frameworks →", onSelect: fn() },
+  },
+};

--- a/packages/components/src/combobox/combobox.test.tsx
+++ b/packages/components/src/combobox/combobox.test.tsx
@@ -34,6 +34,19 @@ describe("Combobox", () => {
     );
   });
 
+  it("pinnedAction: renders a persistent row and fires onSelect", async () => {
+    const onSelect = vi.fn();
+    render(
+      <Combobox
+        options={options}
+        pinnedAction={{ label: "Manage", onSelect }}
+      />,
+    );
+    await userEvent.click(screen.getByRole("combobox"));
+    await userEvent.click(screen.getByRole("button", { name: "Manage" }));
+    expect(onSelect).toHaveBeenCalled();
+  });
+
   it("selects the active option with the keyboard", async () => {
     const onChange = vi.fn();
     render(<Combobox options={options} onChange={onChange} />);

--- a/packages/components/src/combobox/combobox.tsx
+++ b/packages/components/src/combobox/combobox.tsx
@@ -9,6 +9,12 @@ export type ComboboxOption = {
   description?: string;
 };
 
+/** A non-option affordance rendered inside the listbox (e.g. a pinned foot/head row). */
+export type ComboboxAction = {
+  label: React.ReactNode;
+  onSelect: (query: string) => void;
+};
+
 export type ComboboxProps = Omit<
   React.HTMLAttributes<HTMLDivElement>,
   "onChange" | "defaultValue"
@@ -24,6 +30,9 @@ export type ComboboxProps = Omit<
   /** Disable the input and prevent opening the listbox. */
   disabled?: boolean;
   onChange?: (value: string, option: ComboboxOption) => void;
+  /** A persistent row shown at the top of the list — a place for a "manage" or
+   *  "create" affordance that's always reachable, whatever the query. */
+  pinnedAction?: ComboboxAction;
 };
 
 function highlight(label: string, query: string) {
@@ -66,6 +75,7 @@ const Combobox = React.forwardRef<HTMLDivElement, ComboboxProps>(
       emptyMessage = "No results",
       disabled = false,
       onChange,
+      pinnedAction,
       className,
       ...props
     },
@@ -217,6 +227,17 @@ const Combobox = React.forwardRef<HTMLDivElement, ComboboxProps>(
               transition={spring}
               className="absolute top-full left-0 z-popover mt-2 max-h-72 w-full origin-top overflow-y-auto rounded-xl border border-border bg-background p-1 shadow-xl"
             >
+              {pinnedAction && (
+                <li className="mb-1 border-border border-b pb-1">
+                  <button
+                    type="button"
+                    onClick={() => pinnedAction.onSelect(query.trim())}
+                    className="w-full rounded-lg px-3 py-2 text-left font-medium text-primary text-sm hover:bg-accent"
+                  >
+                    {pinnedAction.label}
+                  </button>
+                </li>
+              )}
               {!loading && results.length === 0 && (
                 <li className="px-3 py-6 text-center text-muted-foreground text-sm">
                   {emptyMessage}


### PR DESCRIPTION
## Summary

Adds an optional **`pinnedAction`** — a persistent row pinned to the **top** of the listbox (with a divider), for a "manage" or "create" affordance that stays reachable whatever the query.

- `pinnedAction: { label, onSelect }` — `onSelect` receives the current (trimmed) query
- Exports a small `ComboboxAction` type (`{ label, onSelect }`)

## Included

- Component: the pinned row + `ComboboxAction` type
- Storybook: **PinnedAction** story
- Docs: a "Pinned action" example + props
- Tests: renders the row and fires `onSelect`

## Notes

Additive and presentational — no new dependencies, no business logic.