### PR TITLE
feat(docs): full-bleed Workbench layout for component pages

### DIFF
--- a/apps/docs/content/docs/components/ai/agent-flow/index.mdx
+++ b/apps/docs/content/docs/components/ai/agent-flow/index.mdx
@@ -2,12 +2,18 @@
 title: Agent Flow
 description: A draggable, pannable node-graph that visualizes an agent workflow — labelled nodes with live run status and data packets that flow along the edges between them.
 date: "2026-07-12"
+workbench: true
 ---
 
 import { AgentFlowDemo } from "@/components/demos/agent-flow-demo";
 import { AgentFlowPersistDemo } from "@/components/demos/agent-flow-persist-demo";
 
-<ComponentPreview
+<Workbench>
+
+A draggable, pannable node-graph that visualizes an agent workflow — labelled nodes with live run status and data packets that flow along the edges between them.
+
+<Example
+  label="Default"
   story="ai-agentflow"
   fullWidth
   code={`import { AgentFlow, type AgentFlowNode, type AgentFlowEdge } from "@/components/godui/agent-flow";
@@ -35,7 +41,7 @@ export function AgentFlowDemo() {
 }`}
 >
   <AgentFlowDemo />
-</ComponentPreview>
+</Example>
 
 With `autoPlay`, the graph plays as one continuous light: each node traces its
 border on — growing from the left-edge centre out to both sides — then its icon
@@ -94,7 +100,8 @@ Mark an edge `persist` and its line draws on as the packet travels and then
 reads as an established connection, so the whole traversed route glows once the
 flow reaches the end.
 
-<ComponentPreview
+<Example
+  label="Persistent Edges"
   story="ai-agentflow"
   fullWidth
   code={`const edges: AgentFlowEdge[] = [
@@ -111,7 +118,7 @@ export function AgentFlowPersistDemo() {
 }`}
 >
   <AgentFlowPersistDemo />
-</ComponentPreview>
+</Example>
 
 ## Driving it yourself
 
@@ -171,3 +178,5 @@ const [arrived, setArrived] = useState(new Set<string>());
 | `loop`      | `boolean` | `true`  | Repeat the packet forever. `false` sends one packet that fires `onEdgeArrive` on landing. |
 | `persist`   | `boolean` | `false` | Keep the line lit after its packet passes — draws on like a card's border and stays. |
 | `curvature` | `number`  | `0`     | Bow of the curve in pixels (positive = upward). |
+
+</Workbench>

--- a/apps/docs/content/docs/components/ai/agent-timeline/index.mdx
+++ b/apps/docs/content/docs/components/ai/agent-timeline/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Agent Timeline
 description: A vertical timeline of agent steps with live status, a spring-filled connector, and collapsible reasoning or tool-output bodies that morph open.
+workbench: true
 ---
 
 import { AgentTimelineDemo } from "@/components/demos/agent-timeline-demo";
 
-<ComponentPreview
+<Workbench>
+
+A vertical timeline of agent steps with live status, a spring-filled connector, and collapsible reasoning or tool-output bodies that morph open.
+
+<Example
+  label="Default"
   story="ai-agenttimeline"
   code={`import { AgentTimeline, AgentStep } from "@/components/godui/agent-timeline";
 
@@ -24,7 +30,7 @@ export function AgentTimelineDemo() {
 }`}
 >
   <AgentTimelineDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -62,3 +68,5 @@ import { AgentTimeline, AgentStep } from "@/components/godui/agent-timeline";
 | `children`    | `ReactNode`                                       | —         | Collapsible body. Omit for a leaf step.   |
 | `defaultOpen` | `boolean`                                         | `false`   | Start expanded.                           |
 | `last`        | `boolean`                                         | `false`   | Hides the connector below the step.       |
+
+</Workbench>

--- a/apps/docs/content/docs/components/ai/conversation-thread/index.mdx
+++ b/apps/docs/content/docs/components/ai/conversation-thread/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Conversation Thread
 description: A streaming AI chat surface — messages spring in, tokens reveal with a blinking caret, hover actions fade in, and the view auto-sticks to the latest message.
+workbench: true
 ---
 
 import { ConversationThreadDemo } from "@/components/demos/conversation-thread-demo";
 
