### PR TITLE
feat(combobox): emptyAction CTA in the empty state

### DIFF
--- a/apps/docs/content/docs/components/navigation/combobox/index.mdx
+++ b/apps/docs/content/docs/components/navigation/combobox/index.mdx
@@ -3,7 +3,7 @@ title: Combobox
 description: A type-ahead autocomplete with staggered result reveal, highlighted matches, keyboard navigation, and an async loading state.
 ---
 
-import { ComboboxDemo, ComboboxAsyncDemo } from "@/components/demos/combobox-demo";
+import { ComboboxDemo, ComboboxAsyncDemo, ComboboxEmptyActionDemo } from "@/components/demos/combobox-demo";
 
 <ComponentPreview
   story="navigation-combobox"
@@ -95,6 +95,38 @@ export function DisabledPicker() {
   <ComboboxDemo disabled />
 </ComponentPreview>
 
+### Empty-state action
+
+Pass `emptyAction` to show a call-to-action when nothing matches — for example, to
+invite or create the thing the user was searching for.
+
+<ComponentPreview
+  code={`"use client";
+import { Combobox } from "@/components/godui/combobox";
+import { useState } from "react";
+
+const people = [
+  { label: "Ada Lovelace", value: "ada" },
+  { label: "Grace Hopper", value: "grace" },
+];
+
+export function AssigneePicker() {
+  const [value, setValue] = useState("");
+  return (
+    <Combobox
+      options={people}
+      value={value}
+      onChange={setValue}
+      placeholder="Assign to…"
+      emptyMessage="No teammates found"
+      emptyAction={{ label: "Invite someone", onSelect: () => {} }}
+    />
+  );
+}`}
+>
+  <ComboboxEmptyActionDemo />
+</ComponentPreview>
+
 ## Props
 
 | Prop | Type | Default | Description |
@@ -107,3 +139,4 @@ export function DisabledPicker() {
 | `emptyMessage` | `string` | `"No results"` | Shown when nothing matches |
 | `disabled` | `boolean` | `false` | Disables the input and prevents opening the listbox |
 | `onChange` | `(value, option) => void` | — | Called on selection |
+| `emptyAction` | `ComboboxAction` | — | A CTA button (`{ label, onSelect }`) shown in the empty state |

--- a/apps/docs/src/components/demos/combobox-demo.tsx
+++ b/apps/docs/src/components/demos/combobox-demo.tsx
@@ -100,3 +100,24 @@ export function ComboboxAsyncDemo() {
     </div>
   );
 }
+
+export function ComboboxEmptyActionDemo() {
+  const [value, setValue] = useState("");
+
+  return (
+    <div className="flex h-80 w-full max-w-sm flex-col gap-3 pt-2">
+      <span className="font-medium text-foreground text-sm">Assignee</span>
+      <Combobox
+        options={PEOPLE}
+        value={value}
+        onChange={setValue}
+        placeholder="Assign to…"
+        emptyMessage="No teammates found"
+        emptyAction={{ label: "Invite someone", onSelect: () => {} }}
+      />
+      <p className="text-muted-foreground text-xs">
+        Type a name with no match to reveal the empty-state action.
+      </p>
+    </div>
+  );
+}

--- a/apps/storybook/src/stories/combobox.stories.tsx
+++ b/apps/storybook/src/stories/combobox.stories.tsx
@@ -52,3 +52,11 @@ export const Playground: Story = {};
 export const Disabled: Story = {
   args: { disabled: true },
 };
+
+/** A call-to-action shown in the empty state (type something with no match). */
+export const EmptyStateAction: Story = {
+  args: {
+    emptyMessage: "No frameworks found",
+    emptyAction: { label: "Request a framework", onSelect: fn() },
+  },
+};

--- a/packages/components/src/combobox/combobox.test.tsx
+++ b/packages/components/src/combobox/combobox.test.tsx
@@ -34,6 +34,23 @@ describe("Combobox", () => {
     );
   });
 
+  it("emptyAction: shows a CTA in the empty state and fires onSelect", async () => {
+    const onSelect = vi.fn();
+    render(
+      <Combobox
+        options={options}
+        emptyAction={{ label: "Invite someone", onSelect }}
+      />,
+    );
+    const input = screen.getByRole("combobox");
+    await userEvent.click(input);
+    await userEvent.type(input, "zzz");
+    await userEvent.click(
+      screen.getByRole("button", { name: "Invite someone" }),
+    );
+    expect(onSelect).toHaveBeenCalledWith("zzz");
+  });
+
   it("selects the active option with the keyboard", async () => {
     const onChange = vi.fn();
     render(<Combobox options={options} onChange={onChange} />);

--- a/packages/components/src/combobox/combobox.tsx
+++ b/packages/components/src/combobox/combobox.tsx
@@ -9,6 +9,12 @@ export type ComboboxOption = {
   description?: string;
 };
 
+/** A non-option affordance rendered inside the listbox (e.g. an empty-state CTA). */
+export type ComboboxAction = {
+  label: React.ReactNode;
+  onSelect: (query: string) => void;
+};
+
 export type ComboboxProps = Omit<
   React.HTMLAttributes<HTMLDivElement>,
   "onChange" | "defaultValue"
@@ -24,6 +30,9 @@ export type ComboboxProps = Omit<
   /** Disable the input and prevent opening the listbox. */
   disabled?: boolean;
   onChange?: (value: string, option: ComboboxOption) => void;
+  /** A call-to-action button shown in the empty state — e.g. to create or invite
+   *  the thing the user was searching for. */
+  emptyAction?: ComboboxAction;
 };
 
 function highlight(label: string, query: string) {
@@ -66,6 +75,7 @@ const Combobox = React.forwardRef<HTMLDivElement, ComboboxProps>(
       emptyMessage = "No results",
       disabled = false,
       onChange,
+      emptyAction,
       className,
       ...props
     },
@@ -219,7 +229,16 @@ const Combobox = React.forwardRef<HTMLDivElement, ComboboxProps>(
             >
               {!loading && results.length === 0 && (
                 <li className="px-3 py-6 text-center text-muted-foreground text-sm">
-                  {emptyMessage}
+                  <div>{emptyMessage}</div>
+                  {emptyAction && (
+                    <button
+                      type="button"
+                      onClick={() => emptyAction.onSelect(query.trim())}
+                      className="mt-2 rounded-lg px-3 py-1.5 font-medium text-primary text-sm hover:bg-accent"
+                    >
+                      {emptyAction.label}
+                    </button>
+                  )}
                 </li>
               )}
               {results.map((opt, i) => {


### PR DESCRIPTION
## Summary

Adds an optional **`emptyAction`** — a call-to-action button shown in the empty state, for example to create or invite the thing the user was searching for.

- `emptyAction: { label, onSelect }` — `onSelect` receives the current (trimmed) query
- Exports a small `ComboboxAction` type (`{ label, onSelect }`)

## Included

- Component: the empty-state CTA + `ComboboxAction` type
- Storybook: **EmptyStateAction** story
- Docs: an "Empty-state action" example + props
- Tests: shows the CTA when nothing matches and fires `onSelect` with the query

## Notes

Additive and presentational — no new dependencies, no business logic.