### PR TITLE
fix(docs): make the open badge tooltip link tappable on mobile

### DIFF
--- a/apps/docs/src/components/component-badges.tsx
+++ b/apps/docs/src/components/component-badges.tsx
@@ -98,7 +98,12 @@ function Badge({
       <span
         role="tooltip"
         id={id}
-        className={`pointer-events-none absolute top-full left-0 z-50 w-72 max-w-[min(18rem,80vw)] pt-2 text-left opacity-0 transition-opacity duration-150 group-hover/badge:opacity-100 group-focus-within/badge:opacity-100 ${open ? "opacity-100" : ""} ${href ? "group-hover/badge:pointer-events-auto group-focus-within/badge:pointer-events-auto" : ""} ${open && href ? "pointer-events-auto" : ""}`}
+        // While tapped-open, force pointer events on inline: a base
+        // `pointer-events-auto` utility loses to the base `pointer-events-none`
+        // by stylesheet order, which left the open tooltip (and its link)
+        // untappable, so a tap fell through and closed it. Inline wins reliably.
+        style={open ? { pointerEvents: "auto" } : undefined}
+        className={`pointer-events-none absolute top-full left-0 z-50 w-72 max-w-[min(18rem,80vw)] pt-2 text-left opacity-0 transition-opacity duration-150 group-hover/badge:opacity-100 group-focus-within/badge:opacity-100 ${open ? "opacity-100" : ""} ${href ? "group-hover/badge:pointer-events-auto group-focus-within/badge:pointer-events-auto" : ""}`}
       >
         <span className="block rounded-lg border border-border bg-popover px-3 py-2.5 font-normal text-[13px] text-popover-foreground normal-case leading-relaxed tracking-normal shadow-lg">
           <span className="mb-0.5 block font-semibold text-foreground">


### PR DESCRIPTION
## Description

After the badge tooltip became tap-to-open on mobile, tapping the "Motion Score table" link inside it closed the tooltip instead of navigating. When tapped open, the tooltip's pointer events came from a base `pointer-events-auto` utility, which loses to the base `pointer-events-none` by Tailwind's stylesheet order. The tooltip (and its link) stayed non-interactive, so the tap fell through to the page and the outside-tap handler closed it.

## Type of change

- [x] 🐛 Bug fix (non-breaking change fixing an issue)

## Changes made

- Force `pointer-events: auto` via inline style while the tooltip is open, so it beats the class-order conflict reliably. Desktop hover/focus variant classes are unchanged.

## How to test

1. `pnpm dev`, open `/docs/components/buttons/jelly-button` on a narrow viewport.
2. Tap the "Motion S" badge above the title to open its tooltip.
3. Tap the "Motion Score table" link inside — it navigates to the Learn page instead of closing.

## Screenshots / recordings

Verified via CDP at 390px (touch emulation): with the tooltip open, the link resolves `pointer-events: auto`, and tapping it navigates from `/docs/components/buttons/jelly-button` to `/docs/components/buttons/jelly-button/learn#motion-score`.

## Checklist

- [x] `pnpm check` passes (Biome) on the changed file
- [x] `tsc --noEmit` clean (apps/docs)
- [x] Self-reviewed the diff; no stray logs or dead code