-<ComponentPreview
+<Workbench>
+
+A streaming AI chat surface — messages spring in, tokens reveal with a blinking caret, hover actions fade in, and the view auto-sticks to the latest message.
+
+<Example
+  label="Default"
   story="ai-conversationthread"
   code={`import {
   ConversationThread,
@@ -27,7 +33,7 @@ export function ConversationThreadDemo() {
 }`}
 >
   <ConversationThreadDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -91,3 +97,5 @@ import {
 | `chunk`  | `number`     | `2`     | Characters revealed per tick.        |
 | `speed`  | `number`     | `24`    | Milliseconds between ticks.          |
 | `onDone` | `() => void` | —       | Fired when the full text is shown.   |
+
+</Workbench>

--- a/apps/docs/content/docs/components/ai/prompt-composer/index.mdx
+++ b/apps/docs/content/docs/components/ai/prompt-composer/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Prompt Composer
 description: An AI input box with auto-growing textarea, attachment chips, an inline model picker, and a send button that morphs into a stop control while streaming.
+workbench: true
 ---
 
 import { PromptComposerDemo } from "@/components/demos/prompt-composer-demo";
 
-<ComponentPreview
+<Workbench>
+
+An AI input box with auto-growing textarea, attachment chips, an inline model picker, and a send button that morphs into a stop control while streaming.
+
+<Example
+  label="Default"
   story="ai-promptcomposer"
   code={`import { PromptComposer } from "@/components/godui/prompt-composer";
 import { useState } from "react";
@@ -28,7 +34,7 @@ export function PromptComposerDemo() {
 }`}
 >
   <PromptComposerDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -76,3 +82,5 @@ const [value, setValue] = useState("");
 | `models`              | `string[]`                                    | —                | Enables the inline model picker.                   |
 | `model`               | `string`                                      | —                | Selected model.                                    |
 | `onModelChange`       | `(model: string) => void`                     | —                | Fired when a model is chosen.                      |
+
+</Workbench>

--- a/apps/docs/content/docs/components/ai/prompt-suggestions/index.mdx
+++ b/apps/docs/content/docs/components/ai/prompt-suggestions/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Prompt Suggestions
 description: Animated starter prompts for AI empty states — cards stagger in, lift on hover, and feed straight into the composer when chosen.
+workbench: true
 ---
 
 import { PromptSuggestionsDemo } from "@/components/demos/prompt-suggestions-demo";
 
-<ComponentPreview
+<Workbench>
+
+Animated starter prompts for AI empty states — cards stagger in, lift on hover, and feed straight into the composer when chosen.
+
+<Example
+  label="Default"
   story="ai-promptsuggestions"
   code={`import { PromptSuggestions } from "@/components/godui/prompt-suggestions";
 
@@ -25,7 +31,7 @@ export function PromptSuggestionsDemo() {
 }`}
 >
   <PromptSuggestionsDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -58,3 +64,5 @@ import { PromptSuggestions } from "@/components/godui/prompt-suggestions";
 | `variant`       | `"grid" \| "chips" \| "list"`     | `"grid"` | Layout style.                        |
 | `loading`       | `boolean`                         | `false`  | Render shimmer skeletons.            |
 | `skeletonCount` | `number`                          | `4`      | Skeletons shown while loading.       |
+
+</Workbench>

--- a/apps/docs/content/docs/components/ai/source-citations/index.mdx
+++ b/apps/docs/content/docs/components/ai/source-citations/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Source Citations
 description: Inline numbered citation pills that spring out a rich preview card on hover, plus a collapsible source list for AI answers.
+workbench: true
 ---
 
 import { SourceCitationsDemo } from "@/components/demos/source-citations-demo";
 
-<ComponentPreview
+<Workbench>
+
+Inline numbered citation pills that spring out a rich preview card on hover, plus a collapsible source list for AI answers.
+
+<Example
+  label="Default"
   story="ai-sourcecitations"
   code={`import {
   SourceCitation,
@@ -31,7 +37,7 @@ export function SourceCitationsDemo() {
 }`}
 >
   <SourceCitationsDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -74,3 +80,5 @@ import {
 | `sources`      | `CitationSource[]` | —       | Sources to list.                     |
 | `collapsible`  | `boolean`          | `true`  | Collapse extras behind a toggle.     |
 | `previewCount` | `number`           | `3`     | Shown before **+N more**.            |
+
+</Workbench>

--- a/apps/docs/content/docs/components/ai/voice-orb/index.mdx
+++ b/apps/docs/content/docs/components/ai/voice-orb/index.mdx
@@ -1,12 +1,18 @@
 ---
 title: Voice Orb
 description: A Siri-style audio-reactive orb that breathes when idle, pulses while listening, and swells with the voice as it speaks.
+workbench: true
 ---
 
 import { VoiceOrb } from "@godui/components";
 import { VoiceOrbDemo } from "@/components/demos/voice-orb-demo";
 
-<ComponentPreview
+<Workbench>
+
+A Siri-style audio-reactive orb that breathes when idle, pulses while listening, and swells with the voice as it speaks.
+
+<Example
+  label="Default"
   story="ai-voice-orb"
   code={`import { VoiceOrb, useAudioAmplitude } from "@/components/godui/voice-orb";
 import { useState } from "react";
@@ -19,7 +25,7 @@ export function VoiceOrbDemo() {
 }`}
 >
   <VoiceOrbDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -59,3 +65,5 @@ output level from your TTS / realtime stream.
 | `size`      | `number`                                | `160`    | Diameter in pixels.                                    |
 
 `VoiceOrb` also forwards every standard `<div>` attribute to the root element.
+
+</Workbench>

--- a/apps/docs/content/docs/components/backgrounds/blueprint-grid/index.mdx
+++ b/apps/docs/content/docs/components/backgrounds/blueprint-grid/index.mdx
@@ -1,16 +1,20 @@
 ---
 title: Blueprint Grid
 description: A technical lattice — lines, dots, or a perspective floor — with a light sweep and cursor spotlight.
+workbench: true
 ---
 
 import { BlueprintGrid } from "@godui/components";
+
+<Workbench>
 
 The engineering-blueprint backdrop: a precise lattice with a diagonal light
 sweep traveling across it and a soft spotlight that follows the cursor. Choose
 ruled `lines`, a `dots` matrix, or a floor-fading `perspective` grid. Pure CSS.
 Drop it as the first child of a `relative overflow-hidden` container.
 
-<ComponentPreview
+<Example
+  label="Default"
   fullWidth
   story="backgrounds-blueprint-grid"
   code={`import { BlueprintGrid } from "@/components/godui/blueprint-grid";
@@ -34,7 +38,7 @@ export function BlueprintGridDemo() {
       <p className="mt-2 text-muted-foreground">Move your cursor across the grid.</p>
     </div>
   </div>
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -59,7 +63,8 @@ content at `z-raised`+. Color defaults to `--color-border`. The sweep hides unde
 
 ### Dots
 
-<ComponentPreview
+<Example
+  label="Dots"
   fullWidth
   code={`import { BlueprintGrid } from "@/components/godui/blueprint-grid";
 
@@ -74,11 +79,12 @@ export function BlueprintGridDots() {
   <div className="relative w-full flex-1 overflow-hidden bg-background">
     <BlueprintGrid variant="dots" />
   </div>
-</ComponentPreview>
+</Example>
 
 ### Perspective
 
-<ComponentPreview
+<Example
+  label="Perspective"
   fullWidth
   code={`import { BlueprintGrid } from "@/components/godui/blueprint-grid";
 
@@ -93,7 +99,7 @@ export function BlueprintGridPerspective() {
   <div className="relative w-full flex-1 overflow-hidden bg-background">
     <BlueprintGrid variant="perspective" color="#6366f1" />
   </div>
-</ComponentPreview>
+</Example>
 
 ## Props
 
@@ -109,3 +115,5 @@ export function BlueprintGridPerspective() {
 | `spotlightRadius` | `number` | `200` | Spotlight radius (px). |
 
 Also accepts standard `div` attributes (e.g. `className`, `style`).
+
+</Workbench>

--- a/apps/docs/content/docs/components/backgrounds/decorative-background/index.mdx
+++ b/apps/docs/content/docs/components/backgrounds/decorative-background/index.mdx
@@ -12,8 +12,12 @@ container and your content sits above it. Pick a look below — 44 patterns port
 `backgroundImage`, and `backgroundSize`; the picker fills them in.
 
 <Example label="Default" fullWidth>
-  <BackgroundShowcase component="decorative" />
+  <BackgroundShowcase component="decorative" embedded />
 </Example>
+
+## Installation
+
+<ComponentInstall name="decorative-background" />
 
 ## Usage
 

--- a/apps/docs/content/docs/components/backgrounds/decorative-background/index.mdx
+++ b/apps/docs/content/docs/components/backgrounds/decorative-background/index.mdx
@@ -1,14 +1,19 @@
 ---
 title: Decorative Background
 description: Full-bleed decorative backgrounds — radial and corner gradient washes.
+workbench: true
 ---
+
+<Workbench>
 
 A full-bleed decorative wash. Drop it as the first child of a `relative overflow-hidden`
 container and your content sits above it. Pick a look below — 44 patterns ported from
 [PatternCraft](https://patterncraft.fun). The component itself just takes `background`,
 `backgroundImage`, and `backgroundSize`; the picker fills them in.
 
-<BackgroundShowcase component="decorative" />
+<Example label="Default" fullWidth>
+  <BackgroundShowcase component="decorative" />
+</Example>
 
 ## Usage
 
@@ -32,3 +37,5 @@ just the standard `div` attributes.
 | `className` | `string` | Extra classes on the layer (it is `absolute inset-0 z-base`). |
 
 All other `div` attributes are forwarded.
+
+</Workbench>

--- a/apps/docs/content/docs/components/backgrounds/effect-background/index.mdx
+++ b/apps/docs/content/docs/components/backgrounds/effect-background/index.mdx
@@ -12,8 +12,12 @@ container and your content sits above it. Pick a look below — 66 patterns port
 `backgroundImage`, and `backgroundSize`; the picker fills them in.
 
 <Example label="Default" fullWidth>
-  <BackgroundShowcase component="effect" />
+  <BackgroundShowcase component="effect" embedded />
 </Example>
+
+## Installation
+
+<ComponentInstall name="effect-background" />
 
 ## Usage
 

--- a/apps/docs/content/docs/components/backgrounds/effect-background/index.mdx
+++ b/apps/docs/content/docs/components/backgrounds/effect-background/index.mdx
@@ -1,14 +1,19 @@
 ---
 title: Effect Background
 description: Full-bleed effect backgrounds — radial glows, aurora dreams, and soft pastel washes.
+workbench: true
 ---
+
+<Workbench>
 
 A full-bleed atmospheric layer. Drop it as the first child of a `relative overflow-hidden`
 container and your content sits above it. Pick a look below — 66 patterns ported from
 [PatternCraft](https://patterncraft.fun). The component itself just takes `background`,
 `backgroundImage`, and `backgroundSize`; the picker fills them in.
 
-<BackgroundShowcase component="effect" />
+<Example label="Default" fullWidth>
+  <BackgroundShowcase component="effect" />
+</Example>
 
 ## Usage
 
@@ -32,3 +37,5 @@ just the standard `div` attributes.
 | `className` | `string` | Extra classes on the layer (it is `absolute inset-0 z-base`). |
 
 All other `div` attributes are forwarded.
+
+</Workbench>

--- a/apps/docs/content/docs/components/backgrounds/flow-field/index.mdx
+++ b/apps/docs/content/docs/components/backgrounds/flow-field/index.mdx
@@ -1,16 +1,20 @@
 ---
 title: Flow Field
 description: Particles streaming along an evolving noise vector field, leaving silky fading trails.
+workbench: true
 ---
 
 import { FlowField } from "@godui/components";
+
+<Workbench>
 
 Hundreds of particles ride an invisible, slowly-evolving current, leaving silky
 trails that fade behind them — generative, organic, hypnotic. It paints its own
 themed background, so drop it as the first child of a `relative` container and
 let your content sit above it.
 
-<ComponentPreview
+<Example
+  label="Default"
   fullWidth
   story="backgrounds-flow-field"
   code={`import { FlowField } from "@/components/godui/flow-field";
@@ -34,7 +38,7 @@ export function FlowFieldDemo() {
       <p className="mt-2 text-muted-foreground">Currents you never see twice.</p>
     </div>
   </div>
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -63,7 +67,8 @@ trails in `color` (default `--color-primary`); both track light/dark. Caps DPR a
 
 Lower `fade` for longer, silkier streaks.
 
-<ComponentPreview
+<Example
+  label="Long Trails"
   fullWidth
   code={`import { FlowField } from "@/components/godui/flow-field";
 
@@ -78,7 +83,7 @@ export function FlowFieldLong() {
   <div className="relative w-full flex-1 overflow-hidden">
     <FlowField fade={0.02} speed={1.2} />
   </div>
-</ComponentPreview>
+</Example>
 
 ## Props
 
@@ -91,3 +96,5 @@ export function FlowFieldLong() {
 | `fade` | `number` | `0.06` | Trail fade per frame, `0`–`1` (lower = longer trails). |
 
 Also accepts standard `div` attributes (e.g. `className`, `style`).
+
+</Workbench>

--- a/apps/docs/content/docs/components/backgrounds/geometric-background/index.mdx
+++ b/apps/docs/content/docs/components/backgrounds/geometric-background/index.mdx
@@ -12,8 +12,12 @@ container and your content sits above it. Pick a look below — 99 patterns port
 `backgroundImage`, and `backgroundSize`; the picker fills them in.
 
 <Example label="Default" fullWidth>
-  <BackgroundShowcase component="geometric" />
+  <BackgroundShowcase component="geometric" embedded />
 </Example>
+
+## Installation
+
+<ComponentInstall name="geometric-background" />
 
 ## Usage
 

--- a/apps/docs/content/docs/components/backgrounds/geometric-background/index.mdx
+++ b/apps/docs/content/docs/components/backgrounds/geometric-background/index.mdx
@@ -1,14 +1,19 @@
 ---
 title: Geometric Background
 description: Full-bleed geometric backgrounds — grids, dashed grids, diagonal crosses, and masked fades.
+workbench: true
 ---
+
+<Workbench>
 
 A full-bleed geometric layer. Drop it as the first child of a `relative overflow-hidden`
 container and your content sits above it. Pick a look below — 99 patterns ported from
 [PatternCraft](https://patterncraft.fun). The component itself just takes `background`,
 `backgroundImage`, and `backgroundSize`; the picker fills them in.
 
-<BackgroundShowcase component="geometric" />
+<Example label="Default" fullWidth>
+  <BackgroundShowcase component="geometric" />
+</Example>
 
 ## Usage
 
@@ -32,3 +37,5 @@ just the standard `div` attributes.
 | `className` | `string` | Extra classes on the layer (it is `absolute inset-0 z-base`). |
 
 All other `div` attributes are forwarded.
+
+</Workbench>

--- a/apps/docs/content/docs/components/backgrounds/gradient-background/index.mdx
+++ b/apps/docs/content/docs/components/backgrounds/gradient-background/index.mdx
@@ -1,14 +1,19 @@
 ---
 title: Gradient Background
 description: Full-bleed gradient backgrounds — radial glows, aurora washes, and depth fades.
+workbench: true
 ---
+
+<Workbench>
 
 A full-bleed gradient layer. Drop it as the first child of a `relative overflow-hidden`
 container and your content sits above it. Pick a look below — 48 gradients ported from
 [PatternCraft](https://patterncraft.fun). The component itself just takes `background`,
 `backgroundImage`, and `backgroundSize`; the picker fills them in.
 
-<BackgroundShowcase component="gradient" />
+<Example label="Default" fullWidth>
+  <BackgroundShowcase component="gradient" />
+</Example>
 
 ## Usage
 
@@ -32,3 +37,5 @@ just the standard `div` attributes.
 | `className` | `string` | Extra classes on the layer (it is `absolute inset-0 z-base`). |
 
 All other `div` attributes are forwarded.
+
+</Workbench>

--- a/apps/docs/content/docs/components/backgrounds/gradient-background/index.mdx
+++ b/apps/docs/content/docs/components/backgrounds/gradient-background/index.mdx
@@ -12,8 +12,12 @@ container and your content sits above it. Pick a look below — 48 gradients por
 `backgroundImage`, and `backgroundSize`; the picker fills them in.
 
 <Example label="Default" fullWidth>
-  <BackgroundShowcase component="gradient" />
+  <BackgroundShowcase component="gradient" embedded />
 </Example>
+
+## Installation
+
+<ComponentInstall name="gradient-background" />
 
 ## Usage
 

--- a/apps/docs/content/docs/components/backgrounds/light-rays/index.mdx
+++ b/apps/docs/content/docs/components/backgrounds/light-rays/index.mdx
@@ -1,16 +1,20 @@
 ---
 title: Light Rays
 description: Volumetric god-rays that slowly sweep and breathe, with optional film grain. Pure CSS.
+workbench: true
 ---
 
 import { LightRays } from "@godui/components";
+
+<Workbench>
 
 A soft fan of volumetric light rays beams down from above, slowly sweeping and
 breathing in intensity, finished with a layer of film grain. Cinematic and warm —
 the spotlight-from-the-heavens hero. Pure CSS. Drop it as the first child of a
 `relative overflow-hidden` container.
 
-<ComponentPreview
+<Example
+  label="Default"
   fullWidth
   story="backgrounds-light-rays"
   code={`import { LightRays } from "@/components/godui/light-rays";
@@ -34,7 +38,7 @@ export function LightRaysDemo() {
       <p className="mt-2 text-muted-foreground">God-rays that gently breathe.</p>
     </div>
   </div>
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -59,7 +63,8 @@ content at `z-raised`+. Color defaults to `--color-primary`. The sweep stops und
 
 ### Warm
 
-<ComponentPreview
+<Example
+  label="Warm"
   fullWidth
   code={`import { LightRays } from "@/components/godui/light-rays";
 
@@ -74,7 +79,7 @@ export function LightRaysWarm() {
   <div className="relative w-full flex-1 overflow-hidden bg-background">
     <LightRays color="#f59e0b" rayCount={18} intensity={0.7} />
   </div>
-</ComponentPreview>
+</Example>
 
 ## Props
 
@@ -88,3 +93,5 @@ export function LightRaysWarm() {
 | `grain` | `number` | `0.05` | Film-grain amount, `0`–`1` (`0` disables it). |
 
 Also accepts standard `div` attributes (e.g. `className`, `style`).
+
+</Workbench>

--- a/apps/docs/content/docs/components/backgrounds/liquid-metaballs/index.mdx
+++ b/apps/docs/content/docs/components/backgrounds/liquid-metaballs/index.mdx
@@ -1,16 +1,20 @@
 ---
 title: Liquid Metaballs
 description: Gooey blobs that drift, collide, and merge under an SVG goo filter — with a cursor blob.
+workbench: true
 ---
 
 import { LiquidMetaballs } from "@godui/components";
+
+<Workbench>
 
 Soft blobs of color drift across the surface and fuse into one gooey mass
 wherever they meet, courtesy of an SVG goo filter. An extra blob follows the
 cursor and merges with the rest. Playful and organic. Drop it as the first child
 of a `relative` container.
 
-<ComponentPreview
+<Example
+  label="Default"
   fullWidth
   story="backgrounds-liquid-metaballs"
   code={`import { LiquidMetaballs } from "@/components/godui/liquid-metaballs";
@@ -34,7 +38,7 @@ export function LiquidMetaballsDemo() {
       <p className="mt-2 text-muted-foreground">Move your cursor to stir the goo.</p>
     </div>
   </div>
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -62,7 +66,8 @@ coexist safely. Pauses off-screen and on hidden tabs; freezes under
 
 Raise `gooeyness` and `blobCount`.
 
-<ComponentPreview
+<Example
+  label="Extra Gooey"
   fullWidth
   code={`import { LiquidMetaballs } from "@/components/godui/liquid-metaballs";
 
@@ -77,7 +82,7 @@ export function LiquidMetaballsGooey() {
   <div className="relative w-full flex-1 overflow-hidden bg-background">
     <LiquidMetaballs gooeyness={24} blobCount={9} />
   </div>
-</ComponentPreview>
+</Example>
 
 ## Props
 
@@ -90,3 +95,5 @@ export function LiquidMetaballsGooey() {
 | `interactive` | `boolean` | `true` | A blob follows the cursor (adds a pointer listener). |
 
 Also accepts standard `div` attributes (e.g. `className`, `style`).
+
+</Workbench>

--- a/apps/docs/content/docs/components/backgrounds/pixel-grid/index.mdx
+++ b/apps/docs/content/docs/components/backgrounds/pixel-grid/index.mdx
@@ -1,9 +1,12 @@
 ---
 title: Pixel Grid
 description: A grid of squares that flicker their opacity — as an automatic animated background, or revealed only under the cursor.
+workbench: true
 ---
 
 import { PixelGrid } from "@godui/components";
+
+<Workbench>
 
 A field of small squares that flicker their opacity on a loop. It has two modes.
 With `interactive={false}` the whole field flickers on its own — an automatic
@@ -14,7 +17,8 @@ static dim, depending on `cursorReveal`. Drop it as the first child of a
 color defaults to the `--color-foreground` theme token and re-resolves on theme
 change, so it tracks light and dark automatically.
 
-<ComponentPreview
+<Example
+  label="Default"
   fullWidth
   story="backgrounds-pixel-grid"
   code={`import { PixelGrid } from "@/components/godui/pixel-grid";
@@ -30,7 +34,7 @@ export function PixelGridDemo() {
   <div className="relative w-full flex-1 overflow-hidden bg-background">
     <PixelGrid interactive={false} />
   </div>
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -59,7 +63,8 @@ Set `interactive` so only the squares within `interactionRadius` of the cursor
 animate. With the default `cursorReveal="hidden"`, the rest stay invisible — a
 spotlight that follows the pointer.
 
-<ComponentPreview
+<Example
+  label="Cursor Reveal"
   fullWidth
   code={`import { PixelGrid } from "@/components/godui/pixel-grid";
 
@@ -76,14 +81,15 @@ export function PixelGridCursor() {
     <PixelGrid interactive />
     <p className="relative z-10 text-sm font-medium text-foreground">Move your cursor across the grid</p>
   </div>
-</ComponentPreview>
+</Example>
 
 ### Cursor reveal over a dim field
 
 `cursorReveal="dim"` keeps the squares outside the radius visible at a static low
 opacity, so the cursor lights up an already-present grid.
 
-<ComponentPreview
+<Example
+  label="Cursor Reveal Over A Dim Field"
   fullWidth
   code={`import { PixelGrid } from "@/components/godui/pixel-grid";
 
@@ -100,13 +106,14 @@ export function PixelGridCursorDim() {
     <PixelGrid interactive cursorReveal="dim" />
     <p className="relative z-10 text-sm font-medium text-foreground">Move your cursor across the grid</p>
   </div>
-</ComponentPreview>
+</Example>
 
 ### Custom color
 
 Pass any CSS color string to `color` to override the theme token.
 
-<ComponentPreview
+<Example
+  label="Custom Color"
   fullWidth
   code={`import { PixelGrid } from "@/components/godui/pixel-grid";
 
@@ -121,13 +128,14 @@ export function PixelGridColored() {
   <div className="relative w-full flex-1 overflow-hidden bg-background">
     <PixelGrid interactive={false} color="oklch(0.7 0.18 280)" maxOpacity={0.5} />
   </div>
-</ComponentPreview>
+</Example>
 
 ### Dense grid
 
 Smaller `squareSize` and `gridGap` pack the field tighter.
 
-<ComponentPreview
+<Example
+  label="Dense Grid"
   fullWidth
   code={`import { PixelGrid } from "@/components/godui/pixel-grid";
 
@@ -142,7 +150,7 @@ export function PixelGridDense() {
   <div className="relative w-full flex-1 overflow-hidden bg-background">
     <PixelGrid interactive={false} squareSize={2} gridGap={2} flickerChance={0.2} maxOpacity={0.4} />
   </div>
-</ComponentPreview>
+</Example>
 
 ## Props
 
@@ -164,3 +172,5 @@ Also accepts standard `div` attributes (e.g. `className`, `style`).
 
 Honors `prefers-reduced-motion`: the flicker animation pauses and a single static
 frame is drawn instead.
+
+</Workbench>

--- a/apps/docs/content/docs/components/backgrounds/topographic-drift/index.mdx
+++ b/apps/docs/content/docs/components/backgrounds/topographic-drift/index.mdx
@@ -1,15 +1,19 @@
 ---
 title: Topographic Drift
 description: Slowly drifting topographic contour lines — a living elevation map drawn with marching squares.
+workbench: true
 ---
 
 import { TopographicDrift } from "@godui/components";
+
+<Workbench>
 
 Contour lines of an imaginary landscape, slowly rising and falling as the terrain
 beneath them evolves. Editorial, cartographic, and calm — drawn with marching
 squares on one Canvas. Drop it as the first child of a `relative` container.
 
-<ComponentPreview
+<Example
+  label="Default"
   fullWidth
   story="backgrounds-topographic-drift"
   code={`import { TopographicDrift } from "@/components/godui/topographic-drift";
@@ -33,7 +37,7 @@ export function TopographicDriftDemo() {
       <p className="mt-2 text-muted-foreground">Terrain that never stops shifting.</p>
     </div>
   </div>
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -61,7 +65,8 @@ at 2, pauses off-screen and on hidden tabs, and renders a static map under
 
 More levels, finer terrain.
 
-<ComponentPreview
+<Example
+  label="Dense"
   fullWidth
   code={`import { TopographicDrift } from "@/components/godui/topographic-drift";
 
@@ -76,7 +81,7 @@ export function TopographicDriftDense() {
   <div className="relative w-full flex-1 overflow-hidden bg-background">
     <TopographicDrift lineCount={16} noiseScale={0.006} />
   </div>
-</ComponentPreview>
+</Example>
 
 ## Props
 
@@ -89,3 +94,5 @@ export function TopographicDriftDense() {
 | `weight` | `number` | `1` | Contour line width (px). |
 
 Also accepts standard `div` attributes (e.g. `className`, `style`).
+
+</Workbench>

--- a/apps/docs/content/docs/components/backgrounds/warp-starfield/index.mdx
+++ b/apps/docs/content/docs/components/backgrounds/warp-starfield/index.mdx
@@ -1,15 +1,19 @@
 ---
 title: Warp Starfield
 description: A depth starfield you fly through — cursor parallax and an optional hyperspace warp.
+workbench: true
 ---
 
 import { WarpStarfield } from "@godui/components";
+
+<Workbench>
 
 Stars stream toward you out of the dark, with the cursor gently steering the
 field for parallax. Flip on `warp` for a hyperspace jump where the stars stretch
 into streaks. Drop it as the first child of a `relative` container.
 
-<ComponentPreview
+<Example
+  label="Default"
   fullWidth
   story="backgrounds-warp-starfield"
   code={`import { WarpStarfield } from "@/components/godui/warp-starfield";
@@ -33,7 +37,7 @@ export function WarpStarfieldDemo() {
       <p className="mt-2 text-muted-foreground">Move your cursor to steer.</p>
     </div>
   </div>
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -59,7 +63,8 @@ tabs, and renders a static frame under `prefers-reduced-motion`.
 
 ### Hyperspace
 
-<ComponentPreview
+<Example
+  label="Hyperspace"
   fullWidth
   code={`import { WarpStarfield } from "@/components/godui/warp-starfield";
 
@@ -74,7 +79,7 @@ export function WarpStarfieldHyperspace() {
   <div className="relative w-full flex-1 overflow-hidden bg-background">
     <WarpStarfield warp speed={1.6} />
   </div>
-</ComponentPreview>
+</Example>
 
 ## Props
 
@@ -88,3 +93,5 @@ export function WarpStarfieldHyperspace() {
 | `parallax` | `number` | `30` | Cursor parallax strength (px). |
 
 Also accepts standard `div` attributes (e.g. `className`, `style`).
+
+</Workbench>

--- a/apps/docs/content/docs/components/buttons/gooey-fab/index.mdx
+++ b/apps/docs/content/docs/components/buttons/gooey-fab/index.mdx
@@ -1,15 +1,18 @@
 ---
 title: Gooey FAB
 description: A floating action button that gooey-morphs to extrude its satellite actions like liquid metaballs.
+workbench: true
 ---
 
 import { GooeyFab } from "@godui/components";
 
+<Workbench>
+
 The Gooey FAB extrudes a set of satellite actions from a single trigger, fused by an SVG metaball filter so they split apart like mercury. The trigger icon rotates from a plus into a cross as it opens.
 
-<ComponentPreview
+<Example
+  label="Default"
   story="buttons-gooey-fab"
-  className="min-h-64 items-end"
   code={`import { GooeyFab } from "@/components/godui/gooey-fab";
 
 const Icon = ({ d }) => (
@@ -37,7 +40,47 @@ export function GooeyFabDemo() {
       { label: "Delete", icon: <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="size-[45%]"><path d="M3 6h18M8 6V4h8v2M6 6l1 14h10l1-14" /></svg> },
     ]}
   />
-</ComponentPreview>
+</Example>
+
+<Example
+  label="Downward"
+  code={`<GooeyFab
+  direction="down"
+  actions={[
+    { label: "Copy", icon: <CopyIcon /> },
+    { label: "Cut", icon: <CutIcon /> },
+    { label: "Paste", icon: <PasteIcon /> },
+  ]}
+/>`}
+>
+  <GooeyFab
+    direction="down"
+    actions={[
+      { label: "Copy", icon: <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="size-[45%]"><rect x="9" y="9" width="13" height="13" rx="2" /><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" /></svg> },
+      { label: "Cut", icon: <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="size-[45%]"><circle cx="6" cy="6" r="3" /><circle cx="6" cy="18" r="3" /><path d="M20 4 8.12 15.88M14.47 14.48 20 20M8.12 8.12 12 12" /></svg> },
+      { label: "Paste", icon: <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="size-[45%]"><path d="M15 2H9a1 1 0 0 0-1 1v2a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V3a1 1 0 0 0-1-1Z" /><path d="M8 4H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2h-2" /></svg> },
+    ]}
+  />
+</Example>
+
+<Example
+  label="Large"
+  code={`<GooeyFab
+  size="lg"
+  actions={[
+    { label: "Camera", icon: <CameraIcon /> },
+    { label: "Image", icon: <ImageIcon /> },
+  ]}
+/>`}
+>
+  <GooeyFab
+    size="lg"
+    actions={[
+      { label: "Camera", icon: <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="size-[45%]"><path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3l-2.5-3Z" /><circle cx="12" cy="13" r="3" /></svg> },
+      { label: "Image", icon: <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="size-[45%]"><rect x="3" y="3" width="18" height="18" rx="2" /><circle cx="9" cy="9" r="2" /><path d="m21 15-3.09-3.09a2 2 0 0 0-2.82 0L6 21" /></svg> },
+    ]}
+  />
+</Example>
 
 ## Installation
 
@@ -71,3 +114,5 @@ import { GooeyFab } from "@/components/godui/gooey-fab";
 | `onOpenChange` | `(open: boolean) => void` | — | Fires when the open state changes |
 | `triggerIcon` | `ReactNode` | plus → cross | Custom trigger icon |
 | `triggerLabel` | `string` | `"Open actions"` | Accessible trigger label |
+
+</Workbench>

--- a/apps/docs/content/docs/components/buttons/hold-confirm-button/index.mdx
+++ b/apps/docs/content/docs/components/buttons/hold-confirm-button/index.mdx
@@ -1,13 +1,17 @@
 ---
 title: Hold Confirm Button
 description: Press and hold to confirm a destructive action — a radial fill commits at 100%, releasing early cancels.
+workbench: true
 ---
 
 import { HoldConfirmButton } from "@godui/components";
 
+<Workbench>
+
 The Hold Confirm Button replaces a confirmation dialog with a deliberate gesture: hold to fill the progress sweep, release early to cancel. It supports pointer and keyboard holds.
 
-<ComponentPreview
+<Example
+  label="Default"
   story="buttons-hold-confirm-button"
   code={`import { HoldConfirmButton } from "@/components/godui/hold-confirm-button";
 
@@ -20,27 +24,10 @@ export function HoldConfirmButtonDemo() {
 }`}
 >
   <HoldConfirmButton>Hold to delete</HoldConfirmButton>
-</ComponentPreview>
+</Example>
 
-## Installation
-
-<ComponentInstall name="hold-confirm-button" />
-
-## Usage
-
-```tsx
-import { HoldConfirmButton } from "@/components/godui/hold-confirm-button";
-```
-
-```tsx
-<HoldConfirmButton onConfirm={deleteAccount}>Hold to delete</HoldConfirmButton>
-```
-
-## Examples
-
-### Variants and duration
-
-<ComponentPreview
+<Example
+  label="Variants"
   code={`import { HoldConfirmButton } from "@/components/godui/hold-confirm-button";
 
 export function HoldConfirmButtonVariants() {
@@ -56,7 +43,21 @@ export function HoldConfirmButtonVariants() {
     <HoldConfirmButton variant="destructive">Hold to delete</HoldConfirmButton>
     <HoldConfirmButton variant="default" duration={1400}>Hold to publish</HoldConfirmButton>
   </div>
-</ComponentPreview>
+</Example>
+
+## Installation
+
+<ComponentInstall name="hold-confirm-button" />
+
+## Usage
+
+```tsx
+import { HoldConfirmButton } from "@/components/godui/hold-confirm-button";
+```
+
+```tsx
+<HoldConfirmButton onConfirm={deleteAccount}>Hold to delete</HoldConfirmButton>
+```
 
 ## Props
 
@@ -68,3 +69,5 @@ export function HoldConfirmButtonVariants() {
 | `duration` | `number` | `900` | ms the user must hold to confirm |
 | `holdingLabel` | `ReactNode` | `"Confirming…"` | Label while holding |
 | `confirmedLabel` | `ReactNode` | `"Confirmed"` | Label after confirming |
+
+</Workbench>

--- a/apps/docs/content/docs/components/buttons/jelly-button/index.mdx
+++ b/apps/docs/content/docs/components/buttons/jelly-button/index.mdx
@@ -2,11 +2,17 @@
 title: Jelly Button
 description: A squishy button that deforms on press and springs back with a jelly wobble — all on the compositor.
 date: "2026-07-24"
+workbench: true
 ---
 
 import { JellyButton } from "@godui/components";
 
-<ComponentPreview
+<Workbench>
+
+A squishy button that deforms on press and springs back with a jelly wobble — all running on the compositor.
+
+<Example
+  label="Default"
   story="buttons-jelly-button"
   code={`import { JellyButton } from "@/components/godui/jelly-button";
 
@@ -25,27 +31,10 @@ export function JellyButtonDemo() {
     <JellyButton variant="secondary">Press me</JellyButton>
     <JellyButton variant="outline">Press me</JellyButton>
   </div>
-</ComponentPreview>
+</Example>
 
-## Installation
-
-<ComponentInstall name="jelly-button" />
-
-## Usage
-
-```tsx
-import { JellyButton } from "@/components/godui/jelly-button";
-```
-
-```tsx
-<JellyButton variant="primary">Press me</JellyButton>
-```
-
-## Examples
-
-### Sizes
-
-<ComponentPreview
+<Example
+  label="Sizes"
   code={`import { JellyButton } from "@/components/godui/jelly-button";
 
 export function JellyButtonSizes() {
@@ -63,13 +52,10 @@ export function JellyButtonSizes() {
     <JellyButton size="md">Medium</JellyButton>
     <JellyButton size="lg">Large</JellyButton>
   </div>
-</ComponentPreview>
+</Example>
 
-### Squash
-
-The `squash` prop (`0`–`1`) sets how hard the button deforms on press. Lower is subtle, higher is bouncier.
-
-<ComponentPreview
+<Example
+  label="Squash"
   code={`import { JellyButton } from "@/components/godui/jelly-button";
 
 export function JellyButtonSquash() {
@@ -87,11 +73,10 @@ export function JellyButtonSquash() {
     <JellyButton squash={0.6}>Default</JellyButton>
     <JellyButton squash={1}>Extra squishy</JellyButton>
   </div>
-</ComponentPreview>
+</Example>
 
-### Disabled
-
-<ComponentPreview
+<Example
+  label="Disabled"
   code={`import { JellyButton } from "@/components/godui/jelly-button";
 
 export function JellyButtonDisabled() {
@@ -99,7 +84,23 @@ export function JellyButtonDisabled() {
 }`}
 >
   <JellyButton disabled>Press me</JellyButton>
-</ComponentPreview>
+</Example>
+
+## Installation
+
+<ComponentInstall name="jelly-button" />
+
+## Usage
+
+```tsx
+import { JellyButton } from "@/components/godui/jelly-button";
+```
+
+```tsx
+<JellyButton variant="primary">Press me</JellyButton>
+```
+
+The `squash` prop (`0`–`1`) sets how hard the button deforms on press. Lower is subtle, higher is bouncier.
 
 ## Props
 
@@ -108,3 +109,5 @@ export function JellyButtonDisabled() {
 | `variant` | `"primary" \| "secondary" \| "outline"` | `"primary"` | Color scheme |
 | `size` | `"sm" \| "md" \| "lg"` | `"md"` | Button padding and text size |
 | `squash` | `number` | `0.6` | How hard the button deforms on press (`0`–`1`) |
+
+</Workbench>

--- a/apps/docs/content/docs/components/buttons/magic-button/index.mdx
+++ b/apps/docs/content/docs/components/buttons/magic-button/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Magic Button
 description: A pushable 3D button with rainbow edge animation and solid front face.
+workbench: true
 ---
 
 import { MagicButton } from "@godui/components";
 
-<ComponentPreview
+<Workbench>
+
+A pushable 3D button with a rainbow edge animation and a solid front face.
+
+<Example
+  label="Default"
   story="buttons-magic-button"
   code={`import { MagicButton } from "@/components/godui/magic-button";
 
@@ -22,27 +28,10 @@ export function MagicButtonDemo() {
     <MagicButton variant="default">Push me</MagicButton>
     <MagicButton variant="secondary">Push me</MagicButton>
   </div>
-</ComponentPreview>
+</Example>
 
-## Installation
-
-<ComponentInstall name="magic-button" />
-
-## Usage
-
-```tsx
-import { MagicButton } from "@/components/godui/magic-button";
-```
-
-```tsx
-<MagicButton variant="default">Push me</MagicButton>
-```
-
-## Examples
-
-### Sizes
-
-<ComponentPreview
+<Example
+  label="Sizes"
   code={`import { MagicButton } from "@/components/godui/magic-button";
 
 export function MagicButtonSizes() {
@@ -60,13 +49,10 @@ export function MagicButtonSizes() {
     <MagicButton size="md">Medium</MagicButton>
     <MagicButton size="lg">Large</MagicButton>
   </div>
-</ComponentPreview>
+</Example>
 
-### Without rainbow
-
-Set `rainbow={false}` for a static 3D edge that uses the variant color instead of the animated gradient.
-
-<ComponentPreview
+<Example
+  label="No Rainbow"
   code={`import { MagicButton } from "@/components/godui/magic-button";
 
 export function MagicButtonPlain() {
@@ -82,11 +68,10 @@ export function MagicButtonPlain() {
     <MagicButton rainbow={false}>Push me</MagicButton>
     <MagicButton variant="secondary" rainbow={false}>Push me</MagicButton>
   </div>
-</ComponentPreview>
+</Example>
 
-### Disabled
-
-<ComponentPreview
+<Example
+  label="Disabled"
   code={`import { MagicButton } from "@/components/godui/magic-button";
 
 export function MagicButtonDisabled() {
@@ -94,7 +79,23 @@ export function MagicButtonDisabled() {
 }`}
 >
   <MagicButton disabled>Push me</MagicButton>
-</ComponentPreview>
+</Example>
+
+## Installation
+
+<ComponentInstall name="magic-button" />
+
+## Usage
+
+```tsx
+import { MagicButton } from "@/components/godui/magic-button";
+```
+
+```tsx
+<MagicButton variant="default">Push me</MagicButton>
+```
+
+Set `rainbow={false}` for a static 3D edge that uses the variant color instead of the animated gradient.
 
 ## Props
 
@@ -103,3 +104,5 @@ export function MagicButtonDisabled() {
 | `variant` | `"default" \| "secondary"` | `"default"` | Front face color scheme |
 | `size` | `"sm" \| "default" \| "lg"` | `"default"` | Button padding and text size |
 | `rainbow` | `boolean` | `true` | Animate the 3D edge and shadow with a rainbow gradient |
+
+</Workbench>

--- a/apps/docs/content/docs/components/buttons/magnetic-button/index.mdx
+++ b/apps/docs/content/docs/components/buttons/magnetic-button/index.mdx
@@ -1,12 +1,18 @@
 ---
 title: Magnetic Button
 description: A button whose content is magnetically pulled toward the cursor within a sensor range, springing back on exit.
+workbench: true
 ---
 
 import { MagneticButton } from "@godui/components";
 import { MagneticButtonDemo } from "@/components/demos/magnetic-button-demo";
 
-<ComponentPreview
+<Workbench>
+
+A button whose content is magnetically pulled toward the cursor within a sensor range, springing back on exit.
+
+<Example
+  label="Default"
   story="buttons-magnetic-button"
   code={`import { MagneticButton } from "@/components/godui/magnetic-button";
 import { ArrowRight, Star } from "lucide-react";
@@ -41,7 +47,57 @@ export function MagneticButtonDemo() {
 }`}
 >
   <MagneticButtonDemo />
-</ComponentPreview>
+</Example>
+
+<Example
+  label="Variants"
+  code={`<div className="flex items-center gap-4">
+  <MagneticButton variant="default">Default</MagneticButton>
+  <MagneticButton variant="secondary">Secondary</MagneticButton>
+  <MagneticButton variant="outline">Outline</MagneticButton>
+</div>`}
+>
+  <div className="flex items-center gap-4">
+    <MagneticButton variant="default">Default</MagneticButton>
+    <MagneticButton variant="secondary">Secondary</MagneticButton>
+    <MagneticButton variant="outline">Outline</MagneticButton>
+  </div>
+</Example>
+
+<Example
+  label="Sizes"
+  code={`<div className="flex items-center gap-4">
+  <MagneticButton size="sm">Small</MagneticButton>
+  <MagneticButton size="md">Medium</MagneticButton>
+  <MagneticButton size="lg">Large</MagneticButton>
+</div>`}
+>
+  <div className="flex items-center gap-4">
+    <MagneticButton size="sm">Small</MagneticButton>
+    <MagneticButton size="md">Medium</MagneticButton>
+    <MagneticButton size="lg">Large</MagneticButton>
+  </div>
+</Example>
+
+<Example
+  label="Stronger Pull"
+  code={`<MagneticButton strength={0.8} range={48} size="lg">Pull me</MagneticButton>`}
+>
+  <MagneticButton strength={0.8} range={48} size="lg">Pull me</MagneticButton>
+</Example>
+
+<Example
+  label="Static Label"
+  code={`<div className="flex items-center gap-4">
+  <MagneticButton size="lg" range={44}>Parallax label</MagneticButton>
+  <MagneticButton variant="secondary" size="lg" range={44} staticLabel>Centered label</MagneticButton>
+</div>`}
+>
+  <div className="flex items-center gap-4">
+    <MagneticButton size="lg" range={44}>Parallax label</MagneticButton>
+    <MagneticButton variant="secondary" size="lg" range={44} staticLabel>Centered label</MagneticButton>
+  </div>
+</Example>
 
 ## Installation
 
@@ -62,72 +118,12 @@ import { MagneticButton } from "@/components/godui/magnetic-button";
 <MagneticButton>Get started</MagneticButton>
 ```
 
-### Variants
-
-```tsx
-<MagneticButton variant="default">Default</MagneticButton>
-<MagneticButton variant="secondary">Secondary</MagneticButton>
-<MagneticButton variant="outline">Outline</MagneticButton>
-```
-
-<ComponentPreview
-  code={`<div className="flex items-center gap-4">
-  <MagneticButton variant="default">Default</MagneticButton>
-  <MagneticButton variant="secondary">Secondary</MagneticButton>
-  <MagneticButton variant="outline">Outline</MagneticButton>
-</div>`}
->
-  <div className="flex items-center gap-4">
-    <MagneticButton variant="default">Default</MagneticButton>
-    <MagneticButton variant="secondary">Secondary</MagneticButton>
-    <MagneticButton variant="outline">Outline</MagneticButton>
-  </div>
-</ComponentPreview>
-
-### Sizes
-
-<ComponentPreview
-  code={`<div className="flex items-center gap-4">
-  <MagneticButton size="sm">Small</MagneticButton>
-  <MagneticButton size="md">Medium</MagneticButton>
-  <MagneticButton size="lg">Large</MagneticButton>
-</div>`}
->
-  <div className="flex items-center gap-4">
-    <MagneticButton size="sm">Small</MagneticButton>
-    <MagneticButton size="md">Medium</MagneticButton>
-    <MagneticButton size="lg">Large</MagneticButton>
-  </div>
-</ComponentPreview>
-
-### Stronger pull and wider sensor
-
 `strength` controls how far the button follows the cursor (0–1); `range` adds
 invisible padding so the pull engages before the pointer reaches the edge.
-
-<ComponentPreview
-  code={`<MagneticButton strength={0.8} range={48} size="lg">Pull me</MagneticButton>`}
->
-  <MagneticButton strength={0.8} range={48} size="lg">Pull me</MagneticButton>
-</ComponentPreview>
-
-### Keep the label centered
 
 By default the label drifts a little further than the shell for parallax. Set
 `staticLabel` so the label rides with the button and stays centered — the whole
 button moves as one piece, with no drift.
-
-<ComponentPreview
-  code={`<div className="flex items-center gap-4">
-  <MagneticButton size="lg" range={44}>Parallax label</MagneticButton>
-  <MagneticButton variant="secondary" size="lg" range={44} staticLabel>Centered label</MagneticButton>
-</div>`}
->
-  <div className="flex items-center gap-4">
-    <MagneticButton size="lg" range={44}>Parallax label</MagneticButton>
-    <MagneticButton variant="secondary" size="lg" range={44} staticLabel>Centered label</MagneticButton>
-  </div>
-</ComponentPreview>
 
 ## Props
 
@@ -140,3 +136,5 @@ button moves as one piece, with no drift.
 | `staticLabel` | `boolean`                                 | `false`     | Keep the label centered in the button (rides with the shell, no drift). |
 
 `MagneticButton` also forwards every standard `<button>` attribute to the element.
+
+</Workbench>

--- a/apps/docs/content/docs/components/buttons/mask-button/index.mdx
+++ b/apps/docs/content/docs/components/buttons/mask-button/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Mask Button
 description: A button whose face wipes away on hover via an animated CSS sprite-sheet mask, revealing the label behind it.
+workbench: true
 ---
 
 import { MaskButton } from "@godui/components";
 
-<ComponentPreview
+<Workbench>
+
+A button whose face wipes away on hover via an animated CSS sprite-sheet mask, revealing the label behind it.
+
+<Example
+  label="Default"
   story="buttons-mask-button"
   code={`import { MaskButton } from "@godui/components";
 
@@ -24,13 +30,50 @@ export function MaskButtonDemo() {
     <MaskButton mask="urban">Hover me</MaskButton>
     <MaskButton mask="forest">Hover me</MaskButton>
   </div>
-</ComponentPreview>
+</Example>
 
-The primary face is masked by a horizontal sprite-sheet image. On hover the
-mask flipbooks frame-by-frame (`steps()` on `mask-position`), wiping the face
-away to reveal the label, then plays in reverse on mouse-leave. Each `mask`
-value uses a different sprite for a distinct transition. Inspired by
-[this Codrops article](https://tympanus.net/codrops/2016/09/29/transition-effect-with-css-masks/).
+<Example
+  label="Secondary"
+  code={`import { MaskButton } from "@godui/components";
+
+export function MaskButtonSecondary() {
+  return <MaskButton mask="nature" variant="secondary">Hover me</MaskButton>;
+}`}
+>
+  <MaskButton mask="nature" variant="secondary">Hover me</MaskButton>
+</Example>
+
+<Example
+  label="Sizes"
+  code={`import { MaskButton } from "@godui/components";
+
+export function MaskButtonSizes() {
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-6">
+      <MaskButton size="sm">Small</MaskButton>
+      <MaskButton size="md">Medium</MaskButton>
+      <MaskButton size="lg">Large</MaskButton>
+    </div>
+  );
+}`}
+>
+  <div className="flex flex-wrap items-center justify-center gap-6">
+    <MaskButton size="sm">Small</MaskButton>
+    <MaskButton size="md">Medium</MaskButton>
+    <MaskButton size="lg">Large</MaskButton>
+  </div>
+</Example>
+
+<Example
+  label="Disabled"
+  code={`import { MaskButton } from "@godui/components";
+
+export function MaskButtonDisabled() {
+  return <MaskButton disabled>Hover me</MaskButton>;
+}`}
+>
+  <MaskButton disabled>Hover me</MaskButton>
+</Example>
 
 ## Installation
 
@@ -58,53 +101,11 @@ import { MaskButton } from "@godui/components";
 <MaskButton mask="nature">Hover me</MaskButton>
 ```
 
-## Examples
-
-### Secondary
-
-<ComponentPreview
-  code={`import { MaskButton } from "@godui/components";
-
-export function MaskButtonSecondary() {
-  return <MaskButton mask="nature" variant="secondary">Hover me</MaskButton>;
-}`}
->
-  <MaskButton mask="nature" variant="secondary">Hover me</MaskButton>
-</ComponentPreview>
-
-### Sizes
-
-<ComponentPreview
-  code={`import { MaskButton } from "@godui/components";
-
-export function MaskButtonSizes() {
-  return (
-    <div className="flex flex-wrap items-center justify-center gap-6">
-      <MaskButton size="sm">Small</MaskButton>
-      <MaskButton size="md">Medium</MaskButton>
-      <MaskButton size="lg">Large</MaskButton>
-    </div>
-  );
-}`}
->
-  <div className="flex flex-wrap items-center justify-center gap-6">
-    <MaskButton size="sm">Small</MaskButton>
-    <MaskButton size="md">Medium</MaskButton>
-    <MaskButton size="lg">Large</MaskButton>
-  </div>
-</ComponentPreview>
-
-### Disabled
-
-<ComponentPreview
-  code={`import { MaskButton } from "@godui/components";
-
-export function MaskButtonDisabled() {
-  return <MaskButton disabled>Hover me</MaskButton>;
-}`}
->
-  <MaskButton disabled>Hover me</MaskButton>
-</ComponentPreview>
+The primary face is masked by a horizontal sprite-sheet image. On hover the
+mask flipbooks frame-by-frame (`steps()` on `mask-position`), wiping the face
+away to reveal the label, then plays in reverse on mouse-leave. Each `mask`
+value uses a different sprite for a distinct transition. Inspired by
+[this Codrops article](https://tympanus.net/codrops/2016/09/29/transition-effect-with-css-masks/).
 
 ## Props
 
@@ -117,3 +118,5 @@ Accepts all native `<button>` attributes.
 | `size` | `"sm" \| "md" \| "lg"` | `"md"` | Size scale (padding / font / radius) |
 | `children` | `ReactNode` | — | Button label |
 | `disabled` | `boolean` | `false` | Disable the button and its animation |
+
+</Workbench>

--- a/apps/docs/content/docs/components/buttons/progress-fold-button/index.mdx
+++ b/apps/docs/content/docs/components/buttons/progress-fold-button/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Progress Fold Button
 description: A 3D button whose front face folds back to reveal a controlled progress bar while loading.
+workbench: true
 ---
 
 import { ProgressFoldButton } from "@godui/components";
 
-<ComponentPreview
+<Workbench>
+
+A 3D button whose front face folds back to reveal a controlled progress bar while loading.
+
+<Example
+  label="Default"
   story="buttons-progress-fold-button"
   code={`import { ProgressFoldButton } from "@/components/godui/progress-fold-button";
 
@@ -22,20 +28,10 @@ export function ProgressFoldButtonDemo() {
     <ProgressFoldButton variant="primary">Submit</ProgressFoldButton>
     <ProgressFoldButton variant="secondary">Submit</ProgressFoldButton>
   </div>
-</ComponentPreview>
+</Example>
 
-The front face folds back on hover, revealing the layers behind it. Set
-`status="loading"` to hold the fold open and run a progress bar — controlled by
-you, like the Magic Input.
-
-## Loading
-
-`status` and `progress` are fully controlled. While `status="loading"` the front
-face folds open and a progress bar runs behind it — determinate when you pass
-`progress`, otherwise an indeterminate segment sweeps across. Back to `idle` and
-the front folds flat again.
-
-<ComponentPreview
+<Example
+  label="Loading"
   code={`import { ProgressFoldButton } from "@/components/godui/progress-fold-button";
 
 export function ProgressFoldButtonLoading() {
@@ -55,7 +51,64 @@ export function ProgressFoldButtonLoading() {
       Determinate
     </ProgressFoldButton>
   </div>
-</ComponentPreview>
+</Example>
+
+<Example
+  label="Sizes"
+  code={`import { ProgressFoldButton } from "@/components/godui/progress-fold-button";
+
+export function ProgressFoldButtonSizes() {
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-6">
+      <ProgressFoldButton size="sm">Small</ProgressFoldButton>
+      <ProgressFoldButton size="md">Medium</ProgressFoldButton>
+      <ProgressFoldButton size="lg">Large</ProgressFoldButton>
+    </div>
+  );
+}`}
+>
+  <div className="flex flex-wrap items-center justify-center gap-6">
+    <ProgressFoldButton size="sm">Small</ProgressFoldButton>
+    <ProgressFoldButton size="md">Medium</ProgressFoldButton>
+    <ProgressFoldButton size="lg">Large</ProgressFoldButton>
+  </div>
+</Example>
+
+<Example
+  label="Disabled"
+  code={`import { ProgressFoldButton } from "@/components/godui/progress-fold-button";
+
+export function ProgressFoldButtonDisabled() {
+  return <ProgressFoldButton disabled>Submit</ProgressFoldButton>;
+}`}
+>
+  <ProgressFoldButton disabled>Submit</ProgressFoldButton>
+</Example>
+
+## Installation
+
+<ComponentInstall componentName="ProgressFoldButton" />
+
+## Usage
+
+```tsx
+import { ProgressFoldButton } from "@/components/godui/progress-fold-button";
+```
+
+```tsx
+<ProgressFoldButton status="loading" progress={40}>
+  Submit
+</ProgressFoldButton>
+```
+
+The front face folds back on hover, revealing the layers behind it. Set
+`status="loading"` to hold the fold open and run a progress bar — controlled by
+you, like the Magic Input.
+
+`status` and `progress` are fully controlled. While `status="loading"` the front
+face folds open and a progress bar runs behind it — determinate when you pass
+`progress`, otherwise an indeterminate segment sweeps across. Back to `idle` and
+the front folds flat again.
 
 Wire it up by flipping `status` from your handler:
 
@@ -80,58 +133,6 @@ export function Example() {
 }
 ```
 
-## Installation
-
-<ComponentInstall componentName="ProgressFoldButton" />
-
-## Usage
-
-```tsx
-import { ProgressFoldButton } from "@/components/godui/progress-fold-button";
-```
-
-```tsx
-<ProgressFoldButton status="loading" progress={40}>
-  Submit
-</ProgressFoldButton>
-```
-
-## Examples
-
-### Sizes
-
-<ComponentPreview
-  code={`import { ProgressFoldButton } from "@/components/godui/progress-fold-button";
-
-export function ProgressFoldButtonSizes() {
-  return (
-    <div className="flex flex-wrap items-center justify-center gap-6">
-      <ProgressFoldButton size="sm">Small</ProgressFoldButton>
-      <ProgressFoldButton size="md">Medium</ProgressFoldButton>
-      <ProgressFoldButton size="lg">Large</ProgressFoldButton>
-    </div>
-  );
-}`}
->
-  <div className="flex flex-wrap items-center justify-center gap-6">
-    <ProgressFoldButton size="sm">Small</ProgressFoldButton>
-    <ProgressFoldButton size="md">Medium</ProgressFoldButton>
-    <ProgressFoldButton size="lg">Large</ProgressFoldButton>
-  </div>
-</ComponentPreview>
-
-### Disabled
-
-<ComponentPreview
-  code={`import { ProgressFoldButton } from "@/components/godui/progress-fold-button";
-
-export function ProgressFoldButtonDisabled() {
-  return <ProgressFoldButton disabled>Submit</ProgressFoldButton>;
-}`}
->
-  <ProgressFoldButton disabled>Submit</ProgressFoldButton>
-</ComponentPreview>
-
 ## Props
 
 Accepts all native `<button>` attributes.
@@ -145,3 +146,5 @@ Accepts all native `<button>` attributes.
 | `children` | `ReactNode` | — | Button label |
 | `disabled` | `boolean` | `false` | Disable the button and its animations |
 | `onClick` | `(e) => void` | — | Fires on click; flip `status` from here to start loading |
+
+</Workbench>

--- a/apps/docs/content/docs/components/buttons/shimmer-button/index.mdx
+++ b/apps/docs/content/docs/components/buttons/shimmer-button/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Shimmer Button
 description: A button with an animated shimmering border light effect.
+workbench: true
 ---
 
 import { ShimmerButton } from "@godui/components";
 
-<ComponentPreview
+<Workbench>
+
+A button with an animated shimmering border light effect.
+
+<Example
+  label="Default"
   story="buttons-shimmer-button"
   code={`import { ShimmerButton } from "@/components/godui/shimmer-button";
 
@@ -24,27 +30,10 @@ export function ShimmerButtonDemo() {
     <ShimmerButton variant="secondary">Secondary</ShimmerButton>
     <ShimmerButton variant="outline">Outline</ShimmerButton>
   </div>
-</ComponentPreview>
+</Example>
 
-## Installation
-
-<ComponentInstall componentName="ShimmerButton" />
-
-## Usage
-
-```tsx
-import { ShimmerButton } from "@/components/godui/shimmer-button";
-```
-
-```tsx
-<ShimmerButton variant="primary">Click me</ShimmerButton>
-```
-
-## Examples
-
-### Sizes
-
-<ComponentPreview
+<Example
+  label="Sizes"
   code={`import { ShimmerButton } from "@/components/godui/shimmer-button";
 
 export function ShimmerButtonSizes() {
@@ -62,13 +51,10 @@ export function ShimmerButtonSizes() {
     <ShimmerButton size="md">Medium</ShimmerButton>
     <ShimmerButton size="lg">Large</ShimmerButton>
   </div>
-</ComponentPreview>
+</Example>
 
-### Without shimmer
-
-Set `shimmer={false}` to keep the button styling without the animated border light.
-
-<ComponentPreview
+<Example
+  label="Static"
   code={`import { ShimmerButton } from "@/components/godui/shimmer-button";
 
 export function ShimmerButtonStatic() {
@@ -76,11 +62,10 @@ export function ShimmerButtonStatic() {
 }`}
 >
   <ShimmerButton shimmer={false}>No shimmer</ShimmerButton>
-</ComponentPreview>
+</Example>
 
-### Disabled
-
-<ComponentPreview
+<Example
+  label="Disabled"
   code={`import { ShimmerButton } from "@/components/godui/shimmer-button";
 
 export function ShimmerButtonDisabled() {
@@ -88,7 +73,23 @@ export function ShimmerButtonDisabled() {
 }`}
 >
   <ShimmerButton disabled>Disabled</ShimmerButton>
-</ComponentPreview>
+</Example>
+
+## Installation
+
+<ComponentInstall componentName="ShimmerButton" />
+
+## Usage
+
+```tsx
+import { ShimmerButton } from "@/components/godui/shimmer-button";
+```
+
+```tsx
+<ShimmerButton variant="primary">Click me</ShimmerButton>
+```
+
+Set `shimmer={false}` to keep the button styling without the animated border light.
 
 ## Props
 
@@ -100,3 +101,5 @@ export function ShimmerButtonDisabled() {
 | `shimmerColor` | `string` | variant default | Color of the shimmering light |
 | `shimmerDuration` | `string` | `"3s"` | Duration of the shimmer animation |
 | `background` | `string` | variant default | Background color override |
+
+</Workbench>

--- a/apps/docs/content/docs/components/buttons/slide-confirm-button/index.mdx
+++ b/apps/docs/content/docs/components/buttons/slide-confirm-button/index.mdx
@@ -1,14 +1,18 @@
 ---
 title: Slide Confirm Button
 description: A drag-to-confirm thumb for high-stakes actions — slide past the threshold to commit, release early to spring back.
+workbench: true
 ---
 
 import { SlideConfirmButton } from "@godui/components";
 import { SlideConfirmButtonAsyncDemo } from "@/components/demos/slide-confirm-button-demo";
 
+<Workbench>
+
 The Slide Confirm Button is the most deliberate confirmation gesture: drag the thumb across the track, the fill trails behind it, and it snaps to confirm past the threshold. Pointer, touch, and keyboard are all supported.
 
-<ComponentPreview
+<Example
+  label="Default"
   story="buttons-slide-confirm-button"
   code={`import { SlideConfirmButton } from "@/components/godui/slide-confirm-button";
 
@@ -22,27 +26,10 @@ export function SlideConfirmButtonDemo() {
 }`}
 >
   <SlideConfirmButton label="Slide to deploy" />
-</ComponentPreview>
+</Example>
 
-## Installation
-
-<ComponentInstall name="slide-confirm-button" />
-
-## Usage
-
-```tsx
-import { SlideConfirmButton } from "@/components/godui/slide-confirm-button";
-```
-
-```tsx
-<SlideConfirmButton label="Slide to pay" onConfirm={charge} />
-```
-
-## Examples
-
-### Destructive
-
-<ComponentPreview
+<Example
+  label="Destructive"
   code={`import { SlideConfirmButton } from "@/components/godui/slide-confirm-button";
 
 export function SlideConfirmButtonDestructive() {
@@ -50,13 +37,10 @@ export function SlideConfirmButtonDestructive() {
 }`}
 >
   <SlideConfirmButton variant="destructive" label="Slide to delete" />
-</ComponentPreview>
+</Example>
 
-### Async confirm
-
-When `onConfirm` returns a promise, the thumb shows a spinner and the track swaps in `loadingLabel` while the work runs, then lands on the confirmed state once it resolves. If the promise rejects, the control springs back to idle so the action can be retried.
-
-<ComponentPreview
+<Example
+  label="Async"
   code={`import { SlideConfirmButton } from "@/components/godui/slide-confirm-button";
 
 export function SlideConfirmButtonAsync() {
@@ -74,7 +58,23 @@ export function SlideConfirmButtonAsync() {
 }`}
 >
   <SlideConfirmButtonAsyncDemo />
-</ComponentPreview>
+</Example>
+
+## Installation
+
+<ComponentInstall name="slide-confirm-button" />
+
+## Usage
+
+```tsx
+import { SlideConfirmButton } from "@/components/godui/slide-confirm-button";
+```
+
+```tsx
+<SlideConfirmButton label="Slide to pay" onConfirm={charge} />
+```
+
+When `onConfirm` returns a promise, the thumb shows a spinner and the track swaps in `loadingLabel` while the work runs, then lands on the confirmed state once it resolves. If the promise rejects, the control springs back to idle so the action can be retried.
 
 ## Props
 
@@ -87,3 +87,5 @@ export function SlideConfirmButtonAsync() {
 | `label` | `ReactNode` | `"Slide to confirm"` | Track label |
 | `loadingLabel` | `ReactNode` | `"Working…"` | Label shown while an async `onConfirm` is pending |
 | `confirmedLabel` | `ReactNode` | `"Confirmed"` | Label after confirming |
+
+</Workbench>

--- a/apps/docs/content/docs/components/collaboration/comment-pin/index.mdx
+++ b/apps/docs/content/docs/components/collaboration/comment-pin/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Comment Pin
 description: Figma-style annotation pins that spring in over any surface and expand into a threaded comment popover with a reply field.
+workbench: true
 ---
 
 import { CommentPinDemo } from "@/components/demos/comment-pin-demo";
 
-<ComponentPreview
+<Workbench>
+
+Figma-style annotation pins that spring in over any surface and expand into a threaded comment popover with a reply field.
+
+<Example
+  label="Default"
   fullWidth
   story="collaboration-commentpin"
   code={`import { CommentPin } from "@/components/godui/comment-pin";
@@ -28,7 +34,7 @@ export function CommentPinDemo() {
 }`}
 >
   <CommentPinDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -61,3 +67,5 @@ import { CommentPin } from "@/components/godui/comment-pin";
 | `open`         | `boolean`                 | —       | Controlled open state.                   |
 | `onOpenChange` | `(open: boolean) => void` | —       | Fired when the thread toggles.           |
 | `onReply`      | `(text: string) => void`  | —       | Enables and handles the reply field.     |
+
+</Workbench>

--- a/apps/docs/content/docs/components/collaboration/live-cursors/index.mdx
+++ b/apps/docs/content/docs/components/collaboration/live-cursors/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Live Cursors
 description: Smoothly interpolated multiplayer cursors with trailing name flags and optional cursor-chat — the signature "this app is alive" effect.
+workbench: true
 ---
 
 import { LiveCursorsDemo } from "@/components/demos/live-cursors-demo";
 
-<ComponentPreview
+<Workbench>
+
+Smoothly interpolated multiplayer cursors with trailing name flags and optional cursor-chat — the signature "this app is alive" effect.
+
+<Example
+  label="Default"
   fullWidth
   story="collaboration-livecursors"
   code={`import {
@@ -24,7 +30,7 @@ export function LiveCursorsDemo() {
 }`}
 >
   <LiveCursorsDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -66,3 +72,5 @@ import { LiveCursors } from "@/components/godui/live-cursors";
 | Prop    | Type       | Default                  | Description                  |
 | ------- | ---------- | ------------------------ | ---------------------------- |
 | `names` | `string[]` | four sample teammates    | Names for the drifting peers.|
+
+</Workbench>

--- a/apps/docs/content/docs/components/collaboration/notification-inbox/index.mdx
+++ b/apps/docs/content/docs/components/collaboration/notification-inbox/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Notification Inbox
 description: A Linear-style notification center with time-bucketed groups, unread accent rails, swipe-to-archive, mark-all-read, and a polished empty state.
+workbench: true
 ---
 
 import { NotificationInboxDemo } from "@/components/demos/notification-inbox-demo";
 
-<ComponentPreview
+<Workbench>
+
+A Linear-style notification center with time-bucketed groups, unread accent rails, swipe-to-archive, mark-all-read, and a polished empty state.
+
+<Example
+  label="Default"
   story="collaboration-notificationinbox"
   code={`import { NotificationInbox } from "@/components/godui/notification-inbox";
 import { useState } from "react";
@@ -26,7 +32,7 @@ export function NotificationInboxDemo() {
 }`}
 >
   <NotificationInboxDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -60,3 +66,5 @@ import { NotificationInbox } from "@/components/godui/notification-inbox";
 | `onArchive`     | `(id: string) => void`    | —         | Fired when a row is swiped away.    |
 | `onMarkAllRead` | `() => void`              | —         | Fired by the mark-all-read action.  |
 | `title`         | `string`                  | `"Inbox"` | Header title.                       |
+
+</Workbench>

--- a/apps/docs/content/docs/components/collaboration/presence-facepile/index.mdx
+++ b/apps/docs/content/docs/components/collaboration/presence-facepile/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Presence Facepile
 description: Live avatars with animated status rings, spring join/leave, and a +N overflow that expands into a presence list — who's online, idle, or typing right now.
+workbench: true
 ---
 
 import { PresenceFacepileDemo } from "@/components/demos/presence-facepile-demo";
 
-<ComponentPreview
+<Workbench>
+
+Live avatars with animated status rings, spring join/leave, and a +N overflow that expands into a presence list — who's online, idle, or typing right now.
+
+<Example
+  label="Default"
   story="collaboration-presencefacepile"
   code={`import { PresenceFacepile } from "@/components/godui/presence-facepile";
 
@@ -23,7 +29,7 @@ export function PresenceFacepileDemo() {
 }`}
 >
   <PresenceFacepileDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -52,3 +58,5 @@ import { PresenceFacepile } from "@/components/godui/presence-facepile";
 | `max`        | `number`                  | `5`     | Avatars before the `+N` chip.        |
 | `size`       | `"sm" \| "md" \| "lg"`    | `"md"`  | Avatar size.                         |
 | `showStatus` | `boolean`                 | `true`  | Render status rings/typing dots.     |
+
+</Workbench>

--- a/apps/docs/content/docs/components/effects/beam-draw/index.mdx
+++ b/apps/docs/content/docs/components/effects/beam-draw/index.mdx
@@ -1,13 +1,17 @@
 ---
 title: Beam Draw
 description: SVG beams that draw themselves along scroll progress with a soft glow.
+workbench: true
 ---
 
 import { BeamDrawDemo } from "@/components/demos/beam-draw-demo";
 
+<Workbench>
+
 A set of flowing SVG beams that stroke themselves into existence as you scroll, trailing a soft glow — the connective, high-energy accent for a hero or section transition. Scroll the preview.
 
-<ComponentPreview
+<Example
+  label="Default"
   fullWidth
   story="effects-beam-draw"
   code={`import { BeamDraw } from "@/components/godui/beam-draw";
@@ -27,7 +31,7 @@ export function Pipeline() {
 }`}
 >
   <BeamDrawDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -61,3 +65,5 @@ viewBox.
 | `strokeWidth` | `number`   | `2`            | Stroke width of each beam.                    |
 
 `BeamDraw` also forwards every standard `<svg>` attribute to the root.
+
+</Workbench>

--- a/apps/docs/content/docs/components/effects/border-beam/index.mdx
+++ b/apps/docs/content/docs/components/effects/border-beam/index.mdx
@@ -1,17 +1,21 @@
 ---
 title: Border Beam
 description: An animated beam of light that travels around the border of its container.
+workbench: true
 ---
 
 import { BorderBeam } from "@godui/components";
 import { BorderBeamDemo } from "@/components/demos/border-beam-demo";
+
+<Workbench>
 
 A streak of light rides the border of whatever you put it in. Drop it inside a
 `relative overflow-hidden` element — most often a [shadcn
 `Card`](https://ui.shadcn.com/docs/components/card) — and it traces the rounded
 corners on a loop.
 
-<ComponentPreview
+<Example
+  label="Default"
   story="effects-border-beam"
   code={`import { BorderBeam } from "@/components/godui/border-beam";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
@@ -34,7 +38,7 @@ export function BorderBeamDemo() {
 }`}
 >
   <BorderBeamDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -79,7 +83,8 @@ self-contained — drop `BorderBeam` into your own `Card` the same way.
 
 Set `reverse` to send the beam counter-clockwise.
 
-<ComponentPreview
+<Example
+  label="Reverse"
   code={`import { BorderBeam } from "@/components/godui/border-beam";
 
 export function BorderBeamReverse() {
@@ -95,13 +100,14 @@ export function BorderBeamReverse() {
     <p className="text-sm text-muted-foreground">Counter-clockwise beam.</p>
     <BorderBeam size={70} reverse />
   </div>
-</ComponentPreview>
+</Example>
 
 ### Glow
 
 `glow` renders a soft blurred echo behind the beam for a neon look.
 
-<ComponentPreview
+<Example
+  label="Glow"
   code={`import { BorderBeam } from "@/components/godui/border-beam";
 
 export function BorderBeamGlow() {
@@ -117,14 +123,15 @@ export function BorderBeamGlow() {
     <p className="text-sm text-muted-foreground">Glowing beam.</p>
     <BorderBeam size={80} glow />
   </div>
-</ComponentPreview>
+</Example>
 
 ### Thick colored
 
 Turn `rainbow` off and pass `colorFrom` / `colorTo` to drive your own gradient,
 with a wider `borderWidth`.
 
-<ComponentPreview
+<Example
+  label="Thick Colored"
   code={`import { BorderBeam } from "@/components/godui/border-beam";
 
 export function BorderBeamColored() {
@@ -152,13 +159,14 @@ export function BorderBeamColored() {
       colorTo="var(--chart-4)"
     />
   </div>
-</ComponentPreview>
+</Example>
 
 ### Dual beams
 
 Render two beams with opposite `delay` values for a continuous double chase.
 
-<ComponentPreview
+<Example
+  label="Dual Beams"
   code={`import { BorderBeam } from "@/components/godui/border-beam";
 
 export function BorderBeamDual() {
@@ -176,7 +184,7 @@ export function BorderBeamDual() {
     <BorderBeam size={70} duration={6} />
     <BorderBeam size={70} duration={6} delay={3} />
   </div>
-</ComponentPreview>
+</Example>
 
 ## Props
 
@@ -194,3 +202,5 @@ export function BorderBeamDual() {
 | `glow` | `boolean` | `false` | Render a soft blurred echo behind the beam. |
 
 Also accepts standard `div` attributes (e.g. `className`, `style`).
+
+</Workbench>

--- a/apps/docs/content/docs/components/effects/confetti/index.mdx
+++ b/apps/docs/content/docs/components/effects/confetti/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Confetti
 description: A physics-based confetti burst with an imperative fire API for celebratory moments.
+workbench: true
 ---
 
 import { ConfettiDemo } from "@/components/demos/confetti-demo";
 
-<ComponentPreview
+<Workbench>
+
+A physics-based confetti burst with an imperative fire API for celebratory moments.
+
+<Example
+  label="Default"
   story="effects-confetti"
   code={`import { ConfettiButton } from "@/components/godui/confetti";
 
@@ -18,7 +24,7 @@ export function ConfettiDemo() {
 }`}
 >
   <ConfettiDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -74,3 +80,5 @@ confetti({ particleCount: 200, spread: 120 });
 
 Forwards every standard `<button>` attribute. `ConfettiOptions` is re-exported
 from `canvas-confetti`.
+
+</Workbench>

--- a/apps/docs/content/docs/components/effects/encrypted-card/index.mdx
+++ b/apps/docs/content/docs/components/effects/encrypted-card/index.mdx
@@ -2,13 +2,17 @@
 title: Encrypted Card
 description: A card whose surface hides a live stream of scrambling ciphertext, revealed only through a soft spotlight that follows the pointer.
 date: "2026-07-11"
+workbench: true
 ---
 
 import { EncryptedCardDemo } from "@/components/demos/encrypted-card-demo";
 
+<Workbench>
+
 Security and AI products love the "there's something powerful under the hood" feeling. `EncryptedCard` renders your real content on top, but the surface underneath is a living field of ciphertext that re-scrambles every frame — visible only inside a radial reveal that tracks the cursor. Move across the card and the encryption bleeds through, then re-seals.
 
-<ComponentPreview
+<Example
+  label="Default"
   story="effects-encrypted-card"
   code={`import { EncryptedCard } from "@/components/godui/encrypted-card";
 
@@ -31,7 +35,7 @@ export function ApiKeyCard() {
 }`}
 >
   <EncryptedCardDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -73,3 +77,5 @@ reveal becomes a static peek, so nothing flickers for motion-sensitive users.
 | `streamOpacity` | `number` | `1` | Opacity of the revealed glyph stream, 0–1. Lower values make the ciphertext subtler. |
 
 All other `div` props are forwarded to the root element.
+
+</Workbench>

--- a/apps/docs/content/docs/components/effects/fluid-cursor/index.mdx
+++ b/apps/docs/content/docs/components/effects/fluid-cursor/index.mdx
@@ -1,12 +1,18 @@
 ---
 title: Fluid Cursor
 description: A spring-lagged blend-mode cursor that trails the pointer and swells over interactive elements.
+workbench: true
 ---
 
 import { FluidCursor } from "@godui/components";
 import { FluidCursorDemo } from "@/components/demos/fluid-cursor-demo";
 
-<ComponentPreview
+<Workbench>
+
+A spring-lagged blend-mode cursor that trails the pointer and swells over interactive elements.
+
+<Example
+  label="Default"
   story="effects-fluid-cursor"
   code={`import { FluidCursor } from "@/components/godui/fluid-cursor";
 import { useRef } from "react";
@@ -22,7 +28,7 @@ export function FluidCursorDemo() {
 }`}
 >
   <FluidCursorDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -69,3 +75,5 @@ const ref = useRef(null);
 | `trail`               | `boolean`                         | `true`             | Render the soft lagging smear.                         |
 | `containerRef`        | `RefObject<HTMLElement \| null>`  | —                  | Scope the cursor to a positioned element.              |
 | `interactiveSelector` | `string`                          | links, buttons, `[data-cursor]` | Elements that enlarge the cursor on hover. |
+
+</Workbench>

--- a/apps/docs/content/docs/components/effects/image-trail/index.mdx
+++ b/apps/docs/content/docs/components/effects/image-trail/index.mdx
@@ -1,14 +1,18 @@
 ---
 title: Image Trail
 description: Images spawn along the pointer's path, pop in, and drift away — the signature portfolio hover effect.
+workbench: true
 ---
 
 import { ImageTrail } from "@godui/components";
 import { ImageTrailDemo } from "@/components/demos/image-trail-demo";
 
+<Workbench>
+
 As the pointer moves across the area, images are emitted along its path — each pops in, tilts toward the direction of travel, then drifts up and fades. Move your cursor across the frame below.
 
-<ComponentPreview
+<Example
+  label="Default"
   fullWidth
   story="effects-imagetrail"
   code={`import { ImageTrail } from "@/components/godui/image-trail";
@@ -27,7 +31,7 @@ export function Hero() {
 }`}
 >
   <ImageTrailDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -80,3 +84,5 @@ gallery of the images is shown instead. Trail images are decorative
 | `size`      | `number`   | `180`   | Width/height of each trail image, in px.                     |
 
 `ImageTrail` also forwards every standard `<div>` attribute to the root element.
+
+</Workbench>

--- a/apps/docs/content/docs/components/effects/lamp/index.mdx
+++ b/apps/docs/content/docs/components/effects/lamp/index.mdx
@@ -1,12 +1,18 @@
 ---
 title: Lamp
 description: A conic-gradient lamp that ignites and reveals a headline as it scrolls into view.
+workbench: true
 ---
 
 import { Lamp } from "@godui/components";
 import { LampDemo } from "@/components/demos/lamp-demo";
 
-<ComponentPreview
+<Workbench>
+
+A conic-gradient lamp that ignites and reveals a headline as it scrolls into view.
+
+<Example
+  label="Default"
   story="effects-lamp"
   code={`import { Lamp } from "@/components/godui/lamp";
 
@@ -19,7 +25,7 @@ export function LampDemo() {
 }`}
 >
   <LampDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -59,3 +65,5 @@ import { Lamp } from "@/components/godui/lamp";
 | `color` | `string` | `var(--primary)` | Accent color of the light.            |
 
 `Lamp` also forwards every standard `<div>` attribute to the root element.
+
+</Workbench>

--- a/apps/docs/content/docs/components/effects/liquid-image/index.mdx
+++ b/apps/docs/content/docs/components/effects/liquid-image/index.mdx
@@ -1,14 +1,18 @@
 ---
 title: Liquid Image
 description: A premium hover effect that ripples and distorts an image like liquid, intensifying with cursor speed.
+workbench: true
 ---
 
 import { LiquidImage } from "@godui/components";
 import { LiquidImageDemo } from "@/components/demos/liquid-image-demo";
 
+<Workbench>
+
 Hover an image and it distorts like the surface of water — the ripple ramps in, follows your cursor speed, and settles with a damped wave when you leave. Hover the images below.
 
-<ComponentPreview
+<Example
+  label="Default"
   story="effects-liquidimage"
   code={`import { LiquidImage } from "@/components/godui/liquid-image";
 
@@ -23,7 +27,7 @@ export function Gallery() {
 }`}
 >
   <LiquidImageDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -80,3 +84,5 @@ component degrades cleanly. Always pass a meaningful `alt`.
 | `imgClassName`| `string`               | —         | Classes for the inner `<img>` (sizing, aspect, object-fit).  |
 
 `LiquidImage` also forwards every standard `<div>` attribute to the root element.
+
+</Workbench>

--- a/apps/docs/content/docs/components/effects/marquee/index.mdx
+++ b/apps/docs/content/docs/components/effects/marquee/index.mdx
@@ -1,12 +1,18 @@
 ---
 title: Marquee
 description: An infinite, seamless scrolling row or column of content that pauses on hover.
+workbench: true
 ---
 
 import { Marquee } from "@godui/components";
 import { MarqueeDemo } from "@/components/demos/marquee-demo";
 
-<ComponentPreview
+<Workbench>
+
+An infinite, seamless scrolling row or column of content that pauses on hover.
+
+<Example
+  label="Default"
   story="effects-marquee"
   code={`import { Marquee } from "@/components/godui/marquee";
 
@@ -26,7 +32,7 @@ export function MarqueeDemo() {
 }`}
 >
   <MarqueeDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -72,7 +78,8 @@ the marquee a fixed height).
 
 ### Reverse direction
 
-<ComponentPreview
+<Example
+  label="Reverse Direction"
   code={`<Marquee direction="right" speed={26}>
   {["Design", "Engineering", "Motion", "Craft", "Detail", "Systems"].map((t) => (
     <span key={t} className="px-4 text-lg font-semibold text-muted-foreground">{t}</span>
@@ -84,13 +91,14 @@ the marquee a fixed height).
       <span key={t} className="px-4 text-lg font-semibold text-muted-foreground">{t}</span>
     ))}
   </Marquee>
-</ComponentPreview>
+</Example>
 
 ### Vertical
 
 Give a vertical marquee a fixed height; it scrolls along the column.
 
-<ComponentPreview
+<Example
+  label="Vertical"
   code={`<div className="flex h-64 justify-center">
   <Marquee direction="up" speed={18} className="h-full">
     {reviews.map((r) => (
@@ -106,7 +114,7 @@ Give a vertical marquee a fixed height; it scrolls along the column.
       ))}
     </Marquee>
   </div>
-</ComponentPreview>
+</Example>
 
 ## Props
 
@@ -119,3 +127,5 @@ Give a vertical marquee a fixed height; it scrolls along the column.
 | `repeat`       | `number`                                 | `4`      | Times the children are duplicated to fill the track.|
 
 `Marquee` also forwards every standard `<div>` attribute to the root element.
+
+</Workbench>

--- a/apps/docs/content/docs/components/effects/particle-dissolve/index.mdx
+++ b/apps/docs/content/docs/components/effects/particle-dissolve/index.mdx
@@ -1,14 +1,18 @@
 ---
 title: Particle Dissolve
 description: Text or an image is sampled into particles that scatter and reform — a dramatic entrance or transition.
+workbench: true
 ---
 
 import { ParticleDissolve } from "@godui/components";
 import { ParticleDissolveDemo } from "@/components/demos/particle-dissolve-demo";
 
+<Workbench>
+
 The source — a headline, a logo, or an image — is sampled into thousands of particles that fly in from scatter to form the shape, hold with a subtle shimmer, then disperse and reform. A strong second-read moment for a hero.
 
-<ComponentPreview
+<Example
+  label="Default"
   story="effects-particledissolve"
   code={`import { ParticleDissolve } from "@/components/godui/particle-dissolve";
 
@@ -17,7 +21,7 @@ export function Hero() {
 }`}
 >
   <ParticleDissolveDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -80,3 +84,5 @@ animation.
 | `width` / `height` | `number`                            | `640` / `240`  | Canvas size in CSS px.                               |
 
 `ParticleDissolve` also forwards every standard `<canvas>` attribute.
+
+</Workbench>

--- a/apps/docs/content/docs/components/effects/scroll-progress/index.mdx
+++ b/apps/docs/content/docs/components/effects/scroll-progress/index.mdx
@@ -1,15 +1,19 @@
 ---
 title: Scroll Progress
 description: A spring-smoothed reading indicator — a pinned top bar or a fading back-to-top ring.
+workbench: true
 ---
 
 import { ScrollProgressCircleDemo, ScrollProgressDemo } from "@/components/demos/scroll-progress-demo";
+
+<Workbench>
 
 The `bar` variant pins a progress line to the top of the page and fills as the
 reader scrolls. Leave `container` unset to track the whole page, or pass a ref
 to track a scrollable element (as the preview below does).
 
-<ComponentPreview
+<Example
+  label="Default"
   story="effects-scroll-progress"
   code={`import { ScrollProgress } from "@/components/godui/scroll-progress";
 
@@ -19,14 +23,15 @@ export function ScrollProgressDemo() {
 }`}
 >
   <ScrollProgressDemo />
-</ComponentPreview>
+</Example>
 
 ## Circle variant
 
 `variant="circle"` renders a circular progress ring that fades in past
 `showAfter` and scrolls back to top on click.
 
-<ComponentPreview
+<Example
+  label="Circle Variant"
   code={`import { ScrollProgress } from "@/components/godui/scroll-progress";
 
 export function ScrollProgressCircle() {
@@ -34,7 +39,7 @@ export function ScrollProgressCircle() {
 }`}
 >
   <ScrollProgressCircleDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -64,3 +69,5 @@ const ref = useRef<HTMLElement>(null);
 | `size` | `number` | `44` | Ring diameter in px. |
 | `showAfter` | `number` | `0.05` | Reveal the ring past this fraction. |
 | `position` | `"bottom-right" \| "bottom-left"` | `"bottom-right"` | Corner the ring docks to. |
+
+</Workbench>

--- a/apps/docs/content/docs/components/effects/scroll-reveal/index.mdx
+++ b/apps/docs/content/docs/components/effects/scroll-reveal/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Scroll Reveal
 description: Reveals its children with a spring as they scroll into view, with optional velocity skew.
+workbench: true
 ---
 
 import { ScrollReveal } from "@godui/components";
 
-<ComponentPreview
+<Workbench>
+
+Reveals its children with a spring as they scroll into view, with optional velocity skew.
+
+<Example
+  label="Default"
   story="effects-scrollreveal"
   code={`import { ScrollReveal } from "@/components/godui/scroll-reveal";
 
@@ -20,7 +26,7 @@ export function ScrollRevealDemo() {
   <ScrollReveal>
     <div className="rounded-xl border border-border bg-card p-8 text-lg font-semibold text-foreground shadow-sm">I reveal on scroll</div>
   </ScrollReveal>
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -72,7 +78,8 @@ Use `delay` on adjacent reveals to stagger them.
 
 Reveal a set of cards in sequence as the group scrolls into view.
 
-<ComponentPreview
+<Example
+  label="Staggered Grid"
   code={`<div className="grid grid-cols-3 gap-3">
   {items.map((item, i) => (
     <ScrollReveal key={item} delay={i * 0.1}>
@@ -88,11 +95,12 @@ Reveal a set of cards in sequence as the group scrolls into view.
       </ScrollReveal>
     ))}
   </div>
-</ComponentPreview>
+</Example>
 
 ### From the left, no blur
 
-<ComponentPreview
+<Example
+  label="From The Left"
   code={`<ScrollReveal direction="left" distance={80} blur={false}>
   <div className="rounded-xl border border-border bg-card p-8 text-lg font-semibold text-foreground shadow-sm">Slides in from the left</div>
 </ScrollReveal>`}
@@ -100,7 +108,7 @@ Reveal a set of cards in sequence as the group scrolls into view.
   <ScrollReveal direction="left" distance={80} blur={false}>
     <div className="rounded-xl border border-border bg-card p-8 text-lg font-semibold text-foreground shadow-sm">Slides in from the left</div>
   </ScrollReveal>
-</ComponentPreview>
+</Example>
 
 ## Props
 
@@ -114,3 +122,5 @@ Reveal a set of cards in sequence as the group scrolls into view.
 | `velocitySkew` | `boolean`                                | `false` | Skew the content by scroll velocity.                 |
 
 `ScrollReveal` also forwards every standard `<div>` attribute to the root element.
+
+</Workbench>

--- a/apps/docs/content/docs/components/effects/spotlight-card/index.mdx
+++ b/apps/docs/content/docs/components/effects/spotlight-card/index.mdx
@@ -1,12 +1,18 @@
 ---
 title: Spotlight Card
 description: A card with a radial spotlight glow that follows the pointer, optionally lighting the border.
+workbench: true
 ---
 
 import { SpotlightCard } from "@godui/components";
 import { SpotlightCardDemo } from "@/components/demos/spotlight-card-demo";
 
-<ComponentPreview
+<Workbench>
+
+A card with a radial spotlight glow that follows the pointer, optionally lighting the border.
+
+<Example
+  label="Default"
   story="effects-spotlightcard"
   code={`import { SpotlightCard } from "@/components/godui/spotlight-card";
 import { Check } from "lucide-react";
@@ -35,7 +41,7 @@ export function PricingCard() {
 }`}
 >
   <SpotlightCardDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -79,7 +85,8 @@ import { SpotlightCard } from "@/components/godui/spotlight-card";
 A standalone surface — move the pointer across it to see the glow track and the
 border light up.
 
-<ComponentPreview
+<Example
+  label="Single Card"
   code={`<SpotlightCard className="max-w-sm p-8">
   <h3 className="text-lg font-semibold text-foreground">Pointer-aware surface</h3>
   <p className="mt-2 text-sm text-muted-foreground">A soft radial glow follows the cursor and lights the 1px border.</p>
@@ -89,11 +96,12 @@ border light up.
     <h3 className="text-lg font-semibold text-foreground">Pointer-aware surface</h3>
     <p className="mt-2 text-sm text-muted-foreground">A soft radial glow follows the cursor and lights the 1px border.</p>
   </SpotlightCard>
-</ComponentPreview>
+</Example>
 
 ### Custom glow color
 
-<ComponentPreview
+<Example
+  label="Custom Glow Color"
   code={`<SpotlightCard
   glowColor="color-mix(in oklch, oklch(0.7 0.2 320) 45%, transparent)"
   radius={240}
@@ -111,14 +119,15 @@ border light up.
     <h3 className="text-lg font-semibold text-foreground">Any color you like</h3>
     <p className="mt-2 text-sm text-muted-foreground">Pass any CSS color through glowColor.</p>
   </SpotlightCard>
-</ComponentPreview>
+</Example>
 
 ### Border glow
 
 With `border` enabled (the default), the same gradient is masked to the 1px ring,
 so the border itself lights up where the pointer is closest. Move along the edges.
 
-<ComponentPreview
+<Example
+  label="Border Glow"
   code={`<SpotlightCard
   border
   radius={300}
@@ -138,7 +147,7 @@ so the border itself lights up where the pointer is closest. Move along the edge
     <h3 className="text-lg font-semibold text-foreground">Trace the edge</h3>
     <p className="mt-2 text-sm text-muted-foreground">The border brightens where the pointer is closest, then fades behind it.</p>
   </SpotlightCard>
-</ComponentPreview>
+</Example>
 
 ## Props
 
@@ -149,3 +158,5 @@ so the border itself lights up where the pointer is closest. Move along the edge
 | `border`    | `boolean` | `true`                                                  | Also light the card border on move.      |
 
 `SpotlightCard` also forwards every standard `<div>` attribute to the root element.
+
+</Workbench>

--- a/apps/docs/content/docs/components/effects/spotlight-reveal/index.mdx
+++ b/apps/docs/content/docs/components/effects/spotlight-reveal/index.mdx
@@ -1,14 +1,18 @@
 ---
 title: Spotlight Reveal
 description: A cursor-following flashlight that cuts through the top layer to expose a hidden layer beneath.
+workbench: true
 ---
 
 import { SpotlightReveal } from "@godui/components";
 import { SpotlightRevealDemo } from "@/components/demos/spotlight-reveal-demo";
 
+<Workbench>
+
 Two layers stacked, with a soft spotlight that follows your cursor and punches a hole in the top one — revealing whatever sits beneath. Idle, the spotlight drifts to invite a hover; click to pin it in place. Move across the panel below.
 
-<ComponentPreview
+<Example
+  label="Default"
   story="effects-spotlightreveal"
   code={`import { SpotlightReveal } from "@/components/godui/spotlight-reveal";
 
@@ -30,7 +34,7 @@ export function Reveal() {
 }`}
 >
   <SpotlightRevealDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -82,3 +86,5 @@ beneath.
 | `ease`     | `number`         | `0.16`  | Follow easing per frame, 0 (frozen) – 1 (instant).           |
 
 The cover layer is passed as `children`. `SpotlightReveal` also forwards every standard `<div>` attribute to the root element.
+
+</Workbench>

--- a/apps/docs/content/docs/components/effects/terminal/index.mdx
+++ b/apps/docs/content/docs/components/effects/terminal/index.mdx
@@ -2,13 +2,17 @@
 title: Terminal
 description: An animated terminal window that types out a scripted sequence of commands and output, with window chrome and a blinking caret.
 date: "2026-07-11"
+workbench: true
 ---
 
 import { TerminalDemo } from "@/components/demos/terminal-demo";
 
+<Workbench>
+
 Nothing says "developer tool" like a terminal that types itself. `Terminal` plays a scripted sequence — commands type out character by character with a blinking caret, output lands after a beat — inside a clean window frame. It starts when it scrolls into view, can loop, and collapses to plain text for screen readers and reduced-motion users.
 
-<ComponentPreview
+<Example
+  label="Default"
   story="effects-terminal"
   code={`import { Terminal } from "@/components/godui/terminal";
 
@@ -28,7 +32,7 @@ export function Install() {
 }`}
 >
   <TerminalDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -79,3 +83,5 @@ blink, and the full transcript is always exposed to assistive tech.
 
 `TerminalLine.type` is `"command" \| "output" \| "comment"` (default `"output"`).
 All other `div` props are forwarded to the root element.
+
+</Workbench>

--- a/apps/docs/content/docs/components/glass/liquid-glass-card/index.mdx
+++ b/apps/docs/content/docs/components/glass/liquid-glass-card/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Liquid Glass Card
 description: A glass panel that refracts the content behind it with a mouse-tracked specular highlight.
+workbench: true
 ---
 
 import { LiquidGlassCard } from "@godui/components";
 
-<ComponentPreview
+<Workbench>
+
+A glass panel that refracts the content behind it with a mouse-tracked specular highlight.
+
+<Example
+  label="Default"
   fullWidth
   story="effects-liquid-glass-card"
   code={`import { LiquidGlassCard } from "@/components/godui/liquid-glass-card";
@@ -27,7 +33,7 @@ export function LiquidGlassCardDemo() {
       <p className="mt-2 text-sm text-white/80">Move your cursor across the panel.</p>
     </LiquidGlassCard>
   </div>
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -90,3 +96,5 @@ for a subtle pane of frost.
 
 `LiquidGlassCard` also forwards every standard `<div>` attribute (`className`,
 `style`, `id`, …) to the root element.
+
+</Workbench>

--- a/apps/docs/content/docs/components/glass/liquid-glass-lens/index.mdx
+++ b/apps/docs/content/docs/components/glass/liquid-glass-lens/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Liquid Glass Lens
 description: A circular glass lens that floats over your content and follows the cursor, refracting everything beneath it.
+workbench: true
 ---
 
 import { LiquidGlassLens } from "@godui/components";
 
-<ComponentPreview
+<Workbench>
+
+A circular glass lens that floats over your content and follows the cursor, refracting everything beneath it.
+
+<Example
+  label="Default"
   fullWidth
   story="effects-liquid-glass-lens"
   code={`import { LiquidGlassLens } from "@/components/godui/liquid-glass-lens";
@@ -25,7 +31,7 @@ export function LiquidGlassLensDemo() {
     <h2 className="pointer-events-none select-none text-5xl font-bold tracking-tight text-white drop-shadow">Liquid Glass</h2>
     <LiquidGlassLens size={200} strength={80} />
   </div>
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -78,3 +84,5 @@ import { LiquidGlassLens } from "@/components/godui/liquid-glass-lens";
 
 `LiquidGlassLens` also forwards every standard `<div>` attribute (`className`,
 `style`, `id`, …) to the root element.
+
+</Workbench>

--- a/apps/docs/content/docs/components/inputs/magic-input/index.mdx
+++ b/apps/docs/content/docs/components/inputs/magic-input/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Magic Input
 description: A 3D layered text input that lifts on focus with an optional rainbow edge animation.
+workbench: true
 ---
 
 import { MagicInput } from "@godui/components";
 
-<ComponentPreview
+<Workbench>
+
+A 3D layered text input that lifts on focus with an optional rainbow edge animation.
+
+<Example
+  label="Default"
   story="inputs-magic-input"
   code={`import { MagicInput } from "@/components/godui/magic-input";
 
@@ -24,14 +30,15 @@ export function MagicInputDemo() {
     <MagicInput rainbow={false} placeholder="Primary" />
     <MagicInput variant="secondary" rainbow={false} placeholder="Secondary" />
   </div>
-</ComponentPreview>
+</Example>
 
 ## Variants
 
 The `variant` tints the 3D edge. It shows when `rainbow={false}` (the rainbow
 gradient otherwise overrides the edge while focused).
 
-<ComponentPreview
+<Example
+  label="Variants"
   code={`import { MagicInput } from "@/components/godui/magic-input";
 
 export function MagicInputVariants() {
@@ -47,14 +54,15 @@ export function MagicInputVariants() {
     <MagicInput variant="primary" rainbow={false} placeholder="Primary" />
     <MagicInput variant="secondary" rainbow={false} placeholder="Secondary" />
   </div>
-</ComponentPreview>
+</Example>
 
 ## Depth
 
 `depth="focus"` (default) stays flat until focused. `depth="always"` keeps the
 raised 3D look at rest.
 
-<ComponentPreview
+<Example
+  label="Depth"
   code={`import { MagicInput } from "@/components/godui/magic-input";
 
 export function MagicInputDepth() {
@@ -70,11 +78,12 @@ export function MagicInputDepth() {
     <MagicInput depth="focus" placeholder="On focus" />
     <MagicInput depth="always" placeholder="Always raised" />
   </div>
-</ComponentPreview>
+</Example>
 
 ## Sizes
 
-<ComponentPreview
+<Example
+  label="Sizes"
   code={`import { MagicInput } from "@/components/godui/magic-input";
 
 export function MagicInputSizes() {
@@ -92,7 +101,7 @@ export function MagicInputSizes() {
     <MagicInput size="md" placeholder="Medium" />
     <MagicInput size="lg" placeholder="Large" />
   </div>
-</ComponentPreview>
+</Example>
 
 ## Submit button
 
@@ -100,7 +109,8 @@ Pass `onSubmit` to render an arrow button on the right. It fires with the
 current value on click or when <kbd>Enter</kbd> is pressed. Without `onSubmit`,
 set `submitButton` to render a `type="submit"` button for an enclosing form.
 
-<ComponentPreview
+<Example
+  label="Submit Button"
   code={`import { MagicInput } from "@/components/godui/magic-input";
 
 export function MagicInputSubmit() {
@@ -116,7 +126,7 @@ export function MagicInputSubmit() {
     <MagicInput placeholder="Type and submit" submitButton />
     <MagicInput size="lg" placeholder="Larger" submitButton />
   </div>
-</ComponentPreview>
+</Example>
 
 ## Submit lifecycle
 
@@ -126,7 +136,8 @@ determinate when you pass `progress`, otherwise an indeterminate segment bounces
 end to end. The arrow turns into a circular progress / spinner. `success` and
 `error` flash a green / red sweep with a check / X icon.
 
-<ComponentPreview
+<Example
+  label="Submit Lifecycle"
   code={`import { MagicInput } from "@/components/godui/magic-input";
 
 export function MagicInputStatus() {
@@ -146,7 +157,7 @@ export function MagicInputStatus() {
     <MagicInput placeholder="Success" submitButton status="success" />
     <MagicInput placeholder="Error" submitButton status="error" />
   </div>
-</ComponentPreview>
+</Example>
 
 You drive it from your submit handler:
 
@@ -207,3 +218,5 @@ disable the animated rainbow edge.
 | `submitLabel` | `string` | `"Submit"` | Accessible label for the submit button |
 | `status` | `"idle" \| "loading" \| "success" \| "error"` | `"idle"` | Submit lifecycle state |
 | `progress` | `number` | — | 0–100; makes `loading` determinate (omit for indeterminate) |
+
+</Workbench>

--- a/apps/docs/content/docs/components/inputs/otp-input/index.mdx
+++ b/apps/docs/content/docs/components/inputs/otp-input/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: OTP Input
 description: A segmented one-time-code input with auto-advance, paste-to-fill, a traveling caret, and error shake.
+workbench: true
 ---
 
 import { OTPInput } from "@godui/components";
 
-<ComponentPreview
+<Workbench>
+
+A segmented one-time-code input with auto-advance, paste-to-fill, a traveling caret, and error shake.
+
+<Example
+  label="Default"
   story="inputs-otp-input"
   code={`import { OTPInput } from "@/components/godui/otp-input";
 
@@ -14,13 +20,10 @@ export function OTPInputDemo() {
 }`}
 >
   <OTPInput length={6} />
-</ComponentPreview>
+</Example>
 
-## Masked
-
-Set `mask` to render entered characters as dots — useful for sensitive codes.
-
-<ComponentPreview
+<Example
+  label="Masked"
   code={`import { OTPInput } from "@/components/godui/otp-input";
 
 export function OTPInputMasked() {
@@ -28,14 +31,10 @@ export function OTPInputMasked() {
 }`}
 >
   <OTPInput length={6} mask />
-</ComponentPreview>
+</Example>
 
-## Validation status
-
-`status="error"` shakes the row; `status="success"` settles it. Flip back to
-`idle` to re-arm the shake.
-
-<ComponentPreview
+<Example
+  label="Validation status"
   code={`import { OTPInput } from "@/components/godui/otp-input";
 
 export function OTPInputStatus() {
@@ -51,7 +50,16 @@ export function OTPInputStatus() {
     <OTPInput length={6} status="error" defaultValue="1234" />
     <OTPInput length={6} status="success" defaultValue="123456" />
   </div>
-</ComponentPreview>
+</Example>
+
+## Masked
+
+Set `mask` to render entered characters as dots — useful for sensitive codes.
+
+## Validation status
+
+`status="error"` shakes the row; `status="success"` settles it. Flip back to
+`idle` to re-arm the shake.
 
 ## Installation
 
@@ -79,3 +87,5 @@ import { OTPInput } from "@godui/components";
 | `autoFocus` | `boolean` | `false` | Focus on mount. |
 | `onChange` | `(value: string) => void` | — | Fires on every change. |
 | `onComplete` | `(value: string) => void` | — | Fires when the last cell fills. |
+
+</Workbench>

--- a/apps/docs/content/docs/components/layout/accordion/index.mdx
+++ b/apps/docs/content/docs/components/layout/accordion/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Accordion
 description: A disclosure list with spring height animation, rotating chevrons, and single or multiple open modes.
+workbench: true
 ---
 
 import { Accordion } from "@godui/components";
@@ -24,7 +25,12 @@ export const faqItems = [
   },
 ];
 
-<ComponentPreview
+<Workbench>
+
+A disclosure list with spring height animation, rotating chevrons, and single or multiple open modes.
+
+<Example
+  label="Default"
   story="layout-accordion"
   code={`import { Accordion } from "@/components/godui/accordion";
 
@@ -40,13 +46,14 @@ export function AccordionDemo() {
   <div className="w-full max-w-lg">
     <Accordion items={faqItems} defaultValue="what" />
   </div>
-</ComponentPreview>
+</Example>
 
 ## Multiple open
 
 `type="multiple"` lets any number of panels stay open at once.
 
-<ComponentPreview
+<Example
+  label="Multiple Open"
   code={`import { Accordion } from "@/components/godui/accordion";
 
 export function AccordionMultiple() {
@@ -56,13 +63,14 @@ export function AccordionMultiple() {
   <div className="w-full max-w-lg">
     <Accordion items={faqItems} type="multiple" />
   </div>
-</ComponentPreview>
+</Example>
 
 ## Animation
 
 `animation` sets the motion feel of the height transition — `smooth` (default, no overshoot), `spring` (soft overshoot), or `bounce` (playful).
 
-<ComponentPreview
+<Example
+  label="Animation"
   code={`import { Accordion } from "@/components/godui/accordion";
 
 export function AccordionBounce() {
@@ -72,7 +80,7 @@ export function AccordionBounce() {
   <div className="w-full max-w-lg">
     <Accordion items={faqItems} defaultValue="what" animation="bounce" />
   </div>
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -99,3 +107,5 @@ import { Accordion } from "@godui/components";
 | `defaultValue` | `string \| string[]` | — | Initially open value(s). |
 | `collapsible` | `boolean` | `true` | Allow closing the open panel in single mode. |
 | `animation` | `"smooth" \| "spring" \| "bounce"` | `"smooth"` | Motion feel of the height animation. |
+
+</Workbench>

--- a/apps/docs/content/docs/components/layout/animated-testimonials/index.mdx
+++ b/apps/docs/content/docs/components/layout/animated-testimonials/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Animated Testimonials
 description: A testimonial carousel with a shuffling image stack and crossfading quotes.
+workbench: true
 ---
 
 import { AnimatedTestimonials } from "@godui/components";
@@ -20,7 +21,12 @@ export const demoTestimonials = [
   },
 ];
 
-<ComponentPreview
+<Workbench>
+
+A testimonial carousel with a shuffling image stack and crossfading quotes.
+
+<Example
+  label="Default"
   story="layout-animatedtestimonials"
   code={`import { AnimatedTestimonials } from "@/components/godui/animated-testimonials";
 
@@ -34,7 +40,7 @@ export function AnimatedTestimonialsDemo() {
 }`}
 >
   <AnimatedTestimonials testimonials={demoTestimonials} />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -68,3 +74,5 @@ const testimonials = [
 
 Each `Testimonial` is `{ quote, name, role, src }`. The component also forwards every
 standard `<div>` attribute to the root element.
+
+</Workbench>

--- a/apps/docs/content/docs/components/layout/app-showcase/index.mdx
+++ b/apps/docs/content/docs/components/layout/app-showcase/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: App Showcase
 description: A realistic iPhone or Android device frame that shows your app on screen, with scroll, loop, carousel, and cluster interactions.
+workbench: true
 ---
 
 import { AppShowcaseDemo } from "@/components/demos/app-showcase-demo";
@@ -8,9 +9,12 @@ import { AppShowcaseCarouselDemo } from "@/components/demos/app-showcase-carouse
 import { AppShowcaseClusterDemo } from "@/components/demos/app-showcase-cluster-demo";
 import { AppShowcaseFramesDemo } from "@/components/demos/app-showcase-frames-demo";
 
+<Workbench>
+
 The hero shot of every mobile-app landing page: your screenshots or demo video framed in a real device. Pick a device and an interaction — the screen pans as you scroll, auto-scrolls on a loop, cross-fades a feature tour, or fans out into a parallax cluster. The screen below auto-scrolls while it is in view.
 
-<ComponentPreview
+<Example
+  label="Default"
   story="layout-app-showcase"
   code={`import { AppShowcase } from "@/components/godui/app-showcase";
 
@@ -27,7 +31,7 @@ export function Hero() {
 }`}
 >
   <AppShowcaseDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -65,37 +69,40 @@ preview at the top of this page). Swap `device` for the Android frame:
 
 Cross-fade through multiple screens with dot controls.
 
-<ComponentPreview
+<Example
+  label="Carousel"
   code={`<AppShowcase
   mode="carousel"
   screens={["/a.png", "/b.png", "/c.png"]}
 />`}
 >
   <AppShowcaseCarouselDemo />
-</ComponentPreview>
+</Example>
 
 ### Cluster — parallax centerpiece
 
 Two or three phones at different depths that react to the pointer.
 
-<ComponentPreview
+<Example
+  label="Cluster"
   code={`<AppShowcase
   mode="cluster"
   screens={["/a.png", "/b.png", "/c.png"]}
 />`}
 >
   <AppShowcaseClusterDemo />
-</ComponentPreview>
+</Example>
 
 ### Frame colors
 
 Each device comes in `black`, `silver`, and `gold` finishes.
 
-<ComponentPreview
+<Example
+  label="Frame Colors"
   code={`<AppShowcase mode="loop" frameColor="silver" src="/app-tall.png" />`}
 >
   <AppShowcaseFramesDemo />
-</ComponentPreview>
+</Example>
 
 ## Props
 
@@ -113,3 +120,5 @@ Each device comes in `black`, `silver`, and `gold` finishes.
 | `alt`        | `string`                                      | —          | Accessible label for the screen media.                         |
 
 `AppShowcase` also forwards every standard `<div>` attribute to the root.
+
+</Workbench>

--- a/apps/docs/content/docs/components/layout/avatar-group/index.mdx
+++ b/apps/docs/content/docs/components/layout/avatar-group/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Avatar Group
 description: Overlapping avatars that fan apart on hover, with a +N overflow chip.
+workbench: true
 ---
 
 import { AvatarGroup } from "@godui/components";
@@ -14,7 +15,12 @@ export const people = [
   { src: "https://i.pravatar.cc/80?img=6", alt: "Jo" },
 ];
 
-<ComponentPreview
+<Workbench>
+
+Overlapping avatars that fan apart on hover, with a +N overflow chip.
+
+<Example
+  label="Default"
   story="layout-avatar-group"
   code={`import { AvatarGroup } from "@/components/godui/avatar-group";
 
@@ -32,11 +38,12 @@ export function AvatarGroupDemo() {
 }`}
 >
   <AvatarGroup avatars={people} max={4} />
-</ComponentPreview>
+</Example>
 
 ## Sizes
 
-<ComponentPreview
+<Example
+  label="Sizes"
   code={`import { AvatarGroup } from "@/components/godui/avatar-group";
 
 export function AvatarGroupSizes() {
@@ -54,7 +61,7 @@ export function AvatarGroupSizes() {
     <AvatarGroup avatars={people} max={4} size="md" />
     <AvatarGroup avatars={people} max={4} size="lg" />
   </div>
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -79,3 +86,5 @@ import { AvatarGroup } from "@godui/components";
 | `max` | `number` | `4` | Max shown before the `+N` chip. |
 | `size` | `"sm" \| "md" \| "lg"` | `"md"` | Avatar size. |
 | `spreadOnHover` | `boolean` | `true` | Fan the stack apart on hover. |
+
+</Workbench>

--- a/apps/docs/content/docs/components/layout/bento-grid/index.mdx
+++ b/apps/docs/content/docs/components/layout/bento-grid/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Bento Grid
 description: A modular bento layout of mixed-size cards that stagger in on scroll and lift with a spotlight on hover.
+workbench: true
 ---
 
 import { BentoGridDemo } from "@/components/demos/bento-grid-demo";
 
-<ComponentPreview
+<Workbench>
+
+A modular bento layout of mixed-size cards that stagger in on scroll and lift with a spotlight on hover.
+
+<Example
+  label="Default"
   story="layout-bentogrid"
   code={`import { BentoGrid, BentoCard } from "@/components/godui/bento-grid";
 import { Sparkles, Activity, ShieldCheck, Globe2 } from "lucide-react";
@@ -42,7 +48,7 @@ export function BentoGridDemo() {
 }`}
 >
   <BentoGridDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -88,3 +94,5 @@ own `children` for full control.
 | `cta`         | `ReactNode`    | —       | Call-to-action pinned to the bottom.     |
 
 Both components forward every standard `<div>` attribute to their root element.
+
+</Workbench>

--- a/apps/docs/content/docs/components/layout/card-swap/index.mdx
+++ b/apps/docs/content/docs/components/layout/card-swap/index.mdx
@@ -1,14 +1,18 @@
 ---
 title: Card Swap
 description: A 3D stack of cards that cycles through a showcase loop, with pointer parallax and spring re-flow.
+workbench: true
 ---
 
 import { CardSwap } from "@godui/components";
 import { CardSwapDemo } from "@/components/demos/card-swap-demo";
 
+<Workbench>
+
 A compact, eye-catching way to cycle product features or screens in a hero corner. Cards sit in a 3D perspective stack and spring to their new slot on each swap; the whole stack tilts toward your pointer. Hover to pause, or use the arrows.
 
-<ComponentPreview
+<Example
+  label="Default"
   story="layout-cardswap"
   code={`import { CardSwap } from "@/components/godui/card-swap";
 
@@ -32,7 +36,7 @@ export function FeatureSwap() {
 }`}
 >
   <CardSwapDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -91,3 +95,5 @@ disabled.
 | `scaleStep`    | `number`  | `0.06`   | Scale removed per card going back.                     |
 
 `CardSwap` also forwards every standard `<div>` attribute to the root element.
+
+</Workbench>

--- a/apps/docs/content/docs/components/layout/container-scroll/index.mdx
+++ b/apps/docs/content/docs/components/layout/container-scroll/index.mdx
@@ -1,13 +1,17 @@
 ---
 title: Container Scroll
 description: A device frame that un-tilts from a 3D perspective and scales to rest as you scroll — the classic product hero.
+workbench: true
 ---
 
 import { ContainerScrollDemo } from "@/components/demos/container-scroll-demo";
 
+<Workbench>
+
 The frame starts tilted back in 3D space and gently un-tilts, scales down, and settles as the section scrolls into view — while the headline rises above it. The staple hero moment for a product screenshot or demo video. Scroll the preview.
 
-<ComponentPreview
+<Example
+  label="Default"
   fullWidth
   story="layout-container-scroll"
   code={`import { ContainerScroll } from "@/components/godui/container-scroll";
@@ -21,7 +25,7 @@ export function Hero() {
 }`}
 >
   <ContainerScrollDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -56,3 +60,5 @@ UI. `img` and `video` children are stretched to cover automatically.
 | `children` | `React.ReactNode` | —       | The screen content (image, video, or UI).         |
 
 `ContainerScroll` also forwards every standard `<div>` attribute to the root.
+
+</Workbench>

--- a/apps/docs/content/docs/components/layout/cover-flow/index.mdx
+++ b/apps/docs/content/docs/components/layout/cover-flow/index.mdx
@@ -1,14 +1,18 @@
 ---
 title: Cover Flow
 description: A physics 3D cover flow — the centered slide faces front while neighbours rotate away in perspective, with momentum drag and snap.
+workbench: true
 ---
 
 import { CoverFlow } from "@godui/components";
 import { CoverFlowDemo } from "@/components/demos/cover-flow-demo";
 
+<Workbench>
+
 A tactile way to browse album art, product shots, or covers. Drag across the stage — the row telescopes in 3D and snaps to the nearest slide when you let go. Drag, click a side slide, use the buttons, or the arrow keys.
 
-<ComponentPreview
+<Example
+  label="Default"
   story="layout-coverflow"
   code={`import { CoverFlow } from "@/components/godui/cover-flow";
 
@@ -23,7 +27,7 @@ export function Albums() {
 }`}
 >
   <CoverFlowDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -87,3 +91,5 @@ set, the 3D rotation and depth are dropped for a flat cross-fade.
 | `reflection`   | `boolean`                   | `true`  | Render a fading floor reflection under each slide.   |
 
 `CoverFlow` also forwards every standard `<div>` attribute to the root element.
+
+</Workbench>

--- a/apps/docs/content/docs/components/layout/gooey-stack/index.mdx
+++ b/apps/docs/content/docs/components/layout/gooey-stack/index.mdx
@@ -2,6 +2,7 @@
 title: Gooey Stack
 description: A stack of cards that fuse with a liquid metaball bridge and collapse behind an anchor with a spring.
 date: "2026-07-16"
+workbench: true
 ---
 
 import { GooeyStack } from "@godui/components";
@@ -9,9 +10,12 @@ import { GooeyStackDemo } from "@/components/demos/gooey-stack-demo";
 import { GooeyNotificationsDemo } from "@/components/demos/gooey-notifications-demo";
 import { GooeyWalletDemo } from "@/components/demos/gooey-wallet-demo";
 
+<Workbench>
+
 Stack content and let the surfaces behave like liquid. As the gap between cards shrinks their rounded surfaces bulge and fuse through a gooey metaball bridge; push it negative and the upper cards frost over — heavy blur, fading opacity — and dissolve into the anchor. Toggle `collapsed`, or drive `gap` from a slider for the full continuous sweep.
 
-<ComponentPreview
+<Example
+  label="Default"
   story="layout-gooeystack"
   code={`import { GooeyStack } from "@/components/godui/gooey-stack";
 import { useState } from "react";
@@ -37,7 +41,7 @@ export function ConnectPrompt() {
 }`}
 >
   <GooeyStackDemo />
-</ComponentPreview>
+</Example>
 
 ## Examples
 
@@ -45,7 +49,8 @@ Stacks with **more than two** children collapse rank by rank — the ones furthe
 from the anchor recede and frost the most, with a staggered spring. A notification
 tray folds its history into the newest alert:
 
-<ComponentPreview
+<Example
+  label="Notifications"
   code={`import { GooeyStack } from "@/components/godui/gooey-stack";
 import { useState } from "react";
 
@@ -63,13 +68,14 @@ export function NotificationTray() {
 }`}
 >
   <GooeyNotificationsDemo />
-</ComponentPreview>
+</Example>
 
 The same shape reads as a wallet — three cards fanned out, folding into a stack.
 Keep children on the fused `bg-card` surface and let color come from small accents,
 so the metaball bridge stays seamless:
 
-<ComponentPreview
+<Example
+  label="Wallet"
   code={`import { GooeyStack } from "@/components/godui/gooey-stack";
 import { useState } from "react";
 
@@ -87,7 +93,7 @@ export function Wallet() {
 }`}
 >
   <GooeyWalletDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -159,3 +165,5 @@ and the cards snap between states instead of springing.
 | `radius`       | `number`          | `28`    | Corner radius (px) of the fused surfaces.                               |
 
 `GooeyStack` also forwards every standard `<div>` attribute to the root element.
+
+</Workbench>

--- a/apps/docs/content/docs/components/layout/hero-parallax/index.mdx
+++ b/apps/docs/content/docs/components/layout/hero-parallax/index.mdx
@@ -1,13 +1,17 @@
 ---
 title: Hero Parallax
 description: A scroll-driven grid of cards that drift in alternating directions on a tilted perspective plane.
+workbench: true
 ---
 
 import { HeroParallaxDemo } from "@/components/demos/hero-parallax-demo";
 
+<Workbench>
+
 Three rows of cards drift in alternating directions as you scroll, while the whole plane un-tilts and rises into view. The classic hero moment for a portfolio or product reel. Scroll the preview.
 
-<ComponentPreview
+<Example
+  label="Default"
   fullWidth
   story="layout-hero-parallax"
   code={`import { HeroParallax } from "@/components/godui/hero-parallax";
@@ -25,7 +29,7 @@ export function Showcase() {
 }`}
 >
   <HeroParallaxDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -77,3 +81,5 @@ Pass `header` to replace the default headline block with your own.
 
 Each item is `{ title: string; thumbnail: string; href?: string }`.
 `HeroParallax` also forwards every standard `<div>` attribute to the root.
+
+</Workbench>

--- a/apps/docs/content/docs/components/layout/holographic-card/index.mdx
+++ b/apps/docs/content/docs/components/layout/holographic-card/index.mdx
@@ -2,12 +2,18 @@
 title: Holographic Card
 description: A trading-card holo effect — iridescent foil, specular glare, and glitter that tilt and shift with the pointer or device gyroscope.
 date: "2026-07-10"
+workbench: true
 ---
 
 import { HolographicCard } from "@godui/components";
 import { HolographicCardDemo } from "@/components/demos/holographic-card-demo";
 
-<ComponentPreview
+<Workbench>
+
+A trading-card holo effect — iridescent foil, specular glare, and glitter that tilt and shift with the pointer or device gyroscope.
+
+<Example
+  label="Default"
   story="layout-holographic-card"
   code={`import { HolographicCard } from "@/components/godui/holographic-card";
 
@@ -24,7 +30,7 @@ export function HolographicCardDemo() {
 }`}
 >
   <HolographicCardDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -53,7 +59,8 @@ import { HolographicCard } from "@/components/godui/holographic-card";
 
 ### Colorways
 
-<ComponentPreview
+<Example
+  label="Colorways"
   code={`<div className="flex flex-wrap items-center justify-center gap-6">
   <HolographicCard variant="aurora" className="h-40 w-28" />
   <HolographicCard variant="galaxy" className="h-40 w-28" />
@@ -65,7 +72,7 @@ import { HolographicCard } from "@/components/godui/holographic-card";
     <HolographicCard variant="galaxy" className="h-40 w-28" />
     <HolographicCard variant="gold" className="h-40 w-28" />
   </div>
-</ComponentPreview>
+</Example>
 
 ## Props
 
@@ -78,3 +85,5 @@ import { HolographicCard } from "@/components/godui/holographic-card";
 | `gyroscope`  | `boolean`                                     | `false`     | Drive the tilt from the device gyroscope on touch.    |
 
 `HolographicCard` also forwards every standard `<div>` attribute to the root element.
+
+</Workbench>

--- a/apps/docs/content/docs/components/layout/image-accordion/index.mdx
+++ b/apps/docs/content/docs/components/layout/image-accordion/index.mdx
@@ -1,14 +1,18 @@
 ---
 title: Image Accordion
 description: Horizontal image panels that expand on hover to reveal their caption — an elegant, space-efficient gallery.
+workbench: true
 ---
 
 import { ImageAccordion } from "@godui/components";
 import { ImageAccordionDemo } from "@/components/demos/image-accordion-demo";
 
+<Workbench>
+
 An elegant way to show a handful of features or images in a single band. Hover or focus a panel and it eases wide while the others compress — the image saturates and zooms, and the caption slides up. Move across the panels below.
 
-<ComponentPreview
+<Example
+  label="Default"
   story="layout-imageaccordion"
   code={`import { ImageAccordion } from "@/components/godui/image-accordion";
 
@@ -24,7 +28,7 @@ export function Gallery() {
 }`}
 >
   <ImageAccordionDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -86,3 +90,5 @@ instantly.
 | `height`       | `string`                | `"26rem"` | Height of the accordion (any CSS length).                |
 
 Each `ImageAccordionPanel` has `image`, `title`, optional `description`, and optional `href`.
+
+</Workbench>

--- a/apps/docs/content/docs/components/layout/image-compare/index.mdx
+++ b/apps/docs/content/docs/components/layout/image-compare/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Image Compare
 description: A draggable before/after slider with clip-path reveal, keyboard support, and a pulsing handle hint.
+workbench: true
 ---
 
 import { ImageCompareDemo, ImageCompareVerticalDemo } from "@/components/demos/image-compare-demo";
 
-<ComponentPreview
+<Workbench>
+
+A draggable before/after slider with clip-path reveal, keyboard support, and a pulsing handle hint.
+
+<Example
+  label="Default"
   story="layout-image-compare"
   code={`import { ImageCompare } from "@/components/godui/image-compare";
 
@@ -23,11 +29,12 @@ export function ImageCompareDemo() {
 }`}
 >
   <ImageCompareDemo />
-</ComponentPreview>
+</Example>
 
 ## Vertical
 
-<ComponentPreview
+<Example
+  label="Vertical"
   code={`import { ImageCompare } from "@/components/godui/image-compare";
 
 export function ImageCompareVertical() {
@@ -43,7 +50,7 @@ export function ImageCompareVertical() {
 }`}
 >
   <ImageCompareVerticalDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -74,3 +81,5 @@ larger steps).
 | `beforeLabel` | `string` | — | Badge over the before layer. |
 | `afterLabel` | `string` | — | Badge over the after layer. |
 | `onChange` | `(position: number) => void` | — | Fires as the handle moves. |
+
+</Workbench>

--- a/apps/docs/content/docs/components/layout/inertia-gallery/index.mdx
+++ b/apps/docs/content/docs/components/layout/inertia-gallery/index.mdx
@@ -1,14 +1,18 @@
 ---
 title: Inertia Gallery
 description: A horizontal gallery you throw with the pointer — momentum carries it, it rubber-bands at the ends, and slides scale, blur, and fade with distance from center.
+workbench: true
 ---
 
 import { InertiaGallery } from "@godui/components";
 import { InertiaGalleryDemo } from "@/components/demos/inertia-gallery-demo";
 
+<Workbench>
+
 Throw the strip and let it coast. Each slide scales up, sharpens, and brightens as it nears the center, and dims and blurs as it drifts away — the Apple-Photos feel. Drag, use the buttons, or the arrow keys.
 
-<ComponentPreview
+<Example
+  label="Default"
   story="layout-inertiagallery"
   fullWidth
   code={`import { InertiaGallery } from "@/components/godui/inertia-gallery";
@@ -24,7 +28,7 @@ export function Shots() {
 }`}
 >
   <InertiaGalleryDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -86,3 +90,5 @@ plainly.
 | `onChange`  | `(index: number) => void` | —       | Fired when a new slide reaches center.                          |
 
 `InertiaGallery` also forwards every standard `<div>` attribute to the root element.
+
+</Workbench>

--- a/apps/docs/content/docs/components/layout/morph-gallery/index.mdx
+++ b/apps/docs/content/docs/components/layout/morph-gallery/index.mdx
@@ -1,14 +1,18 @@
 ---
 title: Morph Gallery
 description: A thumbnail grid where a tile morphs into a fullscreen detail view via a shared-element transition, with swipe and keyboard navigation.
+workbench: true
 ---
 
 import { MorphGallery } from "@godui/components";
 import { MorphGalleryDemo } from "@/components/demos/morph-gallery-demo";
 
+<Workbench>
+
 Click a thumbnail and it morphs — the same image element grows from its grid slot into a fullscreen detail via a shared-layout transition. Move between photos with the arrows or keys; close and it morphs back into place.
 
-<ComponentPreview
+<Example
+  label="Default"
   story="layout-morphgallery"
   code={`import { MorphGallery } from "@/components/godui/morph-gallery";
 
@@ -26,7 +30,7 @@ export function Gallery() {
 }`}
 >
   <MorphGalleryDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -79,3 +83,5 @@ cross-fade.
 | `onOpenChange` | `(index: number \| null) => void` | —      | Fired when the detail view opens or closes.   |
 
 `MorphGallery` also forwards every standard `<div>` attribute to the root element.
+
+</Workbench>

--- a/apps/docs/content/docs/components/layout/orbit-carousel/index.mdx
+++ b/apps/docs/content/docs/components/layout/orbit-carousel/index.mdx
@@ -1,14 +1,18 @@
 ---
 title: Orbit Carousel
 description: Slides ride an arc and rotate around a pivot, tilting and receding with angular distance from the front, with momentum drag and snap.
+workbench: true
 ---
 
 import { OrbitCarousel } from "@godui/components";
 import { OrbitCarouselDemo } from "@/components/demos/orbit-carousel-demo";
 
+<Workbench>
+
 Slides fan out on a wheel and rotate around a pivot below the stage. The front slide sits upright and full-size; the rest tilt, shrink, and dim as they curve away. Drag, click a slide, use the buttons, or the arrow keys.
 
-<ComponentPreview
+<Example
+  label="Default"
   story="layout-orbitcarousel"
   code={`import { OrbitCarousel } from "@/components/godui/orbit-carousel";
 
@@ -23,7 +27,7 @@ export function Wheel() {
 }`}
 >
   <OrbitCarouselDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -77,3 +81,5 @@ set, the per-slide tilt is dropped.
 | `onChange`     | `(index: number) => void` | —       | Fired when a new slide settles at the front.   |
 
 `OrbitCarousel` also forwards every standard `<div>` attribute to the root element.
+
+</Workbench>

--- a/apps/docs/content/docs/components/layout/progressive-card-reveal/index.mdx
+++ b/apps/docs/content/docs/components/layout/progressive-card-reveal/index.mdx
@@ -1,16 +1,20 @@
 ---
 title: Progressive Card Reveal
 description: A vertical stack of cards where one card expands to its full view while the rest collapse to compact pills, animating the morph between them.
+workbench: true
 ---
 
 import { ProgressiveCardRevealDemo } from "@/components/demos/progressive-card-reveal-demo";
+
+<Workbench>
 
 A vertical stack of cards. Exactly one card is expanded at a time — the rest
 collapse to compact pills. The parent owns which card is active; clicking a
 collapsed pill asks it to switch, and Framer Motion animates the size morph and
 crossfades the content.
 
-<ComponentPreview
+<Example
+  label="Default"
   story="layout-progressive-card-reveal"
   code={`import { ProgressiveCardReveal } from "@/components/godui/progressive-card-reveal";
 import { useState } from "react";
@@ -64,7 +68,7 @@ export function ProgressiveCardRevealDemo() {
 }`}
 >
   <ProgressiveCardRevealDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -121,3 +125,5 @@ Accepts all `div` attributes. Children must be a `CardCollapsed` and a
 ### ProgressiveCardReveal.CardCollapsed / CardExpanded
 
 Slot wrappers — their children are the collapsed (pill) and expanded views.
+
+</Workbench>

--- a/apps/docs/content/docs/components/layout/reorder-list/index.mdx
+++ b/apps/docs/content/docs/components/layout/reorder-list/index.mdx
@@ -1,12 +1,18 @@
 ---
 title: Reorder List
 description: A drag-to-reorder list where items lift on grab, spring to place, and neighbours flow around them.
+workbench: true
 ---
 
 import { ReorderList, ReorderItem } from "@godui/components";
 import { ReorderListDemo } from "@/components/demos/reorder-list-demo";
 
-<ComponentPreview
+<Workbench>
+
+A drag-to-reorder list where items lift on grab, spring to place, and neighbours flow around them.
+
+<Example
+  label="Default"
   story="layout-reorder-list"
   code={`import { ReorderList, ReorderItem } from "@/components/godui/reorder-list";
 import { useState } from "react";
@@ -30,7 +36,7 @@ export function ReorderListDemo() {
 }`}
 >
   <ReorderListDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -78,3 +84,5 @@ Set `axis="x"` for a horizontal list.
 | `value` | `T`  | —       | The value this item represents within `values`.      |
 
 Both components forward every standard attribute to their underlying `<ul>` / `<li>`.
+
+</Workbench>

--- a/apps/docs/content/docs/components/layout/scroll-stack/index.mdx
+++ b/apps/docs/content/docs/components/layout/scroll-stack/index.mdx
@@ -1,14 +1,18 @@
 ---
 title: Scroll Stack
 description: Pinned cards that scale, recede, and stack as the page scrolls — the premium feature-reveal section.
+workbench: true
 ---
 
 import { ScrollStack } from "@godui/components";
 import { ScrollStackDemo } from "@/components/demos/scroll-stack-demo";
 
+<Workbench>
+
 Each card pins to the top of the scroller while the next one rises over it. As a card is buried it eases down to a smaller scale, dims, and blurs — so depth reads even on a flat stack. Scroll the frame below.
 
-<ComponentPreview
+<Example
+  label="Default"
   story="layout-scrollstack"
   code={`import { ScrollStack } from "@/components/godui/scroll-stack";
 
@@ -33,7 +37,7 @@ export function FeatureStack() {
 }`}
 >
   <ScrollStackDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -93,3 +97,5 @@ vertical list — no pinning, scaling, or blur.
 | `pinTop`    | `string`  | `"12vh"`  | Distance from the top of the scroller where cards pin.                      |
 
 `ScrollStack` also forwards every standard `<div>` attribute to the root element.
+
+</Workbench>

--- a/apps/docs/content/docs/components/layout/spin-viewer/index.mdx
+++ b/apps/docs/content/docs/components/layout/spin-viewer/index.mdx
@@ -2,13 +2,17 @@
 title: Spin Viewer
 description: A 360° product viewer — drag to spin an object through a sequence of frames, with optional idle auto-rotate and a touch-friendly hint.
 date: "2026-07-11"
+workbench: true
 ---
 
 import { SpinViewerDemo } from "@/components/demos/spin-viewer-demo";
 
+<Workbench>
+
 The Apple-store trick for making a product feel real: let people grab it and spin it. `SpinViewer` turns an ordered sequence of frames into a draggable 360° object — mouse or touch. It preloads every frame so the spin is buttery, idles with a slow auto-rotate until the first grab, and drops a "drag to rotate" hint for first-timers. Perfect for a product hero, an app device shot, or a portfolio centerpiece.
 
-<ComponentPreview
+<Example
+  label="Default"
   story="layout-spin-viewer"
   code={`import { SpinViewer } from "@/components/godui/spin-viewer";
 
@@ -18,7 +22,7 @@ export function Product() {
 }`}
 >
   <SpinViewerDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -67,3 +71,5 @@ auto-rotate is disabled under `prefers-reduced-motion` — dragging always works
 | `label` | `string` | `"360-degree view…"` | Accessible label for the viewer. |
 
 All other `div` props are forwarded to the root element.
+
+</Workbench>

--- a/apps/docs/content/docs/components/layout/stack-badge/index.mdx
+++ b/apps/docs/content/docs/components/layout/stack-badge/index.mdx
@@ -2,13 +2,17 @@
 title: Stack Badge
 description: A tech-stack wall of monochrome logo chips that stagger in on scroll and lift into their full brand color with a soft glow on hover.
 date: "2026-07-10"
+workbench: true
 ---
 
 import { StackBadgeDemo } from "@/components/demos/stack-badge-demo";
 
+<Workbench>
+
 The portfolio flex, done right. Instead of a flat row of grey logos, `StackBadge` renders your stack as calm monochrome chips that stagger in on scroll, then lift and warm into their full brand color on hover. Batteries-included: reference 20 popular technologies by name, or drop in any custom `{ name, icon, color }`.
 
-<ComponentPreview
+<Example
+  label="Default"
   story="layout-stack-badge"
   code={`import { StackBadge } from "@/components/godui/stack-badge";
 
@@ -21,7 +25,7 @@ export function Stack() {
 }`}
 >
   <StackBadgeDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -79,3 +83,5 @@ Built-in keys: `react`, `nextjs`, `typescript`, `javascript`, `tailwind`, `node`
 
 `StackBadge` forwards every standard `<div>` attribute. The chips sit still at
 rest — the enter stagger and hover lift both respect `prefers-reduced-motion`.
+
+</Workbench>

--- a/apps/docs/content/docs/components/layout/stepper/index.mdx
+++ b/apps/docs/content/docs/components/layout/stepper/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Stepper
 description: A step indicator with a spring-filled progress line and a number-to-checkmark morph.
+workbench: true
 ---
 
 import { Stepper } from "@godui/components";
@@ -13,7 +14,12 @@ export const onboarding = [
   { label: "Done", description: "All set" },
 ];
 
-<ComponentPreview
+<Workbench>
+
+A step indicator with a spring-filled progress line and a number-to-checkmark morph.
+
+<Example
+  label="Default"
   story="layout-stepper"
   code={`import { Stepper } from "@/components/godui/stepper";
 
@@ -30,14 +36,15 @@ export function StepperDemo() {
   <div className="w-full max-w-xl">
     <Stepper steps={onboarding} active={1} />
   </div>
-</ComponentPreview>
+</Example>
 
 ## Interactive
 
 Drive `active` from state to walk through the steps — the line fills and each
 completed step morphs its number into a checkmark.
 
-<ComponentPreview
+<Example
+  label="Interactive"
   code={`import { useState } from "react";
 import { Stepper } from "@/components/godui/stepper";
 
@@ -57,11 +64,12 @@ export function StepperInteractive() {
 }`}
 >
   <StepperInteractiveDemo />
-</ComponentPreview>
+</Example>
 
 ## Vertical
 
-<ComponentPreview
+<Example
+  label="Vertical"
   code={`import { Stepper } from "@/components/godui/stepper";
 
 export function StepperVertical() {
@@ -69,7 +77,7 @@ export function StepperVertical() {
 }`}
 >
   <Stepper steps={onboarding} active={2} orientation="vertical" />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -97,3 +105,5 @@ import { Stepper } from "@godui/components";
 | `steps` | `Step[]` | — | `{ label, description? }`. |
 | `active` | `number` | — | Zero-based current step; earlier steps render complete. |
 | `orientation` | `"horizontal" \| "vertical"` | `"horizontal"` | Layout direction. |
+
+</Workbench>

--- a/apps/docs/content/docs/components/layout/sticky-scroll/index.mdx
+++ b/apps/docs/content/docs/components/layout/sticky-scroll/index.mdx
@@ -1,13 +1,17 @@
 ---
 title: Sticky Scroll
 description: A pinned two-column reveal where scrolling the text steps a synced visual panel through each item.
+workbench: true
 ---
 
 import { StickyScrollDemo } from "@/components/demos/sticky-scroll-demo";
 
+<Workbench>
+
 Text scrolls in the left column while a pinned panel on the right swaps to match the item in view — the premium way to walk through features one beat at a time. Scroll the preview.
 
-<ComponentPreview
+<Example
+  label="Default"
   fullWidth
   story="layout-sticky-scroll"
   code={`import { StickyScroll } from "@/components/godui/sticky-scroll";
@@ -24,7 +28,7 @@ export function Features() {
 }`}
 >
   <StickyScrollDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -58,3 +62,5 @@ import { StickyScroll } from "@/components/godui/sticky-scroll";
 
 Each item is `{ title: string; description: React.ReactNode; content: React.ReactNode }`.
 `StickyScroll` also forwards every standard `<div>` attribute to the root.
+
+</Workbench>

--- a/apps/docs/content/docs/components/layout/store-badge/index.mdx
+++ b/apps/docs/content/docs/components/layout/store-badge/index.mdx
@@ -1,14 +1,18 @@
 ---
 title: Store Badge
 description: App Store and Google Play download badges with light/dark finishes, a hover sheen, and an optional scan-to-download QR popover.
+workbench: true
 ---
 
 import { StoreBadgeDemo } from "@/components/demos/store-badge-demo";
 import { StoreBadgeQrDemo } from "@/components/demos/store-badge-qr-demo";
 
+<Workbench>
+
 The download CTA that sits under every app hero. Drop in an App Store or Google Play badge, or use the group for the classic dual-badge row. Badges are inline SVG, scale with a single `height` prop, carry the official hairline border, and sweep a subtle sheen on hover.
 
-<ComponentPreview
+<Example
+  label="Default"
   story="layout-store-badge"
   code={`import { StoreBadge, StoreBadgeGroup } from "@/components/godui/store-badge";
 
@@ -22,7 +26,7 @@ export function Download() {
 }`}
 >
   <StoreBadgeDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -36,14 +40,15 @@ encodes the badge's `href` (or `qrUrl`) — so a laptop visitor can install on
 their phone. On touch, the popover is skipped and the badge links normally. The
 QR is generated on the client from the URL — no image, no setup.
 
-<ComponentPreview
+<Example
+  label="Scan To Download"
   code={`<StoreBadgeGroup>
   <StoreBadge store="app-store" href="https://apps.apple.com/app/id6761287549" qr />
   <StoreBadge store="google-play" href="https://play.google.com/store/apps/details?id=lol.hivemind" qr />
 </StoreBadgeGroup>`}
 >
   <StoreBadgeQrDemo />
-</ComponentPreview>
+</Example>
 
 ## Usage
 
@@ -87,3 +92,5 @@ import { QrCode } from "@/components/godui/store-badge";
 
 `StoreBadge` forwards every standard `<a>` attribute. `StoreBadgeGroup` is a flex
 row wrapper for the dual-badge CTA and forwards `<div>` attributes.
+
+</Workbench>

--- a/apps/docs/content/docs/components/layout/swipe-deck/index.mdx
+++ b/apps/docs/content/docs/components/layout/swipe-deck/index.mdx
@@ -1,14 +1,18 @@
 ---
 title: Swipe Deck
 description: A physics, Tinder-style swipeable card deck with throw-to-dismiss, directional intent, and keyboard controls.
+workbench: true
 ---
 
 import { SwipeDeck } from "@godui/components";
 import { SwipeDeckDemo } from "@/components/demos/swipe-deck-demo";
 
+<Workbench>
+
 A tactile way to page through profiles, testimonials, or onboarding screens. Drag the top card — it rotates with the throw and tints toward your intent; release past the threshold and it flies off while the next card springs forward. Drag, use the buttons, or the arrow keys.
 
-<ComponentPreview
+<Example
+  label="Default"
   story="layout-swipedeck"
   code={`import { SwipeDeck } from "@/components/godui/swipe-deck";
 
@@ -23,7 +27,7 @@ export function People() {
 }`}
 >
   <SwipeDeckDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -79,3 +83,5 @@ spring settling is removed.
 | `actions`   | `{ left: string; right: string }`           | —       | Labels for the left/right actions and intent badges.     |
 
 `SwipeDeck` also forwards every standard `<div>` attribute to the root element.
+
+</Workbench>

--- a/apps/docs/content/docs/components/layout/three-d-marquee/index.mdx
+++ b/apps/docs/content/docs/components/layout/three-d-marquee/index.mdx
@@ -1,13 +1,17 @@
 ---
 title: 3D Marquee
 description: A perspective grid of images whose columns drift in alternating directions on a tilted plane.
+workbench: true
 ---
 
 import { ThreeDMarqueeDemo } from "@/components/demos/three-d-marquee-demo";
 
+<Workbench>
+
 A wall of images laid on a tilted 3D plane, its columns drifting up and down in alternating directions — an ambient, high-impact showcase for a hero background or gallery.
 
-<ComponentPreview
+<Example
+  label="Default"
   fullWidth
   story="layout-three-d-marquee"
   code={`import { ThreeDMarquee } from "@/components/godui/three-d-marquee";
@@ -23,7 +27,7 @@ export function Showcase() {
 }`}
 >
   <ThreeDMarqueeDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -54,3 +58,5 @@ import { ThreeDMarquee } from "@/components/godui/three-d-marquee";
 | `columns` | `3 \| 4`   | `4`     | Number of columns.                             |
 
 `ThreeDMarquee` also forwards every standard `<div>` attribute to the root.
+
+</Workbench>

--- a/apps/docs/content/docs/components/layout/tilt-card/index.mdx
+++ b/apps/docs/content/docs/components/layout/tilt-card/index.mdx
@@ -1,12 +1,18 @@
 ---
 title: Tilt Card
 description: A card that tilts in 3D toward the pointer with parallax depth and a specular glare.
+workbench: true
 ---
 
 import { TiltCard } from "@godui/components";
 import { TiltCardDemo } from "@/components/demos/tilt-card-demo";
 
-<ComponentPreview
+<Workbench>
+
+A card that tilts in 3D toward the pointer with parallax depth and a specular glare.
+
+<Example
+  label="Default"
   story="layout-tilt-card"
   code={`import { TiltCard } from "@/components/godui/tilt-card";
 
@@ -20,7 +26,7 @@ export function TiltCardDemo() {
 }`}
 >
   <TiltCardDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -47,7 +53,8 @@ import { TiltCard } from "@/components/godui/tilt-card";
 
 ### Stronger tilt and depth
 
-<ComponentPreview
+<Example
+  label="Stronger Tilt"
   code={`<TiltCard maxTilt={22} depth={70} className="w-72 p-6">
   <h3 className="text-lg font-semibold text-foreground">Deeper parallax</h3>
   <p className="mt-2 text-sm text-muted-foreground">Crank maxTilt and depth for a more dramatic effect.</p>
@@ -57,7 +64,7 @@ import { TiltCard } from "@/components/godui/tilt-card";
     <h3 className="text-lg font-semibold text-foreground">Deeper parallax</h3>
     <p className="mt-2 text-sm text-muted-foreground">Crank maxTilt and depth for a more dramatic effect.</p>
   </TiltCard>
-</ComponentPreview>
+</Example>
 
 ## Props
 
@@ -69,3 +76,5 @@ import { TiltCard } from "@/components/godui/tilt-card";
 | `glare`   | `boolean` | `true`  | Render a specular glare that follows the pointer.    |
 
 `TiltCard` also forwards every standard `<div>` attribute to the root element.
+
+</Workbench>

--- a/apps/docs/content/docs/components/navigation/breadcrumbs/index.mdx
+++ b/apps/docs/content/docs/components/navigation/breadcrumbs/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Breadcrumbs
 description: A breadcrumb trail with a shared-element hover pill that springs between crumbs, animated path changes, and an overflow that collapses into a popover.
+workbench: true
 ---
 
 import { BreadcrumbsDemo, BreadcrumbsCollapsedDemo } from "@/components/demos/breadcrumbs-demo";
 
-<ComponentPreview
+<Workbench>
+
+A breadcrumb trail with a shared-element hover pill that springs between crumbs, animated path changes, and an overflow that collapses into a popover.
+
+<Example
+  label="Default"
   story="navigation-breadcrumbs"
   code={`"use client";
 import { Breadcrumbs } from "@/components/godui/breadcrumbs";
@@ -23,7 +29,7 @@ export function BreadcrumbsDemo() {
 }`}
 >
   <BreadcrumbsDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -53,7 +59,8 @@ Hovering crumbs slides a shared pill; the last crumb is marked as the current pa
 
 Pass `maxItems` to fold the middle into a `…` button that springs open into a popover.
 
-<ComponentPreview
+<Example
+  label="Collapsed Overflow"
   code={`"use client";
 import { Breadcrumbs } from "@/components/godui/breadcrumbs";
 
@@ -71,7 +78,7 @@ export function BreadcrumbsCollapsed() {
 }`}
 >
   <BreadcrumbsCollapsedDemo />
-</ComponentPreview>
+</Example>
 
 ## Props
 
@@ -82,3 +89,5 @@ export function BreadcrumbsCollapsed() {
 | `separator` | `ReactNode` | chevron | Node rendered between crumbs |
 | `collapsible` | `boolean` | `true` | Allow the collapsed middle to expand |
 | `onNavigate` | `(href: string) => void` | — | Called on crumb click (prevents default) |
+
+</Workbench>

--- a/apps/docs/content/docs/components/navigation/combobox/index.mdx
+++ b/apps/docs/content/docs/components/navigation/combobox/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Combobox
 description: A type-ahead autocomplete with staggered result reveal, highlighted matches, keyboard navigation, and an async loading state.
+workbench: true
 ---
 
 import { ComboboxDemo, ComboboxAsyncDemo, ComboboxMultiSelectDemo, ComboboxCreatableDemo, ComboboxPlainDemo, ComboboxPinnedActionDemo, ComboboxEmptyActionDemo } from "@/components/demos/combobox-demo";
 
-<ComponentPreview
+<Workbench>
+
+A type-ahead autocomplete with staggered result reveal, highlighted matches, keyboard navigation, and an async loading state.
+
+<Example
+  label="Default"
   story="navigation-combobox"
   code={`"use client";
 import { Combobox } from "@/components/godui/combobox";
@@ -24,7 +30,7 @@ export function AssigneePicker() {
 }`}
 >
   <ComboboxDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -49,7 +55,8 @@ const [value, setValue] = useState("");
 Pass `onSearch` to resolve options for a query — it debounces input and shows a
 loading state while results arrive.
 
-<ComponentPreview
+<Example
+  label="Async Search"
   code={`"use client";
 import { Combobox } from "@/components/godui/combobox";
 
@@ -72,14 +79,15 @@ export function FrameworkSearch() {
 }`}
 >
   <ComboboxAsyncDemo />
-</ComponentPreview>
+</Example>
 
 ### Disabled
 
 Set `disabled` to make the field non-interactive — it dims the input and prevents
 the listbox from opening.
 
-<ComponentPreview
+<Example
+  label="Disabled"
   code={`"use client";
 import { Combobox } from "@/components/godui/combobox";
 
@@ -93,14 +101,15 @@ export function DisabledPicker() {
 }`}
 >
   <ComboboxDemo disabled />
-</ComponentPreview>
+</Example>
 
 ### Multi-select
 
 Set `multiple` and drive it with `values` + `onToggle` to select several options.
 Chosen options render as chips in the control, and picking one keeps the list open.
 
-<ComponentPreview
+<Example
+  label="Multi-select"
   code={`"use client";
 import { Combobox } from "@/components/godui/combobox";
 import { useState } from "react";
@@ -129,7 +138,7 @@ export function Reviewers() {
 }`}
 >
   <ComboboxMultiSelectDemo />
-</ComponentPreview>
+</Example>
 
 ### Creatable
 
@@ -137,7 +146,8 @@ Set `creatable` to offer the typed value as an “Add …” row when it isn’t
 option. It commits a synthetic option by default, or pass `onCreate` to persist the
 new value yourself (with `creating` for an in-flight spinner).
 
-<ComponentPreview
+<Example
+  label="Creatable"
   code={`"use client";
 import { Combobox } from "@/components/godui/combobox";
 import { useState } from "react";
@@ -169,7 +179,7 @@ export function LabelPicker() {
 }`}
 >
   <ComboboxCreatableDemo />
-</ComponentPreview>
+</Example>
 
 ### Plain dropdown
 
@@ -177,7 +187,8 @@ A short list renders as a plain click-to-open dropdown — no search field — o
 has `searchableThreshold` options or fewer (5 by default). Force either mode with
 `searchable`.
 
-<ComponentPreview
+<Example
+  label="Plain Dropdown"
   code={`"use client";
 import { Combobox } from "@/components/godui/combobox";
 import { useState } from "react";
@@ -195,14 +206,15 @@ export function SizePicker() {
 }`}
 >
   <ComboboxPlainDemo />
-</ComponentPreview>
+</Example>
 
 ### Pinned action
 
 Pass `pinnedAction` to keep a persistent row at the top of the list — a place for a
 “manage” or “create” affordance that’s always reachable, whatever the query.
 
-<ComponentPreview
+<Example
+  label="Pinned Action"
   code={`"use client";
 import { Combobox } from "@/components/godui/combobox";
 import { useState } from "react";
@@ -226,14 +238,15 @@ export function AssigneePicker() {
 }`}
 >
   <ComboboxPinnedActionDemo />
-</ComponentPreview>
+</Example>
 
 ### Empty-state action
 
 Pass `emptyAction` to show a call-to-action when nothing matches — for example, to
 invite or create the thing the user was searching for.
 
-<ComponentPreview
+<Example
+  label="Empty-state Action"
   code={`"use client";
 import { Combobox } from "@/components/godui/combobox";
 import { useState } from "react";
@@ -258,7 +271,7 @@ export function AssigneePicker() {
 }`}
 >
   <ComboboxEmptyActionDemo />
-</ComponentPreview>
+</Example>
 
 ## Props
 
@@ -282,3 +295,5 @@ export function AssigneePicker() {
 | `searchableThreshold` | `number` | `5` | Option count above which search auto-enables |
 | `pinnedAction` | `ComboboxAction` | — | A persistent row (`{ label, onSelect }`) at the top of the list |
 | `emptyAction` | `ComboboxAction` | — | A CTA button (`{ label, onSelect }`) shown in the empty state |
+
+</Workbench>

--- a/apps/docs/content/docs/components/navigation/context-menu/index.mdx
+++ b/apps/docs/content/docs/components/navigation/context-menu/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Context Menu
 description: A right-click menu that springs open from the exact cursor point and flips to stay inside the viewport, with icons, shortcuts, and destructive actions.
+workbench: true
 ---
 
 import { ContextMenuDemo } from "@/components/demos/context-menu-demo";
 
-<ComponentPreview
+<Workbench>
+
+A right-click menu that springs open from the exact cursor point and flips to stay inside the viewport, with icons, shortcuts, and destructive actions.
+
+<Example
+  label="Default"
   story="navigation-context-menu"
   code={`"use client";
 import { ContextMenu } from "@/components/godui/context-menu";
@@ -33,7 +39,7 @@ export function FileContextMenu() {
 }`}
 >
   <ContextMenuDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -63,3 +69,5 @@ const items = [
 | ---- | ---- | ------- | ----------- |
 | `items` | `ContextMenuItem[]` | — | Items, separators, and labels |
 | `children` | `ReactNode` | — | The area that responds to right-click |
+
+</Workbench>

--- a/apps/docs/content/docs/components/navigation/dock/index.mdx
+++ b/apps/docs/content/docs/components/navigation/dock/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Dock
 description: A macOS-style dock whose items magnify with spring physics as the pointer moves across them.
+workbench: true
 ---
 
 import { DockDemo } from "@/components/demos/dock-demo";
 
-<ComponentPreview
+<Workbench>
+
+A macOS-style dock whose items magnify with spring physics as the pointer moves across them.
+
+<Example
+  label="Default"
   fullWidth
   story="navigation-dock"
   code={`import { Dock, DockItem } from "@/components/godui/dock";
@@ -33,7 +39,7 @@ export function DockDemo() {
 }`}
 >
   <DockDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -84,3 +90,5 @@ import { Dock, DockItem } from "@/components/godui/dock";
 
 Both components forward every standard `<div>` attribute to their root element.
 `DockItem` must be rendered inside a `Dock`.
+
+</Workbench>

--- a/apps/docs/content/docs/components/navigation/dropdown-menu/index.mdx
+++ b/apps/docs/content/docs/components/navigation/dropdown-menu/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Dropdown Menu
 description: An accessible dropdown that springs open from its trigger edge, with submenus, icons, shortcuts, separators, and full keyboard navigation.
+workbench: true
 ---
 
 import { DropdownMenuDemo } from "@/components/demos/dropdown-menu-demo";
 
-<ComponentPreview
+<Workbench>
+
+An accessible dropdown that springs open from its trigger edge, with submenus, icons, shortcuts, separators, and full keyboard navigation.
+
+<Example
+  label="Default"
   story="navigation-dropdown-menu"
   code={`"use client";
 import { DropdownMenu } from "@/components/godui/dropdown-menu";
@@ -36,7 +42,7 @@ export function AccountMenu() {
 }`}
 >
   <DropdownMenuDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -70,3 +76,5 @@ Items can be `{ type: "separator" }`, `{ type: "label", label }`, or an action w
 | `items` | `DropdownMenuItem[]` | — | Menu items, separators, labels, submenus |
 | `side` | `"top" \| "bottom" \| "left" \| "right"` | `"bottom"` | Panel side |
 | `align` | `"start" \| "center" \| "end"` | `"start"` | Panel alignment |
+
+</Workbench>

--- a/apps/docs/content/docs/components/navigation/filter-bar/index.mdx
+++ b/apps/docs/content/docs/components/navigation/filter-bar/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Filter Bar
 description: A faceted filter bar with searchable multi-select popovers, count badges, and selections that spring inline into each facet pill.
+workbench: true
 ---
 
 import { FilterBarDemo } from "@/components/demos/filter-bar-demo";
 
-<ComponentPreview
+<Workbench>
+
+A faceted filter bar with searchable multi-select popovers, count badges, and selections that spring inline into each facet pill.
+
+<Example
+  label="Default"
   story="navigation-filter-bar"
   code={`"use client";
 import { FilterBar } from "@/components/godui/filter-bar";
@@ -38,7 +44,7 @@ export function FilterBarDemo() {
 }`}
 >
   <FilterBarDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -77,3 +83,5 @@ selection inline (`Status: Open +2`) and clears with the inline `×`.
 | `onChange` | `(value) => void` | — | Called when the selection changes |
 | `searchable` | `boolean` | `true` | Show a search box in each popover |
 | `showCounts` | `boolean` | `true` | Show option count badges |
+
+</Workbench>

--- a/apps/docs/content/docs/components/navigation/magic-tab/index.mdx
+++ b/apps/docs/content/docs/components/navigation/magic-tab/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Magic Tab
 description: A segmented tab bar where the selected option lifts into a 3D button with an optional rainbow edge.
+workbench: true
 ---
 
 import { MagicTab } from "@godui/components";
 
-<ComponentPreview
+<Workbench>
+
+A segmented tab bar where the selected option lifts into a 3D button with an optional rainbow edge.
+
+<Example
+  label="Default"
   story="navigation-magic-tab"
   code={`import { MagicTab } from "@/components/godui/magic-tab";
 
@@ -27,7 +33,7 @@ export function MagicTabDemo() {
     ]}
     defaultValue="overview"
   />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -61,7 +67,8 @@ const [value, setValue] = useState("overview");
 
 ### Secondary
 
-<ComponentPreview
+<Example
+  label="Secondary"
   code={`import { MagicTab } from "@/components/godui/magic-tab";
 
 const items = [
@@ -83,11 +90,12 @@ export function MagicTabSecondary() {
     defaultValue="overview"
     variant="secondary"
   />
-</ComponentPreview>
+</Example>
 
 ### Without rainbow
 
-<ComponentPreview
+<Example
+  label="Without Rainbow"
   code={`import { MagicTab } from "@/components/godui/magic-tab";
 
 const items = [
@@ -109,13 +117,14 @@ export function MagicTabPlain() {
     defaultValue="overview"
     rainbow={false}
   />
-</ComponentPreview>
+</Example>
 
 ### Disabled tab
 
 Mark any item `disabled` to skip it.
 
-<ComponentPreview
+<Example
+  label="Disabled Tab"
   code={`import { MagicTab } from "@/components/godui/magic-tab";
 
 const items = [
@@ -136,11 +145,12 @@ export function MagicTabDisabled() {
     ]}
     defaultValue="overview"
   />
-</ComponentPreview>
+</Example>
 
 ### Sizes
 
-<ComponentPreview
+<Example
+  label="Sizes"
   code={`import { MagicTab } from "@/components/godui/magic-tab";
 
 const items = [
@@ -188,7 +198,7 @@ export function MagicTabSizes() {
       size="lg"
     />
   </div>
-</ComponentPreview>
+</Example>
 
 ## Props
 
@@ -201,3 +211,5 @@ export function MagicTabSizes() {
 | `variant` | `"default" \| "secondary"` | `"default"` | Selected-tab color scheme |
 | `size` | `"sm" \| "md" \| "lg"` | `"md"` | Tab padding and text size |
 | `rainbow` | `boolean` | `true` | Animate the selected tab's 3D edge and shadow with a rainbow gradient |
+
+</Workbench>

--- a/apps/docs/content/docs/components/navigation/mega-menu/index.mdx
+++ b/apps/docs/content/docs/components/navigation/mega-menu/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Mega Menu
 description: A Vercel-style navigation menu with a direction-aware highlight and a panel that springs and height-morphs between triggers.
+workbench: true
 ---
 
 import { MegaMenuDemo } from "@/components/demos/mega-menu-demo";
 
-<ComponentPreview
+<Workbench>
+
+A Vercel-style navigation menu with a direction-aware highlight and a panel that springs and height-morphs between triggers.
+
+<Example
+  label="Default"
   story="navigation-mega-menu"
   code={`"use client";
 import { MegaMenu } from "@/components/godui/mega-menu";
@@ -43,7 +49,7 @@ export function MegaMenuDemo() {
 }`}
 >
   <MegaMenuDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -83,3 +89,5 @@ Hovering between triggers slides a shared highlight and morphs the panel height.
 | `openDelay` | `number` | `80` | Delay (ms) before opening on hover |
 | `closeDelay` | `number` | `140` | Delay (ms) before closing after leaving |
 | `onNavigate` | `(href: string) => void` | — | Called on link click (prevents default) |
+
+</Workbench>

--- a/apps/docs/content/docs/components/navigation/resizable-header/index.mdx
+++ b/apps/docs/content/docs/components/navigation/resizable-header/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Resizable Header
 description: A sticky navbar that springs into a compact, blurred floating pill as you scroll, with a shared-element active indicator.
+workbench: true
 ---
 
 import { ResizableHeaderDemo } from "@/components/demos/resizable-header-demo";
 
-<ComponentPreview
+<Workbench>
+
+A sticky navbar that springs into a compact, blurred floating pill as you scroll, with a shared-element active indicator.
+
+<Example
+  label="Default"
   story="navigation-resizable-header"
   code={`"use client";
 import { ResizableHeader } from "@/components/godui/resizable-header";
@@ -36,7 +42,7 @@ export function HeaderDemo() {
 }`}
 >
   <ResizableHeaderDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -82,3 +88,5 @@ const scrollRef = useRef(null);
 | `sticky` | `boolean` | `true` | Stick the header to the top |
 | `scrollRef` | `RefObject<HTMLElement>` | — | Scroll container to track (defaults to window) |
 | `onNavigate` | `(href: string) => void` | — | Called on link click (prevents default) |
+
+</Workbench>

--- a/apps/docs/content/docs/components/navigation/segmented-control/index.mdx
+++ b/apps/docs/content/docs/components/navigation/segmented-control/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Segmented Control
 description: An iOS-style selector with a sliding pill that springs between options.
+workbench: true
 ---
 
 import { SegmentedControl } from "@godui/components";
@@ -11,7 +12,12 @@ export const viewOptions = [
   { label: "Month", value: "month" },
 ];
 
-<ComponentPreview
+<Workbench>
+
+An iOS-style selector with a sliding pill that springs between options.
+
+<Example
+  label="Default"
   story="navigation-segmented-control"
   code={`import { SegmentedControl } from "@/components/godui/segmented-control";
 
@@ -26,11 +32,12 @@ export function SegmentedControlDemo() {
 }`}
 >
   <SegmentedControl options={viewOptions} defaultValue="week" />
-</ComponentPreview>
+</Example>
 
 ## Sizes
 
-<ComponentPreview
+<Example
+  label="Sizes"
   code={`import { SegmentedControl } from "@/components/godui/segmented-control";
 
 export function SegmentedControlSizes() {
@@ -48,7 +55,7 @@ export function SegmentedControlSizes() {
     <SegmentedControl options={viewOptions} size="md" />
     <SegmentedControl options={viewOptions} size="lg" />
   </div>
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -80,3 +87,5 @@ const [view, setView] = useState("week");
 | `defaultValue` | `string` | first option | Uncontrolled value. |
 | `size` | `"sm" \| "md" \| "lg"` | `"md"` | Control size. |
 | `onChange` | `(value: string) => void` | — | Fires on selection. |
+
+</Workbench>

--- a/apps/docs/content/docs/components/navigation/tab-bar/index.mdx
+++ b/apps/docs/content/docs/components/navigation/tab-bar/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Tab Bar
 description: A mobile bottom navigation where a shared-element blob slides under the active tab, the icon gives a haptic-style pop, and the label reveals on selection.
+workbench: true
 ---
 
 import { TabBarDemo } from "@/components/demos/tab-bar-demo";
 
-<ComponentPreview
+<Workbench>
+
+A mobile bottom navigation where a shared-element blob slides under the active tab, the icon gives a haptic-style pop, and the label reveals on selection.
+
+<Example
+  label="Default"
   story="navigation-tab-bar"
   code={`"use client";
 import { TabBar } from "@/components/godui/tab-bar";
@@ -25,7 +31,7 @@ export function BottomNav() {
 }`}
 >
   <TabBarDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -55,3 +61,5 @@ Pass `safeArea` to add bottom safe-area padding for devices with a home indicato
 | `labelsOnActiveOnly` | `boolean` | `true` | Reveal the label only on the active tab |
 | `safeArea` | `boolean` | `false` | Add bottom safe-area padding |
 | `onChange` | `(value: string) => void` | — | Called when the active tab changes |
+
+</Workbench>

--- a/apps/docs/content/docs/components/overlays/animated-tooltip/index.mdx
+++ b/apps/docs/content/docs/components/overlays/animated-tooltip/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Animated Tooltip
 description: A tooltip that springs in and tilts in 3D as the pointer moves across its trigger.
+workbench: true
 ---
 
 import { AnimatedTooltipDemo } from "@/components/demos/animated-tooltip-demo";
 
-<ComponentPreview
+<Workbench>
+
+A tooltip that springs in and tilts in 3D as the pointer moves across its trigger.
+
+<Example
+  label="Default"
   story="overlays-animatedtooltip"
   code={`import { AnimatedTooltip } from "@/components/godui/animated-tooltip";
 
@@ -34,7 +40,7 @@ export function TeamStack() {
 }`}
 >
   <AnimatedTooltipDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -72,3 +78,5 @@ import { AnimatedTooltip } from "@/components/godui/animated-tooltip";
 | `children`| `ReactNode`          | —       | The trigger the tooltip is attached to.      |
 
 `AnimatedTooltip` also forwards every standard `<span>` attribute to the root element.
+
+</Workbench>

--- a/apps/docs/content/docs/components/overlays/command-palette/index.mdx
+++ b/apps/docs/content/docs/components/overlays/command-palette/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Command Palette
 description: A ⌘K command menu with fuzzy filtering, keyboard navigation, and spring enter / exit.
+workbench: true
 ---
 
 import { CommandPaletteDemo } from "@/components/demos/command-palette-demo";
 
-<ComponentPreview
+<Workbench>
+
+A ⌘K command menu with fuzzy filtering, keyboard navigation, and spring enter / exit.
+
+<Example
+  label="Default"
   story="overlays-commandpalette"
   code={`"use client";
 import { CommandPalette } from "@/components/godui/command-palette";
@@ -33,7 +39,7 @@ export function CommandPaletteDemo() {
 }`}
 >
   <CommandPaletteDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -78,3 +84,5 @@ export function Example() {
 
 A `CommandItem` is `{ id, label, icon?, shortcut?, keywords?, onSelect? }`; a
 `CommandGroup` is `{ heading?, items }`.
+
+</Workbench>

--- a/apps/docs/content/docs/components/overlays/drawer/index.mdx
+++ b/apps/docs/content/docs/components/overlays/drawer/index.mdx
@@ -1,12 +1,18 @@
 ---
 title: Drawer
 description: A draggable bottom sheet with rubber-band physics, snap points, and flick-to-dismiss.
+workbench: true
 ---
 
 import { DrawerDemo } from "@/components/demos/drawer-demo";
 import { DrawerBottomDemo } from "@/components/demos/drawer-bottom-demo";
 
-<ComponentPreview
+<Workbench>
+
+A draggable bottom sheet with rubber-band physics, snap points, and flick-to-dismiss.
+
+<Example
+  label="Default"
   story="overlays-drawer"
   code={`"use client";
 import { Drawer } from "@/components/godui/drawer";
@@ -33,7 +39,7 @@ export function CartDrawer({ lines, total }) {
 }`}
 >
   <DrawerDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -70,9 +76,12 @@ export function Example() {
 Set `side="bottom"` for a mobile-style sheet — drag the handle (or flick) down to
 dismiss. Great for share menus, quick actions, and confirmations.
 
-<ComponentPreview code={`<Drawer open={open} onOpenChange={setOpen} side="bottom" title="Share">…</Drawer>`}>
+<Example
+  label="Bottom Sheet"
+  code={`<Drawer open={open} onOpenChange={setOpen} side="bottom" title="Share">…</Drawer>`}
+>
   <DrawerBottomDemo />
-</ComponentPreview>
+</Example>
 
 ## Props
 
@@ -83,3 +92,5 @@ dismiss. Great for share menus, quick actions, and confirmations.
 | `side`         | `"bottom" \| "right"`      | `"bottom"` | Side the drawer slides in from.          |
 | `title`        | `ReactNode`                | —          | Accessible title rendered at the top.    |
 | `className`    | `string`                   | —          | Extra classes for the panel.             |
+
+</Workbench>

--- a/apps/docs/content/docs/components/overlays/dynamic-island/index.mdx
+++ b/apps/docs/content/docs/components/overlays/dynamic-island/index.mdx
@@ -1,12 +1,18 @@
 ---
 title: Dynamic Island
 description: An Apple-inspired pill that springs between size presets while its content cross-fades.
+workbench: true
 ---
 
 import { DynamicIsland } from "@godui/components";
 import { DynamicIslandDemo } from "@/components/demos/dynamic-island-demo";
 
-<ComponentPreview
+<Workbench>
+
+An Apple-inspired pill that springs between size presets while its content cross-fades.
+
+<Example
+  label="Default"
   story="overlays-dynamic-island"
   code={`import { DynamicIsland } from "@/components/godui/dynamic-island";
 import { useState } from "react";
@@ -24,7 +30,7 @@ export function DynamicIslandDemo() {
 }`}
 >
   <DynamicIslandDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -58,3 +64,5 @@ Drive `size` and `presenceKey` from state to morph between views. Size presets:
 | `presenceKey` | `React.Key`                                                  | `size`      | Identity of the current content; change to cross-fade. |
 
 `DynamicIsland` also forwards every standard `<div>` attribute to the root element.
+
+</Workbench>

--- a/apps/docs/content/docs/components/overlays/floating-toolbar/index.mdx
+++ b/apps/docs/content/docs/components/overlays/floating-toolbar/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Floating Toolbar
 description: A context toolbar that springs into view with magnetic, morphing action buttons.
+workbench: true
 ---
 
 import { FloatingToolbar } from "@godui/components";
@@ -16,7 +17,12 @@ export const toolbarActions = [
   { icon: icon("M3 6h18M3 12h18M3 18h18"), label: "List" },
 ];
 
-<ComponentPreview
+<Workbench>
+
+A context toolbar that springs into view with magnetic, morphing action buttons.
+
+<Example
+  label="Default"
   story="overlays-floating-toolbar"
   code={`import { FloatingToolbar } from "@/components/godui/floating-toolbar";
 
@@ -34,7 +40,7 @@ export function FloatingToolbarDemo() {
 }`}
 >
   <FloatingToolbar open actions={toolbarActions} />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -62,3 +68,5 @@ const [open, setOpen] = useState(false);
 | `actions` | `ToolbarAction[]` | — | `{ icon, label, onClick?, active?, disabled? }`. |
 | `open` | `boolean` | `true` | Mount/unmount with a spring entrance. |
 | `children` | `ReactNode` | — | Trailing content (dividers, extra controls). |
+
+</Workbench>

--- a/apps/docs/content/docs/components/overlays/morphing-dialog/index.mdx
+++ b/apps/docs/content/docs/components/overlays/morphing-dialog/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Morphing Dialog
 description: A card that physically morphs into a modal through a shared layout, then springs back on close.
+workbench: true
 ---
 
 import {
@@ -11,7 +12,12 @@ import {
 } from "@godui/components";
 import { MorphingDialogDemo } from "@/components/demos/morphing-dialog-demo";
 
-<ComponentPreview
+<Workbench>
+
+A card that physically morphs into a modal through a shared layout, then springs back on close.
+
+<Example
+  label="Default"
   story="overlays-morphing-dialog"
   code={`import {
   MorphingDialog,
@@ -35,7 +41,7 @@ export function MorphingDialogDemo() {
 }`}
 >
   <MorphingDialogDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -82,3 +88,5 @@ default; pass `open` / `onOpenChange` to control it.
 `MorphingDialogTrigger`, `MorphingDialogContent`, and `MorphingDialogClose`
 forward every standard attribute to their root element. The trigger and content
 must share one `MorphingDialog` parent so they animate as a pair.
+
+</Workbench>

--- a/apps/docs/content/docs/components/overlays/toast/index.mdx
+++ b/apps/docs/content/docs/components/overlays/toast/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Toast
 description: Stacked, swipe-dismissible toasts with an imperative toast() API.
+workbench: true
 ---
 
 import { ToastDemo } from "@/components/demos/toast-demo";
 
-<ComponentPreview
+<Workbench>
+
+Stacked, swipe-dismissible toasts with an imperative toast() API.
+
+<Example
+  label="Default"
   story="overlays-toast"
   code={`"use client";
 import { ToastProvider, toast } from "@/components/godui/toast";
@@ -20,7 +26,7 @@ export function ToastDemo() {
 }`}
 >
   <ToastDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -78,3 +84,5 @@ toast({
 Returns the toast `id`. `toast.success` and `toast.error` set the variant;
 `toast.dismiss(id)` removes one early. `options` is
 `{ title?, description?, variant?, duration?, action? }`.
+
+</Workbench>

--- a/apps/docs/content/docs/components/text/aurora-text/index.mdx
+++ b/apps/docs/content/docs/components/text/aurora-text/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Aurora Text
 description: Gradient text with a rainbow aurora that drifts across the letters.
+workbench: true
 ---
 
 import { AuroraText } from "@godui/components";
 
-<ComponentPreview
+<Workbench>
+
+Gradient text with a rainbow aurora that drifts across the letters.
+
+<Example
+  label="Default"
   story="text-auroratext"
   code={`import { AuroraText } from "@/components/godui/aurora-text";
 
@@ -20,7 +26,7 @@ export function AuroraTextDemo() {
   <h1 className="text-6xl font-bold tracking-tight">
     Ship <AuroraText>beautiful</AuroraText> UI
   </h1>
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -72,3 +78,5 @@ seamless cycle, so two or three colors are enough.
 
 `AuroraText` also forwards every standard `<span>` attribute (`className`,
 `style`, `id`, …) to the root element.
+
+</Workbench>

--- a/apps/docs/content/docs/components/text/elastic-text/index.mdx
+++ b/apps/docs/content/docs/components/text/elastic-text/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Elastic Text
 description: Variable-font text whose weight springs up under an automatic spotlight or the pointer.
+workbench: true
 ---
 
 import { ElasticText } from "@godui/components";
 
-<ComponentPreview
+<Workbench>
+
+Variable-font text whose weight springs up under an automatic spotlight or the pointer.
+
+<Example
+  label="Default"
   story="text-elastictext"
   code={`import { ElasticText } from "@/components/godui/elastic-text";
 
@@ -20,7 +26,7 @@ export function ElasticTextDemo() {
   <ElasticText className="text-4xl font-sans tracking-tight">
     Design for Humans
   </ElasticText>
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -71,7 +77,8 @@ The weight emphasis follows the pointer while it's over the text.
 
 `mode="hover"` ties the weight emphasis to the pointer instead of an automatic spotlight.
 
-<ComponentPreview
+<Example
+  label="Hover"
   code={`import { ElasticText } from "@/components/godui/elastic-text";
 
 export function ElasticTextHover() {
@@ -85,13 +92,14 @@ export function ElasticTextHover() {
   <ElasticText mode="hover" className="text-4xl tracking-tight">
     Move Your Mouse
   </ElasticText>
-</ComponentPreview>
+</Example>
 
 ### Plays once
 
 `loop={false}` runs a single spotlight sweep across the text, then settles back to normal weight. Use the replay button to run it again.
 
-<ComponentPreview
+<Example
+  label="Plays Once"
   code={`import { ElasticText } from "@/components/godui/elastic-text";
 
 export function ElasticTextOnce() {
@@ -105,7 +113,7 @@ export function ElasticTextOnce() {
   <ElasticText loop={false} className="text-4xl tracking-tight">
     Plays once
   </ElasticText>
-</ComponentPreview>
+</Example>
 
 ## Props
 
@@ -123,3 +131,5 @@ export function ElasticTextOnce() {
 ## Accessibility
 
 When `prefers-reduced-motion` is enabled, the animation is disabled and the text renders statically at `minWeight`.
+
+</Workbench>

--- a/apps/docs/content/docs/components/text/highlighter/index.mdx
+++ b/apps/docs/content/docs/components/text/highlighter/index.mdx
@@ -1,14 +1,18 @@
 ---
 title: Highlighter
 description: Draw hand-drawn sketch annotations over inline text — highlight, underline, box, circle, and more. Powered by Rough Notation.
+workbench: true
 ---
 
 import { Highlighter } from "@godui/components";
 
+<Workbench>
+
 Draw hand-drawn sketch annotations over inline text, powered by
 [Rough Notation](https://roughnotation.com/).
 
-<ComponentPreview
+<Example
+  label="Default"
   story="text-highlighter"
   code={`import { Highlighter } from "@/components/godui/highlighter";
 
@@ -35,7 +39,7 @@ export function HighlighterDemo() {
     <Highlighter action="crossed-off" color="#a78bfa">crossed-off</Highlighter>{" "}
     <Highlighter action="bracket" color="#fb7185">bracket</Highlighter>
   </p>
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -109,7 +113,8 @@ Set `isView` to defer the draw-in animation until the element scrolls into view.
 
 Drop it around any inline word — the sketch draws over the text in place.
 
-<ComponentPreview
+<Example
+  label="In a Sentence"
   code={`import { Highlighter } from "@/components/godui/highlighter";
 
 export function HighlighterSentence() {
@@ -122,13 +127,14 @@ export function HighlighterSentence() {
 }`}
 >
   <p className="max-w-md text-xl leading-relaxed">The quick brown <Highlighter action="underline" color="#60a5fa">fox</Highlighter> jumps over the <Highlighter action="highlight">lazy dog</Highlighter>.</p>
-</ComponentPreview>
+</Example>
 
 ### Tuning the sketch
 
 Push `strokeWidth`, `iterations`, `padding`, and `animationDuration` for a bolder, looser, slower draw.
 
-<ComponentPreview
+<Example
+  label="Tuning the Sketch"
   code={`import { Highlighter } from "@/components/godui/highlighter";
 
 export function HighlighterTuned() {
@@ -151,7 +157,7 @@ export function HighlighterTuned() {
   <p className="text-3xl font-sans">
     <Highlighter action="box" color="#22d3ee" strokeWidth={2.5} iterations={3} padding={6} animationDuration={900}>Bolder, looser, slower</Highlighter>
   </p>
-</ComponentPreview>
+</Example>
 
 ## Props
 
@@ -171,3 +177,5 @@ export function HighlighterTuned() {
 
 The annotation is a decorative SVG overlay; it does not alter the text content,
 so the underlying text remains fully readable and selectable by screen readers.
+
+</Workbench>

--- a/apps/docs/content/docs/components/text/number-ticker/index.mdx
+++ b/apps/docs/content/docs/components/text/number-ticker/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Number Ticker
 description: Animates a number to its target value with spring physics when scrolled into view.
+workbench: true
 ---
 
 import { NumberTicker } from "@godui/components";
 
-<ComponentPreview
+<Workbench>
+
+Animates a number to its target value with spring physics when scrolled into view.
+
+<Example
+  label="Default"
   story="text-numberticker"
   code={`import { NumberTicker } from "@/components/godui/number-ticker";
 
@@ -16,7 +22,7 @@ export function NumberTickerDemo() {
 }`}
 >
   <NumberTicker value={100} className="text-6xl font-bold tracking-tight" />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -74,3 +80,5 @@ Set `direction="down"` to count from `value` to `startValue`.
 
 `NumberTicker` also forwards every standard `<span>` attribute (`className`,
 `style`, `id`, …) to the root element.
+
+</Workbench>

--- a/apps/docs/content/docs/components/text/scroll-text-reveal/index.mdx
+++ b/apps/docs/content/docs/components/text/scroll-text-reveal/index.mdx
@@ -2,6 +2,7 @@
 title: Scroll Text Reveal
 description: Kinetic typography that scrubs each word from dim to sharp as the paragraph scrolls through view.
 date: "2026-07-10"
+workbench: true
 ---
 
 import { ScrollTextReveal } from "@godui/components";
@@ -10,7 +11,12 @@ import {
   ScrollTextRevealKeepDemo,
 } from "@/components/demos/scroll-text-reveal-demo";
 
-<ComponentPreview
+<Workbench>
+
+Kinetic typography that scrubs each word from dim to sharp as the paragraph scrolls through view.
+
+<Example
+  label="Default"
   story="text-scroll-text-reveal"
   code={`import { ScrollTextReveal } from "@/components/godui/scroll-text-reveal";
 
@@ -23,7 +29,7 @@ export function ScrollTextRevealDemo() {
 }`}
 >
   <ScrollTextRevealDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -60,7 +66,8 @@ import { ScrollTextReveal } from "@/components/godui/scroll-text-reveal";
 With `keepRevealed`, each word latches at full presence once it lands, so the
 paragraph stays lit when the reader scrolls back up instead of re-dimming.
 
-<ComponentPreview
+<Example
+  label="Keep Revealed"
   code={`import { ScrollTextReveal } from "@/components/godui/scroll-text-reveal";
 
 export function ScrollTextRevealKeepDemo() {
@@ -72,7 +79,7 @@ export function ScrollTextRevealKeepDemo() {
 }`}
 >
   <ScrollTextRevealKeepDemo />
-</ComponentPreview>
+</Example>
 
 ## Props
 
@@ -88,3 +95,5 @@ export function ScrollTextRevealKeepDemo() {
 | `segmentClassName` | `string`                            | —                              | Class applied to every segment span.                   |
 
 `ScrollTextReveal` also forwards standard attributes to the root element.
+
+</Workbench>

--- a/apps/docs/content/docs/components/text/text-animate/index.mdx
+++ b/apps/docs/content/docs/components/text/text-animate/index.mdx
@@ -1,13 +1,17 @@
 ---
 title: Text Animate
 description: Staggered entrance animations for headlines and copy, split by word, character, or line.
+workbench: true
 ---
 
 import { TextAnimate } from "@godui/components";
 
+<Workbench>
+
 `TextAnimate` splits text into words, characters, or lines and staggers each fragment through an entrance animation.
 
-<ComponentPreview
+<Example
+  label="Default"
   story="text-textanimate"
   code={`import { TextAnimate } from "@/components/godui/text-animate";
 
@@ -30,7 +34,7 @@ export function TextAnimateDemo() {
   >
     Animate your ideas into reality
   </TextAnimate>
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -86,7 +90,8 @@ Hit the replay button on any preview to play the animation again.
 
 ### Word fade in
 
-<ComponentPreview
+<Example
+  label="Word Fade In"
   code={`import { TextAnimate } from "@/components/godui/text-animate";
 
 export function TextAnimateFade() {
@@ -100,11 +105,12 @@ export function TextAnimateFade() {
   <TextAnimate animation="fadeIn" by="word" className="text-4xl font-semibold tracking-tight">
     Animate your ideas into reality
   </TextAnimate>
-</ComponentPreview>
+</Example>
 
 ### Character stagger
 
-<ComponentPreview
+<Example
+  label="Character Stagger"
   code={`import { TextAnimate } from "@/components/godui/text-animate";
 
 export function TextAnimateChars() {
@@ -118,11 +124,12 @@ export function TextAnimateChars() {
   <TextAnimate animation="slideUp" by="character" stagger={0.03} className="text-3xl font-medium">
     Character by character
   </TextAnimate>
-</ComponentPreview>
+</Example>
 
 ### Scale up
 
-<ComponentPreview
+<Example
+  label="Scale Up"
   code={`import { TextAnimate } from "@/components/godui/text-animate";
 
 export function TextAnimateScale() {
@@ -136,11 +143,12 @@ export function TextAnimateScale() {
   <TextAnimate animation="scaleUp" by="word" className="text-4xl font-semibold tracking-tight">
     Scale up with spring
   </TextAnimate>
-</ComponentPreview>
+</Example>
 
 ### Slide from the right
 
-<ComponentPreview
+<Example
+  label="Slide from the Right"
   code={`import { TextAnimate } from "@/components/godui/text-animate";
 
 export function TextAnimateSlide() {
@@ -154,13 +162,14 @@ export function TextAnimateSlide() {
   <TextAnimate animation="slideLeft" by="word" className="text-4xl font-semibold tracking-tight">
     Slide from the right
   </TextAnimate>
-</ComponentPreview>
+</Example>
 
 ### Semantic heading
 
 Render a real `h1` with `as` while keeping the staggered entrance.
 
-<ComponentPreview
+<Example
+  label="Semantic Heading"
   code={`import { TextAnimate } from "@/components/godui/text-animate";
 
 export function TextAnimateHeading() {
@@ -174,7 +183,7 @@ export function TextAnimateHeading() {
   <TextAnimate as="h1" animation="blurInUp" by="word" className="text-5xl font-bold tracking-tight">
     Hero headline
   </TextAnimate>
-</ComponentPreview>
+</Example>
 
 ## Props
 
@@ -196,3 +205,5 @@ export function TextAnimateHeading() {
 | `variants` | `Variants` | — | Custom Framer Motion item variants |
 
 Respects `prefers-reduced-motion` — text renders immediately without animation when the user has reduced motion enabled.
+
+</Workbench>

--- a/apps/docs/content/docs/components/text/text-scramble/index.mdx
+++ b/apps/docs/content/docs/components/text/text-scramble/index.mdx
@@ -1,14 +1,18 @@
 ---
 title: Text Scramble
 description: Characters cycle through random glyphs and resolve into the target text — a decrypt / matrix reveal.
+workbench: true
 ---
 
 import { TextScramble } from "@godui/components";
 import { TextScrambleDemo } from "@/components/demos/text-scramble-demo";
 
+<Workbench>
+
 Each character flickers through a glyph pool then locks into place, left to right — the unresolved glyphs glow in the accent color until they settle. When the text changes, only the characters that differ re-scramble. The demo below swaps words on a timer.
 
-<ComponentPreview
+<Example
+  label="Default"
   story="text-textscramble"
   code={`import { TextScramble } from "@/components/godui/text-scramble";
 
@@ -17,7 +21,7 @@ export function Decode() {
 }`}
 >
   <TextScrambleDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -84,3 +88,5 @@ with no scramble.
 | `spread`  | `number`                                          | `28`             | Max stagger spread, in frames.                       |
 
 `TextScramble` also forwards every standard `<span>` attribute to the root element.
+
+</Workbench>

--- a/apps/docs/content/docs/components/visualizations/animated-beam/index.mdx
+++ b/apps/docs/content/docs/components/visualizations/animated-beam/index.mdx
@@ -1,13 +1,19 @@
 ---
 title: Animated Beam
 description: An animated gradient beam that travels along a path connecting two separate nodes.
+workbench: true
 ---
 
 import { AnimatedBeamDemo } from "@/components/demos/animated-beam-demo";
 import { AnimatedBeamPipelineDemo } from "@/components/demos/animated-beam-pipeline-demo";
 import { AnimatedBeamSyncDemo } from "@/components/demos/animated-beam-sync-demo";
 
-<ComponentPreview
+<Workbench>
+
+An animated gradient beam that travels along a path connecting two separate nodes.
+
+<Example
+  label="Default"
   story="effects-animated-beam"
   code={`import { AnimatedBeam } from "@/components/godui/animated-beam";
 import { useRef } from "react";
@@ -26,7 +32,7 @@ export function AnimatedBeamDemo() {
 }`}
 >
   <AnimatedBeamDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -63,7 +69,8 @@ Set `pathDashArray` for a dotted or dashed resting line. Here each stage connect
 with a dotted track (`"0.1 8"` with the round cap renders as dots), and staggered
 `delay`s send the beam flowing from stage to stage.
 
-<ComponentPreview
+<Example
+  label="Dotted Data Pipeline"
   code={`const beam = { containerRef, pathDashArray: "0.1 8", duration: 4 };
 
 <AnimatedBeam {...beam} fromRef={clientRef} toRef={edgeRef} delay={0} />
@@ -71,19 +78,20 @@ with a dotted track (`"0.1 8"` with the round cap renders as dots), and staggere
 <AnimatedBeam {...beam} fromRef={computeRef} toRef={dbRef} delay={1.2} />`}
 >
   <AnimatedBeamPipelineDemo />
-</ComponentPreview>
+</Example>
 
 ### Bidirectional sync
 
 Stack two dashed beams with opposite `curvature` — and `reverse` on one — for a
 continuous two-way connection.
 
-<ComponentPreview
+<Example
+  label="Bidirectional Sync"
   code={`<AnimatedBeam containerRef={containerRef} fromRef={deviceRef} toRef={cloudRef} curvature={36} pathDashArray="4 5" />
 <AnimatedBeam containerRef={containerRef} fromRef={deviceRef} toRef={cloudRef} curvature={-36} delay={1.5} reverse pathDashArray="4 5" />`}
 >
   <AnimatedBeamSyncDemo />
-</ComponentPreview>
+</Example>
 
 ## Props
 
@@ -102,3 +110,5 @@ continuous two-way connection.
 | `pathDashArray`      | `string`              | —           | `stroke-dasharray` for the resting path (`"4 5"` dashes, `"0.1 8"` dots). |
 | `gradientStartColor` | `string`              | `var(--primary)` | Leading color of the travelling gradient.|
 | `gradientStopColor`  | `string`              | —           | Trailing color of the travelling gradient.   |
+
+</Workbench>

--- a/apps/docs/content/docs/components/visualizations/globe/index.mdx
+++ b/apps/docs/content/docs/components/visualizations/globe/index.mdx
@@ -1,11 +1,17 @@
 ---
 title: Globe
 description: A draggable, auto-rotating WebGL globe with glowing location markers.
+workbench: true
 ---
 
 import { GlobeDemo } from "@/components/demos/globe-demo";
 
-<ComponentPreview
+<Workbench>
+
+A draggable, auto-rotating WebGL globe with glowing location markers.
+
+<Example
+  label="Default"
   fullWidth
   story="effects-globe"
   code={`import { Globe } from "@/components/godui/globe";
@@ -39,7 +45,7 @@ export function GlobeHero() {
 }`}
 >
   <GlobeDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -83,3 +89,5 @@ import { Globe } from "@/components/godui/globe";
 | `config` | `Partial<COBEOptions>`  | —       | Override any cobe option (markers, colors, glow). |
 
 `Globe` also forwards every standard `<div>` attribute to the root element.
+
+</Workbench>

--- a/apps/docs/content/docs/components/visualizations/gravity/index.mdx
+++ b/apps/docs/content/docs/components/visualizations/gravity/index.mdx
@@ -1,13 +1,17 @@
 ---
 title: Gravity
 description: A physics playground where elements fall, pile, collide, and can be dragged and flung.
+workbench: true
 ---
 
 import { GravityDemo } from "@/components/demos/gravity-demo";
 
+<Workbench>
+
 Drop any elements into a `Gravity` canvas and they become real physics bodies — they fall, stack, collide, and fling when you grab them. Powered by [matter-js](https://brm.io/matter-js/). Grab a pill and throw it.
 
-<ComponentPreview
+<Example
+  label="Default"
   story="visualizations-gravity"
   code={`import { Gravity, MatterBody } from "@/components/godui/gravity";
 
@@ -26,7 +30,7 @@ export function Playground() {
 }`}
 >
   <GravityDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -80,3 +84,5 @@ Set `gravity` to `{ x: 0, y: 0 }` for a floating, bumper-car feel.
 | `bodyType`          | `"rectangle" \| "circle"`     | `"rectangle"` | Collision shape.                                    |
 | `isDraggable`       | `boolean`                     | `true`        | Whether the pointer can grab and fling this body.   |
 | `matterBodyOptions` | `Matter.IChamferableBodyDefinition` | —       | Escape hatch for raw Matter body options.           |
+
+</Workbench>

--- a/apps/docs/content/docs/components/visualizations/orbiting-circles/index.mdx
+++ b/apps/docs/content/docs/components/visualizations/orbiting-circles/index.mdx
@@ -1,12 +1,18 @@
 ---
 title: Orbiting Circles
 description: Icons that orbit a center point on a configurable ring, staying upright as they travel.
+workbench: true
 ---
 
 import { OrbitingCircles } from "@godui/components";
 import { OrbitingCirclesDemo } from "@/components/demos/orbiting-circles-demo";
 
-<ComponentPreview
+<Workbench>
+
+Icons that orbit a center point on a configurable ring, staying upright as they travel.
+
+<Example
+  label="Default"
   fullWidth
   story="effects-orbiting-circles"
   code={`import { OrbitingCircles } from "@/components/godui/orbiting-circles";
@@ -31,7 +37,7 @@ export function OrbitingCirclesDemo() {
 }`}
 >
   <OrbitingCirclesDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -60,7 +66,8 @@ import { OrbitingCircles } from "@/components/godui/orbiting-circles";
 Stack two rings with different `radius`, `duration`, and `reverse` for a layered
 ecosystem diagram.
 
-<ComponentPreview
+<Example
+  label="Reversed Inner Ring"
   fullWidth
   code={`<div className="relative flex h-80 w-full items-center justify-center">
   <OrbitingCircles className="absolute" radius={60} duration={14}>
@@ -85,7 +92,7 @@ ecosystem diagram.
       <span className="flex size-full items-center justify-center rounded-full border border-border bg-card text-sm font-semibold text-foreground">5</span>
     </OrbitingCircles>
   </div>
-</ComponentPreview>
+</Example>
 
 ## Props
 
@@ -99,3 +106,5 @@ ecosystem diagram.
 | `iconSize` | `number`  | `40`    | Size of each orbiting slot in pixels.        |
 
 `OrbitingCircles` also forwards every standard `<div>` attribute to the root element.
+
+</Workbench>

--- a/apps/docs/content/docs/components/visualizations/scroll-timeline/index.mdx
+++ b/apps/docs/content/docs/components/visualizations/scroll-timeline/index.mdx
@@ -1,13 +1,17 @@
 ---
 title: Scroll Timeline
 description: A scrollytelling timeline whose progress line grows as you scroll, revealing entries with sticky labels.
+workbench: true
 ---
 
 import { ScrollTimelineDemo } from "@/components/demos/scroll-timeline-demo";
 
+<Workbench>
+
 A vertical timeline built for storytelling: a progress line traces down the rail as you scroll, entries fade up into place, and each label sticks while its section is in view. Scroll the preview to draw the line.
 
-<ComponentPreview
+<Example
+  label="Default"
   fullWidth
   story="visualizations-scroll-timeline"
   code={`import { ScrollTimeline } from "@/components/godui/scroll-timeline";
@@ -25,7 +29,7 @@ export function Changelog() {
 }`}
 >
   <ScrollTimelineDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -67,3 +71,5 @@ import { ScrollTimeline } from "@/components/godui/scroll-timeline";
 
 Each entry is `{ title: string; date?: string; content: React.ReactNode }`.
 `ScrollTimeline` also forwards every standard `<div>` attribute to the root.
+
+</Workbench>

--- a/apps/docs/content/docs/components/visualizations/world-map/index.mdx
+++ b/apps/docs/content/docs/components/visualizations/world-map/index.mdx
@@ -1,13 +1,17 @@
 ---
 title: World Map
 description: A dotted world map that draws animated arcs between locations, with pulsing endpoint pins.
+workbench: true
 ---
 
 import { WorldMapDemo } from "@/components/demos/world-map-demo";
 
+<Workbench>
+
 A dotted equirectangular map with animated arcs connecting any set of coordinates. Each beam draws in and loops, and every endpoint gets a pulsing pin. The land dots and lines follow your theme.
 
-<ComponentPreview
+<Example
+  label="Default"
   fullWidth
   story="visualizations-world-map"
   code={`import { WorldMap } from "@/components/godui/world-map";
@@ -30,7 +34,7 @@ export function Connections() {
 }`}
 >
   <WorldMapDemo />
-</ComponentPreview>
+</Example>
 
 ## Installation
 
@@ -82,3 +86,5 @@ section background.
 
 Each point is `{ lat: number; lng: number; label?: string }`. `WorldMap` also
 forwards every standard `<div>` attribute to the root element.
+
+</Workbench>

--- a/apps/docs/content/docs/guidelines/patterns.mdx
+++ b/apps/docs/content/docs/guidelines/patterns.mdx
@@ -1,6 +1,7 @@
 ---
 title: Motion Patterns
 description: The reusable motion recipes that put the principles into practice — one card per pattern.
+full: true
 ---
 
 import { MotionPatterns } from "@/components/motion-guidelines/motion-patterns";

--- a/apps/docs/content/docs/guidelines/principles.mdx
+++ b/apps/docs/content/docs/guidelines/principles.mdx
@@ -1,6 +1,7 @@
 ---
 title: Motion Principles
 description: The philosophy behind every animation in GodUI — twelve principles, each with a live demo.
+full: true
 ---
 
 import { MotionPrinciples } from "@/components/motion-guidelines/motion-principles";

--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -13,6 +13,10 @@ export const docs = defineDocs({
     // zod instance.
     schema: frontmatterSchema.extend({
       date: frontmatterSchema.shape.title.optional(),
+      // When true, the component docs page renders in the full-bleed
+      // "Workbench" layout (live stage + dock + drawer) instead of the classic
+      // linear column. Opt-in per page so un-migrated pages keep the old layout.
+      workbench: frontmatterSchema.shape.full.optional(),
     }),
   },
 });

--- a/apps/docs/src/app/docs/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/docs/[[...slug]]/page.tsx
@@ -1,3 +1,4 @@
+import { MOTION_TIER_META } from "@godui/components";
 import {
   DocsBody,
   DocsDescription,
@@ -8,6 +9,10 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { ComponentBadges } from "@/components/component-badges";
 import { getMDXComponents } from "@/components/mdx";
+import {
+  type BadgeItem,
+  WorkbenchProvider,
+} from "@/components/workbench/workbench-context";
 import { DEPENDENCY_NOTES } from "@/lib/dependency-notes";
 import { MOTION_NOTES, STATIC_COMPONENTS } from "@/lib/motion-notes";
 import { motionScore } from "@/lib/motion-score";
@@ -81,6 +86,118 @@ export default async function Page(props: PageProps<"/docs/[[...slug]]">) {
           { label: "Learn", href: `${docsHref}/learn`, active: isLearnPage },
         ]
       : null;
+
+  // Opt-in full-bleed "Workbench" layout: the whole content area becomes the
+  // live preview stage, with docs/code/learn behind a dock + drawer. The MDX
+  // body (wrapped in <Workbench>) owns the stage examples + drawer content; the
+  // page only supplies metadata the MDX doesn't have (title, badges, crumbs).
+  // The workbench renders both the component page AND its `…/learn` route: on the
+  // learn route we render the base component's workbench with the Learn drawer
+  // pre-opened, so a refresh / deep-link (e.g. `…/learn#motion-score`) reopens
+  // the drawer and scrolls to the section instead of showing a bare page.
+  const basePageData = base ? source.getPage(base) : null;
+  const baseHasWorkbench =
+    (basePageData?.data as { workbench?: boolean } | undefined)?.workbench ===
+    true;
+  const renderWorkbench =
+    (isComponentDocsPage &&
+      (page.data as { workbench?: boolean }).workbench === true) ||
+    (isLearnPage && baseHasWorkbench);
+  if (renderWorkbench) {
+    // Compact meta items for the title chip (dot + label + hover tooltip) — the
+    // workbench uses a cleaner inline row than the classic <ComponentBadges>.
+    const PERF_LABEL = { layout: "Layout", paint: "Paint", compute: "Compute" };
+    const badges: BadgeItem[] = [];
+    if (score) {
+      const meta = MOTION_TIER_META[score.grade];
+      badges.push({
+        tone: "sky",
+        label: `Motion ${score.grade}`,
+        title: `${score.grade} — ${meta.name}`,
+        detail: `${meta.summary} ${score.reason}`,
+        href:
+          hasLearn && docsHref ? `${docsHref}/learn#motion-score` : undefined,
+        hrefLabel: "Motion Score table",
+      });
+    }
+    if (motionNote) {
+      badges.push({
+        tone: "amber",
+        label: PERF_LABEL[motionNote.kind],
+        title: "Not fully GPU-composited",
+        detail: motionNote.reason,
+      });
+    } else if (isStatic) {
+      badges.push({
+        tone: "emerald",
+        label: "Static",
+        title: "No animation",
+        detail:
+          "Renders with plain CSS and never animates — nothing for the browser to keep composing or repainting.",
+      });
+    } else {
+      badges.push({
+        tone: "emerald",
+        label: "GPU-only",
+        title: "Runs on the GPU compositor",
+        detail:
+          "Animates only transform, opacity and filter — no main-thread layout or paint, so it stays smooth even under load.",
+      });
+    }
+    if (dependencyNote) {
+      badges.push({
+        tone: "violet",
+        label: "Dependency",
+        title: "Beyond React, Tailwind & Motion",
+        detail: `Uses ${dependencyNote.pkg} to ${dependencyNote.reason}.`,
+      });
+    }
+    const LearnMDX = learnPage?.data.body;
+    const learn = LearnMDX ? (
+      <LearnMDX components={getMDXComponents()} />
+    ) : null;
+    // On the learn route, drive the stage from the base component's MDX and show
+    // the component's own title/description in the chip (not the article's).
+    const WorkbenchMDX =
+      (isLearnPage ? basePageData?.data.body : page.data.body) ??
+      page.data.body;
+    const chipTitle =
+      (isLearnPage ? basePageData?.data.title : page.data.title) ??
+      page.data.title;
+    const chipDescription =
+      (isLearnPage ? basePageData?.data.description : page.data.description) ??
+      page.data.description;
+    return (
+      <DocsPage
+        full
+        toc={[]}
+        breadcrumb={{ enabled: false }}
+        // The stage is the whole page — no prev/next page footer.
+        footer={{ enabled: false }}
+        // Zero the article padding + max-width so the stage fills the main grid
+        // column edge-to-edge. `workbench-page` also cancels the desktop
+        // `#nd-page { padding-top: 1.5rem !important }` rule (which would
+        // otherwise overflow 100dvh and cause a scroll).
+        className="workbench-page max-w-none gap-0 p-0 md:p-0 xl:p-0"
+      >
+        {isLearnPage && docsHref ? <SidebarActiveLink href={docsHref} /> : null}
+        <WorkbenchProvider
+          value={{
+            title: chipTitle,
+            description: chipDescription,
+            badges,
+            learnHref: hasLearn && docsHref ? `${docsHref}/learn` : undefined,
+            docsHref,
+            learn,
+            initialDrawerTab: isLearnPage ? "learn" : undefined,
+            breadcrumbs: crumbs,
+          }}
+        >
+          <WorkbenchMDX components={getMDXComponents()} />
+        </WorkbenchProvider>
+      </DocsPage>
+    );
+  }
 
   return (
     <DocsPage

--- a/apps/docs/src/app/docs/_components/docs-header.tsx
+++ b/apps/docs/src/app/docs/_components/docs-header.tsx
@@ -99,6 +99,23 @@ export function DocsHeader({
             className={cn(iconButton, "md:hidden")}
           />
           <GitHubStars />
+          <a
+            href="https://x.com/LucasBassetti"
+            target="_blank"
+            rel="noreferrer"
+            title="Follow on X"
+            className={iconButton}
+          >
+            <span className="sr-only">Follow on X</span>
+            <svg
+              aria-hidden="true"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              className="size-4"
+            >
+              <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+            </svg>
+          </a>
           <ThemeToggle />
           {/* Mobile: open the sidenav drawer (only when inside DocsLayout, which
             provides SidebarContext — the home page has no sidebar) */}

--- a/apps/docs/src/app/globals.css
+++ b/apps/docs/src/app/globals.css
@@ -242,6 +242,16 @@ p.docs-lead {
   margin: 0 !important;
 }
 
+/* Hide the scrollbar on horizontally-scrollable strips (e.g. the workbench
+   example tab track) while keeping them scrollable. */
+.no-scrollbar {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
 /* Workbench Code tab — framed codebox with a left line-number gutter. */
 .workbench-code .shiki,
 .workbench-code pre {

--- a/apps/docs/src/app/globals.css
+++ b/apps/docs/src/app/globals.css
@@ -89,6 +89,32 @@ body {
     --gutter: max(0px, calc((100vw - 90rem) / 2));
     /* The header is fixed (leaves grid flow), so reserve its height here. */
     padding-top: 3.5rem;
+    /* Width of the Workbench docs rail (see stage-panel.tsx). Read here + by the
+       portaled panel via :root below so both always match. */
+    --wb-panel-w: min(440px, 34vw);
+  }
+
+  /* Expose the rail width to the body-portaled <StagePanel> too. */
+  :root {
+    --wb-panel-w: min(440px, 34vw);
+  }
+
+  /* When the docs rail is open, slide the whole app (header + sidebar + stage)
+     left by `panel − gutter` so the content sits flush against the rail WITHOUT
+     resizing. The rail only opens (via <StagePanel>) when there's enough side
+     slack for this shift not to clip (see use-side-panel-fit.ts); otherwise the
+     docs open as a bottom sheet and this attribute is never set. Transform (not
+     left/right) keeps the slide on the compositor. Each element is transformed
+     individually so the fixed header/sidebar keep their own fixed positioning. */
+  #nd-docs-layout #nd-nav,
+  #nd-docs-layout #nd-sidebar,
+  #nd-docs-layout #nd-page {
+    transition: transform 0.34s cubic-bezier(0.22, 1, 0.36, 1);
+  }
+  #nd-docs-layout[data-wb-panel="open"] #nd-nav,
+  #nd-docs-layout[data-wb-panel="open"] #nd-sidebar,
+  #nd-docs-layout[data-wb-panel="open"] #nd-page {
+    transform: translateX(calc(var(--gutter) - var(--wb-panel-w)));
   }
 
   [data-sidebar-placeholder] {
@@ -127,6 +153,12 @@ body {
   /* Tighten the gap between the header and the content. */
   #nd-page {
     padding-top: 1.5rem !important;
+  }
+
+  /* Workbench pages are full-bleed: the stage owns the whole main column, so
+     drop the content top padding (it would push past 100dvh and scroll). */
+  #nd-page.workbench-page {
+    padding-top: 0 !important;
   }
 
   /* The mobile-only "Menu" block is hidden on desktop but its wrapper's mb-4
@@ -210,6 +242,38 @@ p.docs-lead {
   margin: 0 !important;
 }
 
+/* Workbench Code tab — framed codebox with a left line-number gutter. */
+.workbench-code .shiki,
+.workbench-code pre {
+  margin: 0 !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+  background: transparent !important;
+}
+
+.workbench-code code {
+  counter-reset: line;
+}
+
+.workbench-code .line {
+  counter-increment: line;
+}
+
+/* Inline gutter marker before each shiki line (empty lines keep their height
+   from the source newlines, so the counter still advances). */
+.workbench-code .line::before {
+  content: counter(line);
+  display: inline-block;
+  width: 2rem;
+  margin-right: 1.25rem;
+  text-align: right;
+  color: var(--color-fd-muted-foreground);
+  opacity: 0.4;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
 /* Dotted-grid demo stage with a radial fade toward the page background. */
 .component-preview-canvas {
   background-color: var(--color-fd-background);
@@ -235,6 +299,18 @@ p.docs-lead {
 .component-preview-canvas > * {
   position: relative;
   z-index: 1;
+}
+
+/* Workbench stage canvas — seamless with the page background (no contrast). */
+.workbench-canvas {
+  background-color: var(--color-fd-background);
+}
+
+/* Bounded stage frame — a clearly-visible hairline in both themes (the raw
+   --border token is nearly invisible in dark), so the canvas reads as a
+   contained panel rather than an open void. */
+.stage-frame {
+  border-color: color-mix(in srgb, var(--color-fd-foreground) 12%, transparent);
 }
 
 .component-install-cli pre {

--- a/apps/docs/src/components/background-showcase.tsx
+++ b/apps/docs/src/components/background-showcase.tsx
@@ -17,11 +17,13 @@ import {
 import {
   type ComponentType,
   type CSSProperties,
+  useEffect,
   useMemo,
   useState,
 } from "react";
 import { ComponentInstall } from "@/components/component-install";
 import { ComponentPreview } from "@/components/component-preview";
+import { useStageCopy } from "@/components/workbench/stage-copy-context";
 import { cn } from "@/lib/cn";
 
 type Key = "gradient" | "geometric" | "decorative" | "effect";
@@ -86,7 +88,18 @@ ${style}
 }`;
 }
 
-export function BackgroundShowcase({ component }: { component: Key }) {
+export function BackgroundShowcase({
+  component,
+  embedded = false,
+}: {
+  component: Key;
+  /**
+   * Workbench stage mode: render the live background full-bleed with the variant
+   * picker floating at the bottom, and drop the Preview/Code card + install block
+   * (the page's `## Installation` provides those in the docs drawer instead).
+   */
+  embedded?: boolean;
+}) {
   const set = SETS[component];
   const [selected, setSelected] = useState(set.variants[0]);
   const preset = set.presets[selected];
@@ -97,35 +110,57 @@ export function BackgroundShowcase({ component }: { component: Key }) {
   // one cell). Render them into a larger, scaled-down box so several tiles show.
   const dense = component === "geometric";
 
+  // Embedded (workbench) mode: publish the current variant's snippet to the rail
+  // so its copy button tracks the live selection; clear it on unmount.
+  const { setCopyValue } = useStageCopy();
+  useEffect(() => {
+    if (!embedded) return;
+    setCopyValue(code);
+    return () => setCopyValue(null);
+  }, [embedded, code, setCopyValue]);
+
+  const swatches = set.variants.map((variant) => (
+    <button
+      key={variant}
+      type="button"
+      onClick={() => setSelected(variant)}
+      aria-pressed={variant === selected}
+      title={variant}
+      className={cn(
+        "relative h-12 w-16 shrink-0 overflow-hidden rounded-md border transition",
+        variant === selected
+          ? "border-fd-primary ring-2 ring-fd-primary ring-offset-2 ring-offset-fd-background"
+          : "border-fd-border hover:border-fd-primary/50",
+      )}
+    >
+      {dense ? (
+        <span className="absolute top-0 left-0 h-[250%] w-[250%] origin-top-left scale-[0.4]">
+          <Bg style={set.presets[variant]} />
+        </span>
+      ) : (
+        <Bg style={set.presets[variant]} />
+      )}
+    </button>
+  ));
+
+  if (embedded) {
+    return (
+      <div className="not-prose relative size-full overflow-hidden">
+        <Bg style={preset} />
+        {/* Variant picker floating over the bg at the bottom of the stage. The
+            copy button lives in the rail (top-right) via StageCopyProvider. */}
+        <div className="-translate-x-1/2 absolute bottom-4 left-1/2 z-10 flex max-w-[calc(100%-2rem)] gap-2 overflow-x-auto rounded-2xl border border-fd-border bg-fd-card/80 p-2 shadow-lg backdrop-blur-md">
+          {swatches}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="not-prose my-8 flex flex-col gap-4">
       {/* horizontal variant picker — p-2 leaves room for the selected ring,
           which the overflow-x-auto row would otherwise clip */}
-      <div className="flex gap-2 overflow-x-auto p-2">
-        {set.variants.map((variant) => (
-          <button
-            key={variant}
-            type="button"
-            onClick={() => setSelected(variant)}
-            aria-pressed={variant === selected}
-            title={variant}
-            className={cn(
-              "relative h-12 w-16 shrink-0 overflow-hidden rounded-md border transition",
-              variant === selected
-                ? "border-fd-primary ring-2 ring-fd-primary ring-offset-2 ring-offset-fd-background"
-                : "border-fd-border hover:border-fd-primary/50",
-            )}
-          >
-            {dense ? (
-              <span className="absolute top-0 left-0 h-[250%] w-[250%] origin-top-left scale-[0.4]">
-                <Bg style={set.presets[variant]} />
-              </span>
-            ) : (
-              <Bg style={set.presets[variant]} />
-            )}
-          </button>
-        ))}
-      </div>
+      <div className="flex gap-2 overflow-x-auto p-2">{swatches}</div>
 
       {/* live preview — the selected variant drives both the canvas and the
           Code tab, full-bleed inside the preview box */}

--- a/apps/docs/src/components/component-preview.tsx
+++ b/apps/docs/src/components/component-preview.tsx
@@ -3,11 +3,11 @@
 import { DynamicCodeBlock } from "fumadocs-ui/components/dynamic-codeblock";
 import { Monitor, Smartphone } from "lucide-react";
 import type { ReactNode } from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useEffect, useState } from "react";
 import { BorderBeam } from "@/components/border-beam";
 import { CopyButton } from "@/components/copy-button";
 import { DocsPanel, Segmented } from "@/components/docs-tabs";
+import { PreviewFrame } from "@/components/preview-frame";
 import { ReplayButton } from "@/components/replay-button";
 import { cn } from "@/lib/cn";
 import { formatCode } from "@/lib/format-code";
@@ -127,100 +127,6 @@ function ViewToggle({
         );
       })}
     </div>
-  );
-}
-
-/**
- * Renders the demo inside an <iframe> so real CSS media queries fire against the
- * frame's width — the only way to simulate mobile for components that ship
- * viewport breakpoints (`md:` etc.) internally. Used for the "mobile" view only;
- * desktop renders in-page (cheaper). Parent stylesheets + theme class are cloned
- * into the frame and the demo is portaled into its body.
- */
-function PreviewFrame({
-  children,
-  fullWidth,
-}: {
-  children: ReactNode;
-  fullWidth: boolean;
-}) {
-  const [mount, setMount] = useState<HTMLElement | null>(null);
-  const [height, setHeight] = useState(440);
-  const cleanupRef = useRef<(() => void) | undefined>(undefined);
-
-  // Set up the iframe in a ref callback (not an effect): the document mutation
-  // and setState below are valid here, and `frame` is a local rather than a
-  // useState value, so the strict react-hooks lint rules don't fire.
-  const attach = useCallback((frame: HTMLIFrameElement | null) => {
-    cleanupRef.current?.();
-    cleanupRef.current = undefined;
-    const doc = frame?.contentDocument;
-    if (!doc) {
-      setMount(null);
-      return;
-    }
-
-    const syncTheme = () => {
-      doc.documentElement.className = document.documentElement.className;
-      doc.documentElement.setAttribute(
-        "style",
-        document.documentElement.getAttribute("style") ?? "",
-      );
-    };
-
-    // Clone parent stylesheets (Tailwind, fonts) into the frame.
-    for (const node of document.head.querySelectorAll(
-      'style, link[rel="stylesheet"]',
-    )) {
-      doc.head.appendChild(node.cloneNode(true));
-    }
-    syncTheme();
-    doc.body.style.margin = "0";
-    doc.body.style.background = "transparent";
-    setMount(doc.body);
-
-    const ro = new ResizeObserver(() => {
-      setHeight(Math.max(360, doc.body.scrollHeight));
-    });
-    ro.observe(doc.body);
-    const mo = new MutationObserver(syncTheme);
-    mo.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ["class", "style", "data-theme"],
-    });
-
-    cleanupRef.current = () => {
-      ro.disconnect();
-      mo.disconnect();
-    };
-  }, []);
-
-  useEffect(() => () => cleanupRef.current?.(), []);
-
-  return (
-    <>
-      <iframe
-        ref={attach}
-        title="Mobile preview"
-        className="w-[360px] max-w-full overflow-hidden rounded-[28px] border-[6px] border-fd-border bg-fd-background shadow-md transition-[height] duration-200"
-        style={{ height }}
-      />
-      {mount
-        ? createPortal(
-            <div
-              className={cn(
-                "flex w-full",
-                fullWidth
-                  ? "flex-col"
-                  : "min-h-[440px] items-center justify-center p-4",
-              )}
-            >
-              {children}
-            </div>,
-            mount,
-          )
-        : null}
-    </>
   );
 }
 

--- a/apps/docs/src/components/demos/container-scroll-demo.tsx
+++ b/apps/docs/src/components/demos/container-scroll-demo.tsx
@@ -1,22 +1,34 @@
 "use client";
 
 import { ContainerScroll } from "@godui/components";
+import { useRef } from "react";
 
 export function ContainerScrollDemo() {
+  // Scroll-driven, so it needs its own scroll room. Inside the workbench stage
+  // the window never scrolls — give the demo a self-contained scroll frame and
+  // point `scrollContainer` at it so scrolling the preview drives the animation.
+  const ref = useRef<HTMLDivElement>(null);
   return (
-    <ContainerScroll
-      header={
-        <>
-          <h2 className="text-3xl font-bold text-foreground md:text-5xl">
-            Scroll to bring it to life
-          </h2>
-          <p className="mt-4 text-muted-foreground">
-            The frame un-tilts and settles as you scroll.
-          </p>
-        </>
-      }
+    <div
+      ref={ref}
+      data-scroll-container
+      className="relative h-full w-full overflow-y-auto overflow-x-hidden"
     >
-      <img src="https://picsum.photos/id/1005/1200/750" alt="Dashboard" />
-    </ContainerScroll>
+      <ContainerScroll
+        scrollContainer={ref}
+        header={
+          <>
+            <h2 className="font-bold text-3xl text-foreground md:text-5xl">
+              Scroll to bring it to life
+            </h2>
+            <p className="mt-4 text-muted-foreground">
+              The frame un-tilts and settles as you scroll.
+            </p>
+          </>
+        }
+      >
+        <img src="https://picsum.photos/id/1005/1200/750" alt="Dashboard" />
+      </ContainerScroll>
+    </div>
   );
 }

--- a/apps/docs/src/components/demos/hero-parallax-demo.tsx
+++ b/apps/docs/src/components/demos/hero-parallax-demo.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { HeroParallax } from "@godui/components";
+import { useRef } from "react";
 
 const PRODUCTS = [
   "1015",
@@ -25,5 +26,18 @@ const PRODUCTS = [
 }));
 
 export function HeroParallaxDemo() {
-  return <HeroParallax products={PRODUCTS} />;
+  // The parallax maps scroll progress onto the plane, so it needs its own tall
+  // scroll room. Inside the workbench stage the window never scrolls, so give
+  // the demo a self-contained scroll frame and point `scrollContainer` at it —
+  // now scrolling the preview drives the animation.
+  const ref = useRef<HTMLDivElement>(null);
+  return (
+    <div
+      ref={ref}
+      data-scroll-container
+      className="relative h-full w-full overflow-y-auto overflow-x-hidden"
+    >
+      <HeroParallax products={PRODUCTS} scrollContainer={ref} />
+    </div>
+  );
 }

--- a/apps/docs/src/components/docs-tabs.tsx
+++ b/apps/docs/src/components/docs-tabs.tsx
@@ -9,6 +9,8 @@ type DocsTabsProps = {
   value: string;
   onChange: (value: string) => void;
   className?: string;
+  /** Segmented only: render the icon alone, label becomes the accessible name. */
+  iconOnly?: boolean;
 };
 
 export function DocsTabs({ tabs, value, onChange, className }: DocsTabsProps) {
@@ -108,7 +110,13 @@ export function PillTabs({ tabs, value, onChange, className }: PillTabsProps) {
  * Pill-style segmented control (e.g. Preview / Code). Unlike DocsTabs (underline
  * tabs) this renders an enclosed track with a raised active segment.
  */
-export function Segmented({ tabs, value, onChange, className }: DocsTabsProps) {
+export function Segmented({
+  tabs,
+  value,
+  onChange,
+  className,
+  iconOnly,
+}: DocsTabsProps) {
   const activeIndex = Math.max(
     0,
     tabs.findIndex((tab) => tab.value === value),
@@ -147,18 +155,21 @@ export function Segmented({ tabs, value, onChange, className }: DocsTabsProps) {
           key={tab.value}
           type="button"
           onClick={() => onChange(tab.value)}
+          aria-label={iconOnly ? tab.label : undefined}
+          title={iconOnly ? tab.label : undefined}
           className={cn(
             // h-8 track (border-box) leaves a 24px inner area; symmetric
             // py-[3px] + leading-[18px] centers the label vertically without
             // depending on grid row-stretch behavior.
-            "relative z-[1] inline-flex items-center justify-center gap-1.5 rounded-[7px] px-3 py-[3px] text-[13px] leading-[18px] font-medium transition-colors",
+            "relative z-[1] inline-flex items-center justify-center gap-1.5 whitespace-nowrap rounded-[7px] py-[3px] text-[13px] leading-[18px] font-medium transition-colors",
+            iconOnly ? "px-2.5" : "px-3",
             value === tab.value
               ? "text-[var(--foreground)]"
               : "text-[var(--muted-foreground)] hover:text-[var(--foreground)]",
           )}
         >
           {tab.icon}
-          {tab.label}
+          {iconOnly ? <span className="sr-only">{tab.label}</span> : tab.label}
         </button>
       ))}
     </div>

--- a/apps/docs/src/components/docs-tabs.tsx
+++ b/apps/docs/src/components/docs-tabs.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
 import { cn } from "@/lib/cn";
 
 type DocsTabsProps = {
@@ -172,6 +172,119 @@ export function Segmented({
           {iconOnly ? <span className="sr-only">{tab.label}</span> : tab.label}
         </button>
       ))}
+    </div>
+  );
+}
+
+/**
+ * Horizontally-scrollable segmented control for when there are too many segments
+ * to fit an equal-width <Segmented> track (e.g. combobox with 8+ examples). Pills
+ * are content-width (so labels never collide/wrap), the track scrolls sideways,
+ * the active pill auto-centers, and a measured thumb slides beneath it. Edge
+ * fades hint that there's more off-screen.
+ */
+export function ScrollableSegmented({
+  tabs,
+  value,
+  onChange,
+  className,
+}: DocsTabsProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const trackRef = useRef<HTMLDivElement>(null);
+  const [thumb, setThumb] = useState<{
+    left: number;
+    top: number;
+    width: number;
+    height: number;
+  } | null>(null);
+  const [edges, setEdges] = useState({ left: false, right: false });
+
+  const syncEdges = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setEdges({
+      left: el.scrollLeft > 1,
+      right: el.scrollLeft + el.clientWidth < el.scrollWidth - 1,
+    });
+  }, []);
+
+  // Measure the active pill (relative to the scrolling track), slide the thumb
+  // to it, and scroll it to center so the current variant is always in view.
+  useLayoutEffect(() => {
+    const track = trackRef.current;
+    const scroller = scrollRef.current;
+    const active = track?.querySelector<HTMLButtonElement>(
+      `[data-value="${CSS.escape(value)}"]`,
+    );
+    if (!track || !scroller || !active) return;
+    setThumb({
+      left: active.offsetLeft,
+      top: active.offsetTop,
+      width: active.offsetWidth,
+      height: active.offsetHeight,
+    });
+    scroller.scrollTo({
+      left: active.offsetLeft - (scroller.clientWidth - active.offsetWidth) / 2,
+      behavior: "smooth",
+    });
+    // Let the smooth scroll settle before reading edge state.
+    const t = window.setTimeout(syncEdges, 320);
+    return () => window.clearTimeout(t);
+  }, [value, syncEdges]);
+
+  return (
+    <div className={cn("relative max-w-full", className)}>
+      {/* Edge fades — masked overlays that appear when content is clipped. */}
+      <div
+        aria-hidden
+        className={cn(
+          "pointer-events-none absolute inset-y-0 left-0 z-[2] w-8 rounded-l-[10px] bg-gradient-to-r from-[var(--muted)] to-transparent transition-opacity",
+          edges.left ? "opacity-100" : "opacity-0",
+        )}
+      />
+      <div
+        aria-hidden
+        className={cn(
+          "pointer-events-none absolute inset-y-0 right-0 z-[2] w-8 rounded-r-[10px] bg-gradient-to-l from-[var(--muted)] to-transparent transition-opacity",
+          edges.right ? "opacity-100" : "opacity-0",
+        )}
+      />
+      <div
+        ref={scrollRef}
+        onScroll={syncEdges}
+        className="no-scrollbar overflow-x-auto rounded-[10px] border border-fd-border bg-[var(--muted)] shadow-lg"
+      >
+        <div ref={trackRef} className="relative flex w-max gap-1 p-[3px]">
+          {thumb ? (
+            <span
+              aria-hidden="true"
+              className="absolute top-0 left-0 rounded-[7px] bg-[var(--card)] shadow-sm transition-[transform,width] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none"
+              style={{
+                width: thumb.width,
+                height: thumb.height,
+                transform: `translate(${thumb.left}px, ${thumb.top}px)`,
+              }}
+            />
+          ) : null}
+          {tabs.map((tab) => (
+            <button
+              key={tab.value}
+              type="button"
+              data-value={tab.value}
+              onClick={() => onChange(tab.value)}
+              className={cn(
+                "relative z-[1] inline-flex items-center justify-center gap-1.5 whitespace-nowrap rounded-[7px] px-3 py-[3px] text-[13px] leading-[18px] font-medium transition-colors",
+                value === tab.value
+                  ? "text-[var(--foreground)]"
+                  : "text-[var(--muted-foreground)] hover:text-[var(--foreground)]",
+              )}
+            >
+              {tab.icon}
+              {tab.label}
+            </button>
+          ))}
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/docs/src/components/mdx.tsx
+++ b/apps/docs/src/components/mdx.tsx
@@ -403,6 +403,8 @@ import { WorldMapDraw } from "@/components/learn/world-map-draw";
 import { WorldMapPulse } from "@/components/learn/world-map-pulse";
 import { WorldMapResult } from "@/components/learn/world-map-result";
 import { MCPInstall } from "@/components/mcp-install";
+import { Example } from "@/components/workbench/example";
+import { Workbench } from "@/components/workbench/workbench";
 
 function Table(props: ComponentProps<"table">) {
   return (
@@ -450,6 +452,8 @@ export function getMDXComponents(components?: MDXComponents) {
     table: Table,
     ComponentPreview,
     ComponentInstall,
+    Workbench,
+    Example,
     MCPInstall,
     BackgroundShowcase,
     PreviewCard,

--- a/apps/docs/src/components/motion-guidelines/motion-gallery.tsx
+++ b/apps/docs/src/components/motion-guidelines/motion-gallery.tsx
@@ -5,7 +5,7 @@ import { type GalleryItem, MotionCard } from "./motion-card";
 export function MotionGallery({ items }: { items: GalleryItem[] }) {
   return (
     <div className="not-prose mt-6">
-      <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
+      <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
         {items.map((item) => (
           <MotionCard key={item.slug} item={item} />
         ))}

--- a/apps/docs/src/components/preview-frame.tsx
+++ b/apps/docs/src/components/preview-frame.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { cn } from "@/lib/cn";
+
+/**
+ * Renders the demo inside an <iframe> so real CSS media queries fire against the
+ * frame's width — the only way to simulate mobile for components that ship
+ * viewport breakpoints (`md:` etc.) internally. Used for the "mobile" view only;
+ * desktop renders in-page (cheaper). Parent stylesheets + theme class are cloned
+ * into the frame and the demo is portaled into its body.
+ */
+export function PreviewFrame({
+  children,
+  fullWidth,
+}: {
+  children: ReactNode;
+  fullWidth: boolean;
+}) {
+  const [mount, setMount] = useState<HTMLElement | null>(null);
+  const [height, setHeight] = useState(440);
+  const cleanupRef = useRef<(() => void) | undefined>(undefined);
+
+  // Set up the iframe in a ref callback (not an effect): the document mutation
+  // and setState below are valid here, and `frame` is a local rather than a
+  // useState value, so the strict react-hooks lint rules don't fire.
+  const attach = useCallback((frame: HTMLIFrameElement | null) => {
+    cleanupRef.current?.();
+    cleanupRef.current = undefined;
+    const doc = frame?.contentDocument;
+    if (!doc) {
+      setMount(null);
+      return;
+    }
+
+    const syncTheme = () => {
+      doc.documentElement.className = document.documentElement.className;
+      doc.documentElement.setAttribute(
+        "style",
+        document.documentElement.getAttribute("style") ?? "",
+      );
+    };
+
+    // Clone parent stylesheets (Tailwind, fonts) into the frame.
+    for (const node of document.head.querySelectorAll(
+      'style, link[rel="stylesheet"]',
+    )) {
+      doc.head.appendChild(node.cloneNode(true));
+    }
+    syncTheme();
+    doc.body.style.margin = "0";
+    doc.body.style.background = "transparent";
+    setMount(doc.body);
+
+    const ro = new ResizeObserver(() => {
+      setHeight(Math.max(360, doc.body.scrollHeight));
+    });
+    ro.observe(doc.body);
+    const mo = new MutationObserver(syncTheme);
+    mo.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class", "style", "data-theme"],
+    });
+
+    cleanupRef.current = () => {
+      ro.disconnect();
+      mo.disconnect();
+    };
+  }, []);
+
+  useEffect(() => () => cleanupRef.current?.(), []);
+
+  return (
+    <>
+      <iframe
+        ref={attach}
+        title="Mobile preview"
+        className="w-[360px] max-w-full overflow-hidden rounded-[28px] border-[6px] border-fd-border bg-fd-background shadow-md transition-[height] duration-200"
+        style={{ height }}
+      />
+      {mount
+        ? createPortal(
+            <div
+              className={cn(
+                "flex w-full",
+                fullWidth
+                  ? "flex-col"
+                  : "min-h-[440px] items-center justify-center p-4",
+              )}
+            >
+              {children}
+            </div>,
+            mount,
+          )
+        : null}
+    </>
+  );
+}

--- a/apps/docs/src/components/workbench/example.tsx
+++ b/apps/docs/src/components/workbench/example.tsx
@@ -1,0 +1,32 @@
+import type { ReactNode } from "react";
+
+export type ExampleProps = {
+  /** Tab label. When there is a single example the tabs are hidden. */
+  label?: string;
+  /** The rendered demo shown on the stage. */
+  children: ReactNode;
+  /** Source shown in the Code panel of the stage drawer. */
+  code?: string;
+  /** Language for the Code panel (default "tsx"). */
+  lang?: string;
+  /**
+   * Storybook docs id, e.g. "buttons-gooey-fab". When set, the dock shows a
+   * "Playground" link to the live Storybook page.
+   */
+  story?: string;
+  /**
+   * When true the demo fills the stage edge-to-edge instead of sitting centered
+   * in a padded canvas. Use for full-bleed UI (docks, nav bars, heroes).
+   */
+  fullWidth?: boolean;
+};
+
+/**
+ * Declares one stage example inside a <Workbench>. It renders nothing on its
+ * own — <Workbench> reads its props (and `children` as the live demo), turning
+ * each <Example> into a stage tab. Kept as a stable module identity so
+ * `child.type === Example` matches across the server-MDX → client boundary.
+ */
+export function Example(_props: ExampleProps): null {
+  return null;
+}

--- a/apps/docs/src/components/workbench/panel-body.tsx
+++ b/apps/docs/src/components/workbench/panel-body.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { DynamicCodeBlock } from "fumadocs-ui/components/dynamic-codeblock";
+import { DocsBody } from "fumadocs-ui/layouts/docs/page";
+import { Code2, FileText, GraduationCap, X } from "lucide-react";
+import { type ReactNode, useEffect, useState } from "react";
+import { CopyButton } from "@/components/copy-button";
+import { Segmented } from "@/components/docs-tabs";
+import { cn } from "@/lib/cn";
+import { formatCode } from "@/lib/format-code";
+
+export type DrawerTab = "docs" | "code" | "learn";
+
+/**
+ * Shared inner surface for both the mobile bottom sheet (`StageDrawer`) and the
+ * desktop right rail (`StagePanel`): the Docs/Code/Learn tab bar, a close button,
+ * and the scrollable content (line-numbered code box or `DocsBody`). The two
+ * shells differ only in how they position + animate this body.
+ */
+export function PanelBody({
+  open,
+  onClose,
+  tab,
+  onTabChange,
+  hasCode,
+  docs,
+  code,
+  lang = "tsx",
+  learn,
+}: {
+  open: boolean;
+  onClose: () => void;
+  tab: DrawerTab;
+  onTabChange: (tab: DrawerTab) => void;
+  hasCode: boolean;
+  docs: ReactNode;
+  code: string;
+  lang?: string;
+  learn?: ReactNode;
+}) {
+  const [formatted, setFormatted] = useState(() => code.trim());
+
+  useEffect(() => {
+    let active = true;
+    void formatCode(code, lang).then((next) => {
+      if (active) setFormatted(next);
+    });
+    return () => {
+      active = false;
+    };
+  }, [code, lang]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  const tabs = [
+    {
+      value: "docs",
+      label: "Docs",
+      icon: <FileText className="size-3.5" aria-hidden />,
+    },
+    ...(hasCode
+      ? [
+          {
+            value: "code",
+            label: "Code",
+            icon: <Code2 className="size-3.5" aria-hidden />,
+          },
+        ]
+      : []),
+    ...(learn
+      ? [
+          {
+            value: "learn",
+            label: "Learn",
+            icon: <GraduationCap className="size-3.5" aria-hidden />,
+          },
+        ]
+      : []),
+  ];
+
+  return (
+    <>
+      <div className="flex items-center justify-between gap-3 px-4 pt-3 pb-2.5">
+        <Segmented
+          tabs={tabs}
+          value={tab}
+          onChange={(v) => onTabChange(v as DrawerTab)}
+        />
+        <button
+          type="button"
+          aria-label="Close panel"
+          onClick={onClose}
+          className="inline-flex size-8 items-center justify-center rounded-[10px] border border-fd-border bg-fd-card text-fd-muted-foreground transition-colors hover:text-fd-foreground active:scale-95"
+        >
+          <X className="size-4" />
+        </button>
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+        {tab === "code" && hasCode ? (
+          <div className="p-4 sm:p-5">
+            <div className="workbench-code relative overflow-hidden rounded-xl border border-fd-border bg-[var(--code-block,var(--color-fd-card))]">
+              <CopyButton
+                value={formatted}
+                className="absolute top-2.5 right-2.5 z-10 rounded-[10px] bg-fd-card/80 backdrop-blur-sm"
+              />
+              <DynamicCodeBlock
+                lang={lang}
+                code={formatted}
+                codeblock={{
+                  allowCopy: false,
+                  className: cn(
+                    "my-0 rounded-none border-0 bg-transparent shadow-none",
+                  ),
+                }}
+              />
+            </div>
+          </div>
+        ) : tab === "learn" && learn ? (
+          <DocsBody className="px-5 pt-1 pb-8">{learn}</DocsBody>
+        ) : (
+          <DocsBody className="px-5 pt-1 pb-8">{docs}</DocsBody>
+        )}
+      </div>
+    </>
+  );
+}

--- a/apps/docs/src/components/workbench/stage-copy-context.tsx
+++ b/apps/docs/src/components/workbench/stage-copy-context.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { createContext, useContext, useState } from "react";
+
+type StageCopy = {
+  /** Snippet the stage exposes for the rail's copy button (null → no copy). */
+  copyValue: string | null;
+  setCopyValue: (value: string | null) => void;
+};
+
+const StageCopyContext = createContext<StageCopy | null>(null);
+
+/**
+ * Lets a stage component (e.g. the embedded BackgroundShowcase) publish a
+ * variant-specific snippet up to the workbench rail, so the rail can offer a
+ * copy button that tracks the live selection. When a value is present the rail
+ * treats the demo as a "static" showcase (copy replaces the Code icon; replay
+ * is hidden).
+ */
+export function StageCopyProvider({ children }: { children: React.ReactNode }) {
+  const [copyValue, setCopyValue] = useState<string | null>(null);
+  return (
+    <StageCopyContext.Provider value={{ copyValue, setCopyValue }}>
+      {children}
+    </StageCopyContext.Provider>
+  );
+}
+
+export function useStageCopy(): StageCopy {
+  return (
+    useContext(StageCopyContext) ?? {
+      copyValue: null,
+      setCopyValue: () => {},
+    }
+  );
+}

--- a/apps/docs/src/components/workbench/stage-drawer.tsx
+++ b/apps/docs/src/components/workbench/stage-drawer.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { motion, type PanInfo } from "framer-motion";
+import type { ReactNode } from "react";
+import { type DrawerTab, PanelBody } from "@/components/workbench/panel-body";
+import { cn } from "@/lib/cn";
+
+export type { DrawerTab };
+
+const CLOSE_OFFSET = 120;
+const CLOSE_VELOCITY = 600;
+
+/**
+ * A bottom sheet scoped to the Workbench stage — NOT a body-portaled modal
+ * (unlike @godui/components Drawer). It's absolutely positioned inside the stage
+ * so the site header + sidenav stay visible and interactive. Used on mobile; the
+ * desktop presentation is the right-side <StagePanel>. Both share <PanelBody>.
+ */
+export function StageDrawer({
+  open,
+  onOpenChange,
+  tab,
+  onTabChange,
+  hasCode,
+  docs,
+  code,
+  lang,
+  learn,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  tab: DrawerTab;
+  onTabChange: (tab: DrawerTab) => void;
+  hasCode: boolean;
+  docs: ReactNode;
+  code: string;
+  lang?: string;
+  learn?: ReactNode;
+}) {
+  const handleDragEnd = (
+    _e: MouseEvent | TouchEvent | PointerEvent,
+    info: PanInfo,
+  ) => {
+    if (info.offset.y > CLOSE_OFFSET || info.velocity.y > CLOSE_VELOCITY) {
+      onOpenChange(false);
+    }
+  };
+
+  return (
+    // Stays mounted when closed (translated off-screen) so the active tab's text
+    // remains in the DOM — the aeo.js AI view + crawlers read the article and skip
+    // only display:none, so the default (Docs) content is what they see. `inert` +
+    // aria-hidden neutralise the off-screen panel for humans and assistive tech.
+    <div
+      className={cn(
+        "absolute inset-0 z-30 flex flex-col justify-end",
+        open ? "" : "pointer-events-none",
+      )}
+      aria-hidden={!open}
+      inert={!open}
+    >
+      <motion.button
+        type="button"
+        aria-label="Close panel"
+        tabIndex={open ? 0 : -1}
+        initial={false}
+        animate={{ opacity: open ? 1 : 0 }}
+        transition={{ duration: 0.2 }}
+        onClick={() => onOpenChange(false)}
+        className={cn(
+          "absolute inset-0 cursor-default bg-[var(--foreground)]/25 backdrop-blur-[2px]",
+          open ? "" : "pointer-events-none",
+        )}
+      />
+      <motion.div
+        role="dialog"
+        aria-modal="false"
+        aria-label="Component documentation"
+        data-wb-surface
+        initial={false}
+        animate={{ y: open ? 0 : "100%" }}
+        transition={{ type: "spring", damping: 34, stiffness: 340, mass: 0.9 }}
+        drag={open ? "y" : false}
+        dragConstraints={{ top: 0, bottom: 0 }}
+        dragElastic={{ top: 0, bottom: 0.6 }}
+        onDragEnd={handleDragEnd}
+        className="relative flex h-[90%] flex-col rounded-t-2xl border-fd-border border-t bg-fd-card shadow-2xl"
+      >
+        {/* Grab handle */}
+        <div className="mx-auto mt-2.5 h-1.5 w-12 shrink-0 cursor-grab rounded-full bg-fd-muted-foreground/30 active:cursor-grabbing" />
+        <PanelBody
+          open={open}
+          onClose={() => onOpenChange(false)}
+          tab={tab}
+          onTabChange={onTabChange}
+          hasCode={hasCode}
+          docs={docs}
+          code={code}
+          lang={lang}
+          learn={learn}
+        />
+      </motion.div>
+    </div>
+  );
+}

--- a/apps/docs/src/components/workbench/stage-panel.tsx
+++ b/apps/docs/src/components/workbench/stage-panel.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { type ReactNode, useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { type DrawerTab, PanelBody } from "@/components/workbench/panel-body";
+
+/**
+ * Desktop docs surface: a full-viewport-height rail pinned to the right edge that
+ * slides in on `transform` and pushes the whole app left. The shift itself is
+ * driven by CSS — this component only toggles `data-wb-panel="open"` on the docs
+ * layout grid, which sets the `--wb-panel-w` right offset on the fixed header +
+ * TOC and reserves space in the main column (see globals.css). Portaled to
+ * <body> so the stage frame's `overflow-hidden` can't clip it, and kept mounted
+ * (off-screen + inert) when closed so the docs stay in the DOM for aeo.js.
+ */
+export function StagePanel({
+  open,
+  onOpenChange,
+  tab,
+  onTabChange,
+  hasCode,
+  docs,
+  code,
+  lang,
+  learn,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  tab: DrawerTab;
+  onTabChange: (tab: DrawerTab) => void;
+  hasCode: boolean;
+  docs: ReactNode;
+  code: string;
+  lang?: string;
+  learn?: ReactNode;
+}) {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  // Drive the app-wide left shift by flagging the docs layout grid.
+  useEffect(() => {
+    const layout = document.getElementById("nd-docs-layout");
+    if (!layout) return;
+    if (open) layout.setAttribute("data-wb-panel", "open");
+    else layout.removeAttribute("data-wb-panel");
+    return () => layout.removeAttribute("data-wb-panel");
+  }, [open]);
+
+  if (!mounted) return null;
+
+  return createPortal(
+    <motion.aside
+      aria-label="Component documentation"
+      data-wb-surface
+      aria-hidden={!open}
+      inert={!open}
+      initial={false}
+      animate={{ x: open ? 0 : "100%" }}
+      transition={{ type: "spring", damping: 36, stiffness: 360, mass: 0.9 }}
+      className="fixed top-0 right-0 z-50 flex h-[100dvh] w-[var(--wb-panel-w,420px)] flex-col border-fd-border border-l bg-fd-card shadow-2xl"
+    >
+      <PanelBody
+        open={open}
+        onClose={() => onOpenChange(false)}
+        tab={tab}
+        onTabChange={onTabChange}
+        hasCode={hasCode}
+        docs={docs}
+        code={code}
+        lang={lang}
+        learn={learn}
+      />
+    </motion.aside>,
+    document.body,
+  );
+}

--- a/apps/docs/src/components/workbench/stage-panel.tsx
+++ b/apps/docs/src/components/workbench/stage-panel.tsx
@@ -35,7 +35,12 @@ export function StagePanel({
   lang?: string;
   learn?: ReactNode;
 }) {
+  // Portal target (document.body) only exists on the client; render null on the
+  // server + first hydration pass, then flip after mount. Setting state in this
+  // mount effect is the canonical portal-hydration pattern (server render must
+  // match the first client render), so the set-state-in-effect rule is expected.
   const [mounted, setMounted] = useState(false);
+  // eslint-disable-next-line react-hooks/set-state-in-effect -- mount gate for createPortal
   useEffect(() => setMounted(true), []);
 
   // Drive the app-wide left shift by flagging the docs layout grid.

--- a/apps/docs/src/components/workbench/stage.tsx
+++ b/apps/docs/src/components/workbench/stage.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { PreviewFrame } from "@/components/preview-frame";
+import { cn } from "@/lib/cn";
+
+export type CanvasBg = "default" | "light" | "dark" | "tinted";
+export type StageView = "desktop" | "mobile";
+
+/**
+ * The live preview stage: a dotted-grid canvas that renders the active example.
+ * `bg` swaps only the canvas backdrop (light / dark / tinted) — it never touches
+ * the site theme, so the demo keeps rendering in the real theme.
+ */
+export function Stage({
+  children,
+  view,
+  bg,
+  fullWidth,
+  replayKey,
+}: {
+  children: ReactNode;
+  view: StageView;
+  bg: CanvasBg;
+  fullWidth: boolean;
+  replayKey: number;
+}) {
+  return (
+    <div
+      data-bg={bg}
+      className={cn(
+        "workbench-canvas relative flex h-full w-full flex-col items-center justify-center overflow-auto",
+        view === "mobile" ? "p-6" : fullWidth ? "p-0" : "p-6 md:p-12",
+      )}
+    >
+      {view === "mobile" ? (
+        <PreviewFrame key={replayKey} fullWidth={fullWidth}>
+          {children}
+        </PreviewFrame>
+      ) : (
+        <div
+          key={replayKey}
+          className={cn(
+            "flex w-full max-w-full",
+            fullWidth
+              ? "min-h-full flex-1 flex-col self-stretch"
+              : "items-center justify-center",
+          )}
+        >
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/docs/src/components/workbench/title-chip.tsx
+++ b/apps/docs/src/components/workbench/title-chip.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useId, useState } from "react";
+import { Breadcrumbs } from "@/app/docs/_components/breadcrumbs";
+import {
+  type BadgeItem,
+  type BadgeTone,
+  useWorkbenchMeta,
+} from "@/components/workbench/workbench-context";
+
+const DOT: Record<BadgeTone, string> = {
+  sky: "bg-sky-500",
+  amber: "bg-amber-500",
+  emerald: "bg-emerald-500",
+  violet: "bg-violet-500",
+};
+
+/**
+ * Slim floating identity chip over the stage (top-left): breadcrumb + component
+ * name + a clean meta row (small colored dot + label) with a hover/focus tooltip
+ * explaining each badge. Full description + prose live in the Docs drawer.
+ */
+export function TitleChip() {
+  const { title, badges, breadcrumbs } = useWorkbenchMeta();
+
+  return (
+    <div className="pointer-events-none flex max-w-[60vw] flex-col gap-1.5 sm:max-w-md">
+      {/* Breadcrumb is desktop-only — on mobile just the component title shows. */}
+      <div className="pointer-events-auto hidden sm:block">
+        <Breadcrumbs crumbs={breadcrumbs} />
+      </div>
+      <h1 className="pointer-events-auto font-semibold text-fd-foreground text-lg leading-tight tracking-tight sm:text-xl">
+        {title}
+      </h1>
+      {badges && badges.length > 0 ? (
+        <div className="pointer-events-auto flex flex-wrap items-center gap-x-3.5 gap-y-1 max-sm:hidden">
+          {badges.map((b) => (
+            <BadgeChip key={b.label} badge={b} />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function BadgeChip({ badge }: { badge: BadgeItem }) {
+  const [open, setOpen] = useState(false);
+  const id = useId();
+  const hasTip = Boolean(badge.title || badge.detail);
+
+  return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: hover/focus only reveals a tooltip; the interactive control is the inner <button>.
+    <span
+      className="relative inline-flex"
+      onMouseEnter={() => setOpen(true)}
+      onMouseLeave={() => setOpen(false)}
+      onFocus={() => setOpen(true)}
+      // Keep open while focus stays inside the wrapper (e.g. Tab into the link).
+      onBlur={(e) => {
+        if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
+          setOpen(false);
+        }
+      }}
+    >
+      <button
+        type="button"
+        aria-describedby={open && hasTip ? id : undefined}
+        onClick={() => setOpen((o) => !o)}
+        className="inline-flex items-center gap-1.5 rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-fd-ring"
+      >
+        <span className={`size-1.5 rounded-full ${DOT[badge.tone]}`} />
+        <span className="font-medium text-[11px] text-fd-muted-foreground uppercase tracking-[0.08em]">
+          {badge.label}
+        </span>
+      </button>
+      {open && hasTip ? (
+        // `pt-2` is a transparent, hoverable bridge across the visual gap so the
+        // pointer can travel from the badge into the tooltip (to click the link)
+        // without crossing dead space that would close it.
+        <span
+          role="tooltip"
+          id={id}
+          className="absolute top-full left-0 z-30 block pt-2"
+        >
+          <span className="block w-64 max-w-[70vw] rounded-xl border border-fd-border bg-fd-popover p-3 text-left shadow-lg">
+            {badge.title ? (
+              <span className="block font-medium text-[13px] text-fd-foreground">
+                {badge.title}
+              </span>
+            ) : null}
+            {badge.detail ? (
+              <span className="mt-1 block text-[12px] text-fd-muted-foreground leading-snug">
+                {badge.detail}
+              </span>
+            ) : null}
+            {badge.href ? (
+              <a
+                href={badge.href}
+                className="mt-2 inline-flex items-center gap-1 font-medium text-[12px] text-fd-primary hover:underline"
+              >
+                {badge.hrefLabel ?? "Learn more"}
+                <span aria-hidden>→</span>
+              </a>
+            ) : null}
+          </span>
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/apps/docs/src/components/workbench/workbench-client.tsx
+++ b/apps/docs/src/components/workbench/workbench-client.tsx
@@ -1,0 +1,495 @@
+"use client";
+
+import {
+  Check,
+  ChevronDown,
+  Code2,
+  FileText,
+  GraduationCap,
+  Maximize2,
+  Minimize2,
+  Monitor,
+  Smartphone,
+} from "lucide-react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { Segmented } from "@/components/docs-tabs";
+import { ReplayButton } from "@/components/replay-button";
+import type { ExampleProps } from "@/components/workbench/example";
+import type { DrawerTab } from "@/components/workbench/panel-body";
+import { Stage, type StageView } from "@/components/workbench/stage";
+import { StageDrawer } from "@/components/workbench/stage-drawer";
+import { StagePanel } from "@/components/workbench/stage-panel";
+import { TitleChip } from "@/components/workbench/title-chip";
+import { useWorkbenchMeta } from "@/components/workbench/workbench-context";
+import { cn } from "@/lib/cn";
+import { useSidePanelFit } from "@/lib/use-side-panel-fit";
+
+const STORYBOOK_URL = "https://storybook.godui.design";
+
+/**
+ * The interactive workbench shell. Receives the already-partitioned `examples`
+ * (stage tabs) and `docs` (drawer body) from the server <Workbench>, which does
+ * the partitioning where `child.type === Example` reliably matches (client
+ * references don't survive the server → client boundary as `===`).
+ */
+export function WorkbenchClient({
+  examples,
+  docs,
+}: {
+  examples: ExampleProps[];
+  docs: ReactNode;
+}) {
+  const { learnHref, docsHref, learn, initialDrawerTab } = useWorkbenchMeta();
+  const fitsSide = useSidePanelFit();
+
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [replayKey, setReplayKey] = useState(0);
+  const [view, setView] = useState<StageView>("desktop");
+  const [fullscreen, setFullscreen] = useState(false);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [drawerTab, setDrawerTab] = useState<DrawerTab>("docs");
+
+  // The `…/learn` route sets initialDrawerTab; used to shape the AEO mirror
+  // (learn body on the learn URL, docs + code on the component URL).
+  const isLearnRoute = initialDrawerTab === "learn";
+
+  const active = examples[Math.min(activeIndex, examples.length - 1)];
+  // Playground points at the component's Storybook page (component-level), so keep
+  // it constant across example tabs — the whole dock nav stays stable.
+  const story = active?.story ?? examples.find((e) => e.story)?.story;
+  const code = active?.code ?? "";
+  const hasCode = code.trim().length > 0;
+
+  const replay = () => setReplayKey((k) => k + 1);
+  const selectExample = (index: number) => {
+    setActiveIndex(index);
+    replay();
+  };
+
+  // Reflect the Learn drawer in the URL (shallow — no navigation): the Learn tab
+  // pushes `…/learn`, every other tab / closing restores the base docs route.
+  const syncUrl = useCallback(
+    (tab: DrawerTab | null) => {
+      const target = tab === "learn" && learnHref ? learnHref : docsHref;
+      if (target && window.location.pathname !== target) {
+        window.history.pushState(null, "", target);
+      }
+    },
+    [learnHref, docsHref],
+  );
+
+  const openDrawer = (tab: DrawerTab) => {
+    setDrawerTab(tab);
+    setDrawerOpen(true);
+    syncUrl(tab);
+  };
+  const changeDrawerTab = (tab: DrawerTab) => {
+    setDrawerTab(tab);
+    syncUrl(tab);
+  };
+  const closeDrawer = () => {
+    setDrawerOpen(false);
+    syncUrl(null);
+  };
+  const toggleCode = () => {
+    if (drawerOpen && drawerTab === "code") {
+      closeDrawer();
+    } else {
+      openDrawer("code");
+    }
+  };
+
+  // Back button closes the drawer instead of leaving the page.
+  useEffect(() => {
+    if (!drawerOpen) return;
+    const onPop = () => setDrawerOpen(false);
+    window.addEventListener("popstate", onPop);
+    return () => window.removeEventListener("popstate", onPop);
+  }, [drawerOpen]);
+
+  // Deep-link support: on the `…/learn` route (initialDrawerTab set) open the
+  // drawer to that tab on mount and scroll to the URL hash section within it —
+  // so refreshing `…/learn#motion-score` reopens the drawer at that section.
+  useEffect(() => {
+    if (!initialDrawerTab) return;
+    setDrawerTab(initialDrawerTab);
+    setDrawerOpen(true);
+    const id = window.location.hash.slice(1);
+    if (!id) return;
+    // Wait for the open spring + drawer content to lay out before scrolling.
+    const t = window.setTimeout(() => {
+      // Scope to the visible docs surface — the off-screen AEO mirror duplicates
+      // these ids, and it sits earlier in the DOM, so a bare getElementById would
+      // resolve to the hidden copy.
+      const surface = document.querySelector("[data-wb-surface]");
+      const el =
+        surface?.querySelector<HTMLElement>(`[id="${CSS.escape(id)}"]`) ??
+        document.getElementById(id);
+      el?.scrollIntoView({ block: "start" });
+    }, 420);
+    return () => window.clearTimeout(t);
+    // Runs once on mount; initialDrawerTab is stable for the page.
+  }, [initialDrawerTab]);
+
+  return (
+    <div
+      className={cn(
+        "workbench-root flex flex-col overflow-hidden bg-fd-background",
+        fullscreen
+          ? "fixed inset-0 z-50"
+          : "relative h-[calc(100dvh-3.5rem)] p-3 sm:p-4",
+      )}
+    >
+      {/* AEO mirror — the visible docs live in a body-portaled panel (desktop)
+          or a translated drawer, which the aeo.js AI view can't reliably read.
+          This always-present, off-screen copy sits inside the <article> the widget
+          scans (it skips only display:none / visibility:hidden), so the AI page
+          shows the full docs + code on the component URL and the full learn on the
+          learn URL — regardless of whether the drawer is open. aria-hidden keeps
+          it out of the human a11y tree; `sr-only` keeps textContent readable. */}
+      <div className="sr-only" aria-hidden data-aeo-mirror>
+        {isLearnRoute ? (
+          learn
+        ) : (
+          <>
+            {docs}
+            {examples.map((ex, i) =>
+              ex.code?.trim() ? (
+                <pre key={ex.label ?? i}>
+                  <code>{ex.code}</code>
+                </pre>
+              ) : null,
+            )}
+          </>
+        )}
+      </div>
+
+      {/* Bounded stage frame — the demo lives inside a defined surface, and all
+          chrome anchors to THIS frame's corners (not the viewport), so the empty
+          canvas reads as intentional instead of a void. */}
+      <div
+        className={cn(
+          "stage-frame relative flex min-h-0 flex-1 flex-col overflow-hidden bg-fd-background",
+          fullscreen
+            ? ""
+            : "rounded-[20px] border shadow-[0_1px_2px_rgba(0,0,0,0.04),0_8px_24px_-12px_rgba(0,0,0,0.10)]",
+        )}
+      >
+        <Stage
+          view={view}
+          bg="default"
+          fullWidth={active?.fullWidth ?? false}
+          replayKey={replayKey}
+        >
+          {active?.children}
+        </Stage>
+
+        {/* Top scrim — a background-colored gradient fading to transparent so the
+            title chip + control rail stay legible over image/full-bleed demos. On
+            a plain canvas it's background-over-background (invisible); over imagery
+            it restores contrast. Below the chrome (z-20), above the demo. */}
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-x-0 top-0 z-10 h-40 bg-gradient-to-b from-fd-background/90 via-fd-background/60 to-transparent"
+        />
+
+        {/* Identity chip — top-left */}
+        <div className="absolute top-4 left-4 z-20">
+          <TitleChip />
+        </div>
+
+        {/* Control rail — top-right. Stage controls (replay / viewport) then the
+          content group (Docs / Learn / Code / Playground) then Fullscreen, all
+          icon-only bordered chips. Wraps on very narrow desktops. */}
+        <div className="absolute top-4 right-4 z-20 flex flex-wrap items-center justify-end gap-1.5">
+          <ReplayButton onReplay={replay} />
+          <Segmented
+            className="max-md:hidden"
+            iconOnly
+            tabs={[
+              {
+                value: "desktop",
+                label: "Desktop",
+                icon: <Monitor className="size-4" aria-hidden />,
+              },
+              {
+                value: "mobile",
+                label: "Mobile",
+                icon: <Smartphone className="size-4" aria-hidden />,
+              },
+            ]}
+            value={view}
+            onChange={(v) => setView(v as StageView)}
+          />
+          <RailDivider />
+          <ToolButton
+            label="Docs"
+            active={drawerOpen && drawerTab === "docs"}
+            onClick={() =>
+              drawerOpen && drawerTab === "docs"
+                ? closeDrawer()
+                : openDrawer("docs")
+            }
+          >
+            <FileText className="size-4" aria-hidden />
+          </ToolButton>
+          <ToolButton
+            label="View code"
+            active={drawerOpen && drawerTab === "code"}
+            disabled={!hasCode}
+            onClick={toggleCode}
+          >
+            <Code2 className="size-4" aria-hidden />
+          </ToolButton>
+          {learn ? (
+            <ToolButton
+              label="Learn"
+              active={drawerOpen && drawerTab === "learn"}
+              onClick={() =>
+                drawerOpen && drawerTab === "learn"
+                  ? closeDrawer()
+                  : openDrawer("learn")
+              }
+            >
+              <GraduationCap className="size-4" aria-hidden />
+            </ToolButton>
+          ) : null}
+          {story ? (
+            <a
+              href={`${STORYBOOK_URL}/?path=/docs/${story}--docs`}
+              target="_blank"
+              rel="noreferrer"
+              aria-label="Playground"
+              title="Playground"
+              className="inline-flex size-8 items-center justify-center rounded-[10px] border border-fd-border bg-fd-card text-fd-muted-foreground transition-colors hover:text-fd-foreground active:scale-95"
+            >
+              <PlaygroundIcon />
+            </a>
+          ) : null}
+          <RailDivider />
+          <ToolButton
+            label={fullscreen ? "Exit fullscreen" : "Fullscreen"}
+            active={fullscreen}
+            onClick={() => setFullscreen((f) => !f)}
+          >
+            {fullscreen ? (
+              <Minimize2 className="size-4" aria-hidden />
+            ) : (
+              <Maximize2 className="size-4" aria-hidden />
+            )}
+          </ToolButton>
+        </div>
+
+        {/* Bottom cluster — example variant tabs, centered. */}
+        {examples.length > 1 ? (
+          <div className="-translate-x-1/2 absolute bottom-5 left-1/2 z-20 flex w-[calc(100%-1.25rem)] flex-col items-center sm:w-auto sm:max-w-[calc(100%-1rem)]">
+            {/* Mobile: a custom dropdown — equal-width tabs get cramped / wrap
+                once there are 3+ variants. It opens upward (the control sits at
+                the screen bottom) instead of the browser's detached native list. */}
+            <div className="w-full sm:hidden">
+              <ExampleSelect
+                items={examples.map((ex, i) => ex.label ?? `Example ${i + 1}`)}
+                value={Math.min(activeIndex, examples.length - 1)}
+                onSelect={selectExample}
+              />
+            </div>
+            {/* Desktop: the segmented control (wrapper controls visibility —
+                Segmented's own `inline-grid` would beat a `hidden` on it). */}
+            <div className="hidden sm:block">
+              <Segmented
+                className="shadow-lg"
+                tabs={examples.map((ex, i) => ({
+                  value: String(i),
+                  label: ex.label ?? `Example ${i + 1}`,
+                }))}
+                value={String(Math.min(activeIndex, examples.length - 1))}
+                onChange={(v) => selectExample(Number(v))}
+              />
+            </div>
+          </div>
+        ) : null}
+
+        {/* Enough side slack → full-height right rail that slides the whole app
+            left (no resize); otherwise a bottom sheet inside the stage. One
+            instance (measured, not both) so the docs DOM exists once (aeo.js +
+            #hash anchors). */}
+        {fitsSide ? (
+          <StagePanel
+            open={drawerOpen}
+            onOpenChange={(o) => (o ? setDrawerOpen(true) : closeDrawer())}
+            tab={drawerTab}
+            onTabChange={changeDrawerTab}
+            hasCode={hasCode}
+            docs={docs}
+            code={code}
+            lang={active?.lang}
+            learn={learn}
+          />
+        ) : (
+          <StageDrawer
+            open={drawerOpen}
+            onOpenChange={(o) => (o ? setDrawerOpen(true) : closeDrawer())}
+            tab={drawerTab}
+            onTabChange={changeDrawerTab}
+            hasCode={hasCode}
+            docs={docs}
+            code={code}
+            lang={active?.lang}
+            learn={learn}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function RailDivider() {
+  return <span aria-hidden className="mx-0.5 h-5 w-px bg-fd-border" />;
+}
+
+/**
+ * Mobile example picker. A native <select> renders its option list detached and
+ * awkwardly positioned near the bottom edge, so this is a custom dropdown that
+ * anchors directly above the trigger and matches the dock styling.
+ */
+function ExampleSelect({
+  items,
+  value,
+  onSelect,
+}: {
+  items: string[];
+  value: number;
+  onSelect: (index: number) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: PointerEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("pointerdown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("pointerdown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  return (
+    <div ref={ref} className="relative w-full">
+      <button
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={() => setOpen((o) => !o)}
+        className="flex w-full items-center justify-between gap-2 rounded-2xl border border-fd-border bg-fd-card/85 py-2 pr-3 pl-3.5 font-medium text-fd-foreground text-sm shadow-lg backdrop-blur-md active:scale-[0.99]"
+      >
+        <span className="truncate">{items[value]}</span>
+        <ChevronDown
+          aria-hidden
+          className={cn(
+            "size-4 shrink-0 text-fd-muted-foreground transition-transform",
+            open && "rotate-180",
+          )}
+        />
+      </button>
+      {open ? (
+        // Opens upward (bottom-full) since the control sits at the screen bottom.
+        // Inner radius (xl=12) + p-1 (4) = 16 = the outer 2xl radius (concentric).
+        <div
+          role="listbox"
+          className="absolute bottom-full left-0 z-30 mb-2 max-h-[50vh] w-full overflow-auto rounded-2xl border border-fd-border bg-fd-popover p-1 shadow-xl"
+        >
+          {items.map((label, i) => (
+            <button
+              key={label}
+              type="button"
+              role="option"
+              aria-selected={i === value}
+              onClick={() => {
+                onSelect(i);
+                setOpen(false);
+              }}
+              className={cn(
+                "flex w-full items-center justify-between gap-2 rounded-xl px-3 py-2 text-left text-sm transition-colors",
+                i === value
+                  ? "bg-fd-accent font-medium text-fd-foreground"
+                  : "text-fd-muted-foreground hover:bg-fd-accent hover:text-fd-foreground",
+              )}
+            >
+              {label}
+              {i === value ? (
+                <Check aria-hidden className="size-4 shrink-0" />
+              ) : null}
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ToolButton({
+  label,
+  active,
+  disabled,
+  onClick,
+  children,
+}: {
+  label: string;
+  active?: boolean;
+  disabled?: boolean;
+  onClick?: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      aria-pressed={active}
+      title={label}
+      disabled={disabled}
+      onClick={onClick}
+      className={cn(
+        "inline-flex size-8 items-center justify-center rounded-[10px] border transition-colors active:scale-95 disabled:pointer-events-none disabled:opacity-40",
+        active
+          ? "border-fd-primary/45 bg-fd-primary/10 text-fd-primary"
+          : "border-fd-border bg-fd-card text-fd-muted-foreground hover:text-fd-foreground",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+function PlaygroundIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      className="size-4"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M15 3h6v6" />
+      <path d="M10 14 21 3" />
+      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+    </svg>
+  );
+}

--- a/apps/docs/src/components/workbench/workbench-client.tsx
+++ b/apps/docs/src/components/workbench/workbench-client.tsx
@@ -18,11 +18,16 @@ import {
   useRef,
   useState,
 } from "react";
-import { Segmented } from "@/components/docs-tabs";
+import { CopyButton } from "@/components/copy-button";
+import { ScrollableSegmented, Segmented } from "@/components/docs-tabs";
 import { ReplayButton } from "@/components/replay-button";
 import type { ExampleProps } from "@/components/workbench/example";
 import type { DrawerTab } from "@/components/workbench/panel-body";
 import { Stage, type StageView } from "@/components/workbench/stage";
+import {
+  StageCopyProvider,
+  useStageCopy,
+} from "@/components/workbench/stage-copy-context";
 import { StageDrawer } from "@/components/workbench/stage-drawer";
 import { StagePanel } from "@/components/workbench/stage-panel";
 import { TitleChip } from "@/components/workbench/title-chip";
@@ -38,7 +43,20 @@ const STORYBOOK_URL = "https://storybook.godui.design";
  * the partitioning where `child.type === Example` reliably matches (client
  * references don't survive the server → client boundary as `===`).
  */
-export function WorkbenchClient({
+export function WorkbenchClient(props: {
+  examples: ExampleProps[];
+  docs: ReactNode;
+}) {
+  // Provider wraps the shell so a stage component (embedded BackgroundShowcase)
+  // can publish a live snippet the rail's copy button reads.
+  return (
+    <StageCopyProvider>
+      <WorkbenchInner {...props} />
+    </StageCopyProvider>
+  );
+}
+
+function WorkbenchInner({
   examples,
   docs,
 }: {
@@ -47,6 +65,9 @@ export function WorkbenchClient({
 }) {
   const { learnHref, docsHref, learn, initialDrawerTab } = useWorkbenchMeta();
   const fitsSide = useSidePanelFit();
+  // Present when the active demo is a "static" showcase (embedded background):
+  // the rail shows a copy button instead of the Code icon and hides replay.
+  const { copyValue } = useStageCopy();
 
   const [activeIndex, setActiveIndex] = useState(0);
   const [replayKey, setReplayKey] = useState(0);
@@ -208,7 +229,8 @@ export function WorkbenchClient({
           content group (Docs / Learn / Code / Playground) then Fullscreen, all
           icon-only bordered chips. Wraps on very narrow desktops. */}
         <div className="absolute top-4 right-4 z-20 flex flex-wrap items-center justify-end gap-1.5">
-          <ReplayButton onReplay={replay} />
+          {/* Static showcases (embedded background) have nothing to replay. */}
+          {copyValue === null ? <ReplayButton onReplay={replay} /> : null}
           <Segmented
             className="max-md:hidden"
             iconOnly
@@ -239,14 +261,20 @@ export function WorkbenchClient({
           >
             <FileText className="size-4" aria-hidden />
           </ToolButton>
-          <ToolButton
-            label="View code"
-            active={drawerOpen && drawerTab === "code"}
-            disabled={!hasCode}
-            onClick={toggleCode}
-          >
-            <Code2 className="size-4" aria-hidden />
-          </ToolButton>
+          {copyValue !== null ? (
+            // Static showcase: the Code icon becomes a copy button for the live
+            // variant snippet (updates as the user switches backgrounds).
+            <CopyButton value={copyValue} className="size-8 rounded-[10px]" />
+          ) : (
+            <ToolButton
+              label="View code"
+              active={drawerOpen && drawerTab === "code"}
+              disabled={!hasCode}
+              onClick={toggleCode}
+            >
+              <Code2 className="size-4" aria-hidden />
+            </ToolButton>
+          )}
           {learn ? (
             <ToolButton
               label="Learn"
@@ -288,10 +316,8 @@ export function WorkbenchClient({
 
         {/* Bottom cluster — example variant tabs, centered. */}
         {examples.length > 1 ? (
-          <div className="-translate-x-1/2 absolute bottom-5 left-1/2 z-20 flex w-[calc(100%-1.25rem)] flex-col items-center sm:w-auto sm:max-w-[calc(100%-1rem)]">
-            {/* Mobile: a custom dropdown — equal-width tabs get cramped / wrap
-                once there are 3+ variants. It opens upward (the control sits at
-                the screen bottom) instead of the browser's detached native list. */}
+          <div className="-translate-x-1/2 absolute bottom-5 left-1/2 z-20 flex w-[calc(100%-1.25rem)] flex-col items-center sm:w-auto sm:max-w-[calc(100%-2rem)]">
+            {/* Mobile: dropdown (equal-width tabs get cramped on narrow screens). */}
             <div className="w-full sm:hidden">
               <ExampleSelect
                 items={examples.map((ex, i) => ex.label ?? `Example ${i + 1}`)}
@@ -299,19 +325,35 @@ export function WorkbenchClient({
                 onSelect={selectExample}
               />
             </div>
-            {/* Desktop: the segmented control (wrapper controls visibility —
-                Segmented's own `inline-grid` would beat a `hidden` on it). */}
-            <div className="hidden sm:block">
-              <Segmented
-                className="shadow-lg"
-                tabs={examples.map((ex, i) => ({
-                  value: String(i),
-                  label: ex.label ?? `Example ${i + 1}`,
-                }))}
-                value={String(Math.min(activeIndex, examples.length - 1))}
-                onChange={(v) => selectExample(Number(v))}
-              />
-            </div>
+            {/* Desktop: a segmented tab strip. Few variants → equal-width
+                <Segmented>. Many (e.g. combobox) would collide/overflow, so use
+                a horizontally-scrollable, content-width strip instead of a lone
+                dropdown. Wrappers control visibility — Segmented's own
+                `inline-grid` would beat a `hidden` on the control itself. */}
+            {examples.length > 5 ? (
+              <div className="hidden max-w-full sm:block">
+                <ScrollableSegmented
+                  tabs={examples.map((ex, i) => ({
+                    value: String(i),
+                    label: ex.label ?? `Example ${i + 1}`,
+                  }))}
+                  value={String(Math.min(activeIndex, examples.length - 1))}
+                  onChange={(v) => selectExample(Number(v))}
+                />
+              </div>
+            ) : (
+              <div className="hidden sm:block">
+                <Segmented
+                  className="shadow-lg"
+                  tabs={examples.map((ex, i) => ({
+                    value: String(i),
+                    label: ex.label ?? `Example ${i + 1}`,
+                  }))}
+                  value={String(Math.min(activeIndex, examples.length - 1))}
+                  onChange={(v) => selectExample(Number(v))}
+                />
+              </div>
+            )}
           </div>
         ) : null}
 

--- a/apps/docs/src/components/workbench/workbench-client.tsx
+++ b/apps/docs/src/components/workbench/workbench-client.tsx
@@ -73,8 +73,13 @@ function WorkbenchInner({
   const [replayKey, setReplayKey] = useState(0);
   const [view, setView] = useState<StageView>("desktop");
   const [fullscreen, setFullscreen] = useState(false);
-  const [drawerOpen, setDrawerOpen] = useState(false);
-  const [drawerTab, setDrawerTab] = useState<DrawerTab>("docs");
+  // Deep-link routes (`…/learn`) carry initialDrawerTab — open the drawer to it
+  // from the start via lazy initial state (rather than a mount effect that sets
+  // state, which cascades an extra render).
+  const [drawerOpen, setDrawerOpen] = useState(() => Boolean(initialDrawerTab));
+  const [drawerTab, setDrawerTab] = useState<DrawerTab>(
+    () => initialDrawerTab ?? "docs",
+  );
 
   // The `…/learn` route sets initialDrawerTab; used to shape the AEO mirror
   // (learn body on the learn URL, docs + code on the component URL).
@@ -134,13 +139,12 @@ function WorkbenchInner({
     return () => window.removeEventListener("popstate", onPop);
   }, [drawerOpen]);
 
-  // Deep-link support: on the `…/learn` route (initialDrawerTab set) open the
-  // drawer to that tab on mount and scroll to the URL hash section within it —
-  // so refreshing `…/learn#motion-score` reopens the drawer at that section.
+  // Deep-link support: on the `…/learn` route (initialDrawerTab set) the drawer
+  // starts open on that tab (lazy initial state above); this effect just scrolls
+  // to the URL hash section within it — so refreshing `…/learn#motion-score`
+  // lands on that section.
   useEffect(() => {
     if (!initialDrawerTab) return;
-    setDrawerTab(initialDrawerTab);
-    setDrawerOpen(true);
     const id = window.location.hash.slice(1);
     if (!id) return;
     // Wait for the open spring + drawer content to lay out before scrolling.

--- a/apps/docs/src/components/workbench/workbench-context.tsx
+++ b/apps/docs/src/components/workbench/workbench-context.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { createContext, type ReactNode, useContext } from "react";
+import type { Crumb } from "@/app/docs/_components/breadcrumbs";
+
+export type BadgeTone = "sky" | "amber" | "emerald" | "violet";
+/** One compact meta item shown in the title chip (dot + label + hover tooltip). */
+export type BadgeItem = {
+  tone: BadgeTone;
+  label: string;
+  /** Short tooltip heading. */
+  title?: string;
+  /** Longer tooltip body. */
+  detail?: string;
+  /** Optional "learn more" link in the tooltip. */
+  href?: string;
+  hrefLabel?: string;
+};
+
+/**
+ * Page-level metadata the MDX body doesn't own. Set by the docs page and read by
+ * <Workbench> to render the title chip, breadcrumb and dock links.
+ */
+export type WorkbenchMeta = {
+  title: string;
+  description?: string;
+  /** Compact meta items (dot + label) rendered under the title. */
+  badges?: BadgeItem[];
+  /** Route to the component's Learn article, when one exists. */
+  learnHref?: string;
+  /** Base docs route (used to restore the URL when the Learn drawer closes). */
+  docsHref?: string;
+  /** Pre-rendered Learn article body, shown in the Learn drawer tab. */
+  learn?: ReactNode;
+  /**
+   * When set, the drawer opens to this tab on mount (used by the `…/learn`
+   * route so a refresh/deep-link opens the Learn drawer + scrolls to the hash).
+   */
+  initialDrawerTab?: "docs" | "code" | "learn";
+  breadcrumbs: Crumb[];
+};
+
+const WorkbenchMetaContext = createContext<WorkbenchMeta | null>(null);
+
+export function WorkbenchProvider({
+  value,
+  children,
+}: {
+  value: WorkbenchMeta;
+  children: ReactNode;
+}) {
+  return (
+    <WorkbenchMetaContext.Provider value={value}>
+      {children}
+    </WorkbenchMetaContext.Provider>
+  );
+}
+
+export function useWorkbenchMeta(): WorkbenchMeta {
+  const ctx = useContext(WorkbenchMetaContext);
+  if (!ctx) {
+    throw new Error(
+      "useWorkbenchMeta must be used within <WorkbenchProvider>.",
+    );
+  }
+  return ctx;
+}

--- a/apps/docs/src/components/workbench/workbench.tsx
+++ b/apps/docs/src/components/workbench/workbench.tsx
@@ -1,0 +1,28 @@
+import { Children, isValidElement, type ReactNode } from "react";
+import { Example, type ExampleProps } from "@/components/workbench/example";
+import { WorkbenchClient } from "@/components/workbench/workbench-client";
+
+/**
+ * Server-side entry for the full-bleed component workbench. It partitions its
+ * MDX children — <Example> elements become stage tabs, everything else becomes
+ * the Docs drawer body — then hands the split to the interactive client shell.
+ *
+ * The partition MUST happen here (a server component): MDX creates <Example>
+ * from the same client reference this module imports, so `child.type === Example`
+ * matches. Across the server → client boundary that identity is lost, so doing
+ * it inside the client shell would find zero examples.
+ */
+export function Workbench({ children }: { children: ReactNode }) {
+  const examples: ExampleProps[] = [];
+  const docs: ReactNode[] = [];
+
+  for (const child of Children.toArray(children)) {
+    if (isValidElement(child) && child.type === Example) {
+      examples.push(child.props as ExampleProps);
+    } else {
+      docs.push(child);
+    }
+  }
+
+  return <WorkbenchClient examples={examples} docs={docs} />;
+}

--- a/apps/docs/src/lib/use-side-panel-fit.ts
+++ b/apps/docs/src/lib/use-side-panel-fit.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/** Centered docs layout cap (90rem) — must match `#nd-docs-layout` max-width. */
+const LAYOUT_MAX = 1440;
+/** Docs rail width — must match `--wb-panel-w` (min(440px, 34vw)) in globals.css. */
+function panelWidth(vw: number) {
+  return Math.min(440, vw * 0.34);
+}
+
+/**
+ * `true` when the viewport has enough free horizontal slack (outside the centered
+ * 90rem content) to absorb the docs rail — i.e. the whole app can slide left by
+ * the rail width without clipping or resizing. Otherwise the docs open as a
+ * bottom sheet. Recomputed on resize. SSR-safe default `true` (desktop-first) so
+ * the rail's docs render into the DOM for aeo.js before hydration corrects.
+ */
+export function useSidePanelFit() {
+  const [fits, setFits] = useState(true);
+
+  useEffect(() => {
+    const compute = () => {
+      const vw = window.innerWidth;
+      setFits(vw - Math.min(vw, LAYOUT_MAX) >= panelWidth(vw));
+    };
+    compute();
+    window.addEventListener("resize", compute);
+    return () => window.removeEventListener("resize", compute);
+  }, []);
+
+  return fits;
+}

--- a/packages/components/src/container-scroll/container-scroll.tsx
+++ b/packages/components/src/container-scroll/container-scroll.tsx
@@ -14,13 +14,18 @@ export type ContainerScrollProps = React.HTMLAttributes<HTMLDivElement> & {
   header?: React.ReactNode;
   /** The "screen" content — an image, video, or live UI. */
   children: React.ReactNode;
+  /**
+   * Scrollport whose progress drives the animation. Defaults to the viewport;
+   * pass a ref when embedding inside an `overflow` frame (e.g. a docs preview).
+   */
+  scrollContainer?: React.RefObject<HTMLElement | null>;
 };
 
 // SPRING.smooth — surfaces / shared-layout feel.
 const SPRING = { stiffness: 320, damping: 32, mass: 0.9 } as const;
 
 const ContainerScroll = React.forwardRef<HTMLDivElement, ContainerScrollProps>(
-  ({ header, children, className, ...props }, ref) => {
+  ({ header, children, className, scrollContainer, ...props }, ref) => {
     const reduce = useReducedMotion();
     const containerRef = React.useRef<HTMLDivElement>(null);
     React.useImperativeHandle(
@@ -28,7 +33,10 @@ const ContainerScroll = React.forwardRef<HTMLDivElement, ContainerScrollProps>(
       () => containerRef.current as HTMLDivElement,
     );
 
-    const { scrollYProgress } = useScroll({ target: containerRef });
+    const { scrollYProgress } = useScroll({
+      target: containerRef,
+      container: scrollContainer,
+    });
 
     const rotateX = useSpring(
       useTransform(scrollYProgress, [0, 1], [20, 0]),


### PR DESCRIPTION
## Description

Redesigns every component docs page into a full-bleed **Workbench**: the live component owns the whole content area, variant examples become stage tabs, and all supporting chrome collapses into a floating top-right icon rail (replay · viewport · docs · code · learn · playground) plus a docs surface. On wide screens the docs open as a full-height right rail that slides the whole app left (no resize); when there isn't enough horizontal slack it falls back to a bottom sheet. The goal is to make the component itself the focus instead of a small box competing with prose.

## Type of change

- [x] 🎨 Style / design polish
- [x] 🚀 Feature (non-breaking change adding functionality)
- [x] 📝 Docs

## Changes made

- New `workbench/` components: `Workbench` (server-side RSC child partition), `WorkbenchClient`, `StagePanel` (desktop right rail), `StageDrawer` (mobile bottom sheet), shared `PanelBody`, `Stage`, `TitleChip`, `Example`, context; extracted shared `PreviewFrame`; added `useSidePanelFit`.
- Wired a `workbench: true` branch in `page.tsx` + frontmatter flag (`source.config.ts`) and registered `Workbench`/`Example` MDX primitives.
- Migrated **all ~108 component pages** (buttons + every category) to the `<Workbench>` / `<Example>` shape.
- App-shift CSS: per-element `transform` on `#nd-nav`/`#nd-sidebar`/`#nd-page` (not the grid ancestor, which would re-anchor the fixed header), gated by `data-wb-panel`.
- AEO mirror inside `<article>` so the aeo.js AI view shows full docs + code on component URLs and full learn on learn URLs, regardless of drawer state; deep-link scroll scoped to the visible surface.
- Line-numbered code box, icon tabs, top gradient scrim for legibility over image demos, taller mobile drawer.
- Motion Principles/Patterns: drop the right TOC (`full`) + 3-up grid on desktop.
- Header: X (Twitter) link between GitHub and the theme toggle.

## Related issues

_None._

## How to test

1. `pnpm --filter docs dev`, open `/docs/components/buttons/jelly-button`.
2. Confirm the stage fills the area, example tabs swap the demo, and the top-right rail opens Docs/Code/Learn (right rail on wide screens sliding the app left; bottom sheet on narrow) while Playground opens Storybook.
3. Check `/docs/components/glass/liquid-glass-lens` (scrim legibility over imagery) and `/docs/guidelines/principles` (no TOC, 3 cards per row).

## Screenshots / recordings

_Workbench stage, right-rail docs push, code box, and header X link — captured during review in the Conductor workspace._

## Checklist

- [x] `pnpm check` passes (Biome lint + format)
- [x] `pnpm lint` passes (type-check)
- [x] Commits follow Conventional Commits
- [x] Self-reviewed the diff; no stray logs, dead code, or commented-out blocks
