### PR TITLE
fix(docs): make badge tooltips tappable on mobile + fix Motion Score table layout

### DIFF
--- a/apps/docs/src/components/component-badges.tsx
+++ b/apps/docs/src/components/component-badges.tsx
@@ -53,11 +53,38 @@ function Badge({
 }) {
   const id = React.useId();
   const external = href?.startsWith("http");
+  // Touch devices have no hover, and tapping a button doesn't reliably focus it
+  // (iOS Safari), so the hover/focus-only tooltip never appeared on mobile. Tap
+  // toggles it open; an outside tap or Escape closes it.
+  const [open, setOpen] = React.useState(false);
+  const wrapRef = React.useRef<HTMLSpanElement>(null);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: PointerEvent) => {
+      if (!wrapRef.current?.contains(event.target as Node)) setOpen(false);
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open]);
+
   return (
-    <span className="group/badge relative inline-flex align-middle">
+    <span
+      ref={wrapRef}
+      className="group/badge relative inline-flex align-middle"
+    >
       <button
         type="button"
         aria-describedby={id}
+        aria-expanded={open}
+        onClick={() => setOpen((prev) => !prev)}
         className={`inline-flex cursor-help items-center gap-1.5 rounded-full px-2 py-0.5 font-medium text-[11px] uppercase leading-none tracking-wide ring-1 transition-colors focus:outline-none focus-visible:ring-2 ${TONE[tone].pill}`}
       >
         <span
@@ -71,7 +98,7 @@ function Badge({
       <span
         role="tooltip"
         id={id}
-        className={`pointer-events-none absolute top-full left-0 z-50 w-72 max-w-[min(18rem,80vw)] pt-2 text-left opacity-0 transition-opacity duration-150 group-hover/badge:opacity-100 group-focus-within/badge:opacity-100 ${href ? "group-hover/badge:pointer-events-auto group-focus-within/badge:pointer-events-auto" : ""}`}
+        className={`pointer-events-none absolute top-full left-0 z-50 w-72 max-w-[min(18rem,80vw)] pt-2 text-left opacity-0 transition-opacity duration-150 group-hover/badge:opacity-100 group-focus-within/badge:opacity-100 ${open ? "opacity-100" : ""} ${href ? "group-hover/badge:pointer-events-auto group-focus-within/badge:pointer-events-auto" : ""} ${open && href ? "pointer-events-auto" : ""}`}
       >
         <span className="block rounded-lg border border-border bg-popover px-3 py-2.5 font-normal text-[13px] text-popover-foreground normal-case leading-relaxed tracking-normal shadow-lg">
           <span className="mb-0.5 block font-semibold text-foreground">

--- a/apps/docs/src/components/learn/motion-score-panel.tsx
+++ b/apps/docs/src/components/learn/motion-score-panel.tsx
@@ -50,7 +50,7 @@ function TierChip({ grade, size }: { grade: MotionGrade; size: "sm" | "md" }) {
 
 function Pill({ children }: { children: ReactNode }) {
   return (
-    <span className="ml-3 shrink-0 self-center whitespace-nowrap rounded-full bg-violet-400/20 px-2 py-0.5 font-medium text-[10px] text-violet-700 uppercase tracking-wide dark:text-violet-300">
+    <span className="ml-3 hidden shrink-0 self-center whitespace-nowrap rounded-full bg-violet-400/20 px-2 py-0.5 font-medium text-[10px] text-violet-700 uppercase tracking-wide sm:inline-block dark:text-violet-300">
       {children}
     </span>
   );
@@ -90,7 +90,7 @@ export function MotionScorePanel({ name }: { name: string }) {
               className="flex items-center gap-3 px-4 py-2.5"
             >
               <TierChip grade={tier} size="sm" />
-              <code className="w-[8.5rem] shrink-0 font-mono text-[13px] text-foreground sm:w-44">
+              <code className="w-20 shrink-0 font-mono text-[13px] text-foreground sm:w-44">
                 {a.label}
               </code>
               <span className="min-w-0 flex-1 text-[12.5px] text-fd-muted-foreground leading-snug">


### PR DESCRIPTION
## Description

Two mobile fixes for the component docs.

1. Badge tooltips (the row above a component title) never appeared on mobile. Touch devices have no hover, and tapping a button doesn't reliably focus it, so the hover/focus-only tooltip stayed hidden.
2. The Motion Score table on the Learn tab was cramped on narrow screens: the fixed-width property column squeezed the note column down to one word per line.

## Type of change

- [x] 🐛 Bug fix (non-breaking change fixing an issue)
- [x] 🎨 Style / design polish

## Changes made

- Badge tooltip: tap now toggles it open; an outside tap or Escape closes it (`aria-expanded` reflects state). Hover and keyboard focus still work on desktop.
- Motion Score panel: narrow the property column on mobile (`w-[8.5rem]` → `w-20`, `sm:w-44` unchanged) and hide the "Worst → grade" pill below `sm`, giving the note column room to wrap normally.

## How to test

1. `pnpm dev`, open `/docs/components/buttons/jelly-button` on a narrow viewport.
2. Tap the "Motion S" badge above the title — the tooltip appears; tap outside to close.
3. Open the Learn tab and scroll to the Motion Score panel — the note column reads cleanly, the pill is hidden on mobile.

## Screenshots / recordings

Verified via CDP at 390px (touch emulation): tapping the badge takes the tooltip opacity `0 → 1`, an outside tap returns it to `0`. Table: pill `display:none` on mobile, note column width `40px → 196px`.

## Checklist

- [x] `pnpm check` passes (Biome) on the changed files
- [x] `tsc --noEmit` clean (apps/docs)
- [x] Self-reviewed the diff; no stray logs or dead code