### PR TITLE
fix(docs): mobile workbench header + preview polish; scroll container prop

### DIFF
--- a/apps/docs/content/docs/components/visualizations/orbiting-circles/index.mdx
+++ b/apps/docs/content/docs/components/visualizations/orbiting-circles/index.mdx
@@ -69,28 +69,37 @@ ecosystem diagram.
 <Example
   label="Reversed Inner Ring"
   fullWidth
-  code={`<div className="relative flex h-80 w-full items-center justify-center">
-  <OrbitingCircles className="absolute" radius={60} duration={14}>
-    <Chip>1</Chip>
-    <Chip>2</Chip>
-  </OrbitingCircles>
-  <OrbitingCircles className="absolute" radius={120} duration={24} reverse>
-    <Chip>3</Chip>
-    <Chip>4</Chip>
-    <Chip>5</Chip>
-  </OrbitingCircles>
+  code={`<div className="relative flex h-full min-h-80 w-full items-center justify-center">
+  {/* Each ring in an absolutely-centered wrapper so they share one center. */}
+  <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
+    <OrbitingCircles radius={60} duration={14}>
+      <Chip>1</Chip>
+      <Chip>2</Chip>
+    </OrbitingCircles>
+  </div>
+  <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
+    <OrbitingCircles radius={120} duration={24} reverse>
+      <Chip>3</Chip>
+      <Chip>4</Chip>
+      <Chip>5</Chip>
+    </OrbitingCircles>
+  </div>
 </div>`}
 >
-  <div className="relative flex h-80 w-full items-center justify-center">
-    <OrbitingCircles className="absolute" radius={60} duration={14}>
-      <span className="flex size-full items-center justify-center rounded-full border border-border bg-card text-sm font-semibold text-foreground">1</span>
-      <span className="flex size-full items-center justify-center rounded-full border border-border bg-card text-sm font-semibold text-foreground">2</span>
-    </OrbitingCircles>
-    <OrbitingCircles className="absolute" radius={120} duration={24} reverse>
-      <span className="flex size-full items-center justify-center rounded-full border border-border bg-card text-sm font-semibold text-foreground">3</span>
-      <span className="flex size-full items-center justify-center rounded-full border border-border bg-card text-sm font-semibold text-foreground">4</span>
-      <span className="flex size-full items-center justify-center rounded-full border border-border bg-card text-sm font-semibold text-foreground">5</span>
-    </OrbitingCircles>
+  <div className="relative flex h-full min-h-80 w-full items-center justify-center">
+    <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
+      <OrbitingCircles radius={60} duration={14}>
+        <span className="flex size-full items-center justify-center rounded-full border border-border bg-card text-sm font-semibold text-foreground">1</span>
+        <span className="flex size-full items-center justify-center rounded-full border border-border bg-card text-sm font-semibold text-foreground">2</span>
+      </OrbitingCircles>
+    </div>
+    <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
+      <OrbitingCircles radius={120} duration={24} reverse>
+        <span className="flex size-full items-center justify-center rounded-full border border-border bg-card text-sm font-semibold text-foreground">3</span>
+        <span className="flex size-full items-center justify-center rounded-full border border-border bg-card text-sm font-semibold text-foreground">4</span>
+        <span className="flex size-full items-center justify-center rounded-full border border-border bg-card text-sm font-semibold text-foreground">5</span>
+      </OrbitingCircles>
+    </div>
   </div>
 </Example>
 

--- a/apps/docs/src/app/docs/_components/docs-header.tsx
+++ b/apps/docs/src/app/docs/_components/docs-header.tsx
@@ -6,7 +6,7 @@ import {
   FullSearchTrigger,
   SearchTrigger,
 } from "fumadocs-ui/layouts/shared/slots/search-trigger";
-import { ArrowUpRight, Menu } from "lucide-react";
+import { ArrowUpRight, Bot, Menu } from "lucide-react";
 import { type ComponentProps, useEffect, useState } from "react";
 import { cn } from "@/lib/cn";
 import { GitHubStars } from "./github-stars";
@@ -15,6 +15,27 @@ import { ThemeToggle } from "./theme-toggle";
 
 const iconButton =
   "inline-flex size-9 items-center justify-center rounded-full text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground";
+
+/**
+ * Opens the aeo.js AI-view overlay (LLM-optimized markdown of the current page)
+ * by clicking the hidden widget's AI button. The floating widget toggle itself
+ * is hidden via CSS (`.aeo-toggle`) so this header button is the only entry.
+ */
+function AeoTrigger({ className }: { className?: string }) {
+  return (
+    <button
+      type="button"
+      aria-label="View AI-optimized version"
+      title="View for AI / LLMs"
+      onClick={() => {
+        document.querySelector<HTMLButtonElement>(".aeo-ai-btn")?.click();
+      }}
+      className={cn(iconButton, className)}
+    >
+      <Bot className="size-4" />
+    </button>
+  );
+}
 
 export const ANIMATED_ICONS_URL = "https://svg-animated-icons.vercel.app/";
 
@@ -88,6 +109,10 @@ export function DocsHeader({
         </nav>
         <div className="flex-1" />
         <div className="flex items-center gap-1 sm:gap-2">
+          {/* Desktop: open the aeo.js "AI view" overlay (markdown for this page).
+              The floating widget toggle is hidden via CSS; this triggers its AI
+              button. Desktop-only — the overlay isn't useful on small screens. */}
+          <AeoTrigger className="max-md:hidden" />
           {/* Desktop: full search bar */}
           <FullSearchTrigger
             hideIfDisabled

--- a/apps/docs/src/app/globals.css
+++ b/apps/docs/src/app/globals.css
@@ -311,9 +311,23 @@ p.docs-lead {
   z-index: 1;
 }
 
-/* Workbench stage canvas — seamless with the page background (no contrast). */
+/* Workbench stage canvas — a hair off the page background so the card reads as
+   a distinct surface (lighter in dark, darker in light) without real contrast.
+   The color lives on a var (see .stage-frame) so the top scrim fades the same
+   surface. */
 .workbench-canvas {
-  background-color: var(--color-fd-background);
+  background-color: var(--workbench-canvas-bg);
+}
+
+/* Top scrim — fades the card surface (not the page bg) to transparent so the
+   title chip + control rail stay legible over full-bleed / image demos. */
+.stage-scrim {
+  background-image: linear-gradient(
+    to bottom,
+    color-mix(in oklch, var(--workbench-canvas-bg) 90%, transparent),
+    color-mix(in oklch, var(--workbench-canvas-bg) 60%, transparent),
+    transparent
+  );
 }
 
 /* Bounded stage frame — a clearly-visible hairline in both themes (the raw
@@ -321,6 +335,11 @@ p.docs-lead {
    contained panel rather than an open void. */
 .stage-frame {
   border-color: color-mix(in srgb, var(--color-fd-foreground) 12%, transparent);
+  --workbench-canvas-bg: color-mix(
+    in oklch,
+    var(--color-fd-background) 98%,
+    var(--color-fd-foreground)
+  );
 }
 
 .component-install-cli pre {
@@ -790,6 +809,13 @@ figure.shiki div:has(> button[aria-label]) {
   background: currentColor;
   -webkit-mask: var(--godui-close-icon) center / contain no-repeat;
   mask: var(--godui-close-icon) center / contain no-repeat;
+}
+
+/* aeo.js ships a fixed floating Human/AI toggle. We drive its overlay from a
+   custom header button instead (see DocsHeader → AeoTrigger), so hide the
+   default widget while keeping its DOM (the header button clicks .aeo-ai-btn). */
+.aeo-toggle {
+  display: none !important;
 }
 
 /* "Built with GodUI" TOC card — subtle primary-tinted gradient surface. */

--- a/apps/docs/src/components/demos/beam-draw-demo.tsx
+++ b/apps/docs/src/components/demos/beam-draw-demo.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { BeamDraw } from "@godui/components";
+import { useRef } from "react";
 
 // Right-hand nodes, positioned at the y-fractions where the default beams end
 // (40, 150, 250, 360 on the 400-tall viewBox).
@@ -21,41 +22,48 @@ function Chip({ children }: { children: React.ReactNode }) {
 }
 
 export function BeamDrawDemo() {
+  // The preview stage is an inner scroll area, so the beam tracks this container
+  // (not the window) to scrub as you scroll.
+  const scrollRef = useRef<HTMLDivElement>(null);
+
   return (
-    <div className="flex min-h-[140vh] flex-col items-center justify-center gap-12 py-32">
-      <div className="text-center">
-        <h3 className="text-2xl font-bold text-foreground md:text-3xl">
-          Your entire stack, connected
-        </h3>
-        <p className="mt-3 text-muted-foreground">
-          Scroll to light up the pipeline.
-        </p>
-      </div>
-
-      <div className="relative aspect-[5/2] w-full max-w-3xl rounded-2xl border border-border bg-card/60 shadow-xl">
-        <BeamDraw
-          preserveAspectRatio="none"
-          className="absolute inset-0 size-full"
-        />
-
-        {/* Core node — the left endpoint the beams fan out from. */}
-        <div className="absolute left-0 top-1/2 flex -translate-y-1/2 items-center gap-2 rounded-xl border border-border bg-background px-4 py-3 shadow-lg">
-          <span className="size-2.5 rounded-full bg-primary shadow-[0_0_10px_var(--primary)]" />
-          <span className="text-sm font-semibold text-foreground">
-            API Core
-          </span>
+    <div ref={scrollRef} className="h-full w-full overflow-y-auto">
+      <div className="flex min-h-[260vh] flex-col items-center justify-center gap-12 py-[60vh]">
+        <div className="text-center">
+          <h3 className="text-2xl font-bold text-foreground md:text-3xl">
+            Your entire stack, connected
+          </h3>
+          <p className="mt-3 text-muted-foreground">
+            Scroll to light up the pipeline.
+          </p>
         </div>
 
-        {/* Destination nodes at each beam's right endpoint. */}
-        {NODES.map((node) => (
-          <div
-            key={node.label}
-            className="absolute right-0 -translate-y-1/2"
-            style={{ top: node.top }}
-          >
-            <Chip>{node.label}</Chip>
+        <div className="relative aspect-[5/2] w-full max-w-3xl rounded-2xl border border-border bg-card/60 shadow-xl">
+          <BeamDraw
+            container={scrollRef}
+            preserveAspectRatio="none"
+            className="absolute inset-0 size-full"
+          />
+
+          {/* Core node — the left endpoint the beams fan out from. */}
+          <div className="absolute left-0 top-1/2 flex -translate-y-1/2 items-center gap-2 rounded-xl border border-border bg-background px-4 py-3 shadow-lg">
+            <span className="size-2.5 rounded-full bg-primary shadow-[0_0_10px_var(--primary)]" />
+            <span className="text-sm font-semibold text-foreground">
+              API Core
+            </span>
           </div>
-        ))}
+
+          {/* Destination nodes at each beam's right endpoint. */}
+          {NODES.map((node) => (
+            <div
+              key={node.label}
+              className="absolute right-0 -translate-y-1/2"
+              style={{ top: node.top }}
+            >
+              <Chip>{node.label}</Chip>
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/apps/docs/src/components/demos/comment-pin-demo.tsx
+++ b/apps/docs/src/components/demos/comment-pin-demo.tsx
@@ -62,25 +62,30 @@ export function CommentPinDemo() {
     );
 
   return (
-    <div className="relative mx-auto h-[400px] w-full overflow-hidden rounded-2xl border border-border bg-card">
-      <div className="absolute left-6 top-6 h-28 w-56 rounded-xl bg-muted" />
-      <div className="absolute right-10 top-12 h-20 w-40 rounded-xl bg-muted" />
-      <div className="absolute bottom-10 left-12 h-24 w-72 rounded-xl bg-muted" />
-      <p className="absolute bottom-4 right-4 text-xs text-muted-foreground">
-        Click a pin to open its thread.
-      </p>
-      {pins.map((pin) => (
-        <CommentPin
-          key={pin.id}
-          x={pin.x}
-          y={pin.y}
-          resolved={pin.resolved}
-          comments={pin.comments}
-          open={openId === pin.id}
-          onOpenChange={(o) => setOpenId(o ? pin.id : null)}
-          onReply={(body) => reply(pin.id, body)}
-        />
-      ))}
+    <div className="relative flex h-full w-full items-center justify-center overflow-hidden px-6">
+      {/* Centered play area — kept clear of the stage header chrome (title,
+          breadcrumb, badges top-left; controls top-right) by living in a
+          vertically-centered band; pins position by % of this region. */}
+      <div className="relative h-[64%] w-full max-w-2xl">
+        <div className="absolute left-0 top-2 h-28 w-56 rounded-xl bg-muted" />
+        <div className="absolute right-4 top-10 h-20 w-40 rounded-xl bg-muted" />
+        <div className="absolute bottom-6 left-8 h-24 w-72 rounded-xl bg-muted" />
+        <p className="absolute bottom-0 right-0 text-xs text-muted-foreground">
+          Click a pin to open its thread.
+        </p>
+        {pins.map((pin) => (
+          <CommentPin
+            key={pin.id}
+            x={pin.x}
+            y={pin.y}
+            resolved={pin.resolved}
+            comments={pin.comments}
+            open={openId === pin.id}
+            onOpenChange={(o) => setOpenId(o ? pin.id : null)}
+            onReply={(body) => reply(pin.id, body)}
+          />
+        ))}
+      </div>
     </div>
   );
 }

--- a/apps/docs/src/components/demos/context-menu-demo.tsx
+++ b/apps/docs/src/components/demos/context-menu-demo.tsx
@@ -68,10 +68,12 @@ export function ContextMenuDemo() {
   return (
     <ContextMenu items={items}>
       <div className="flex w-full max-w-md select-none flex-col items-center gap-4 rounded-xl border border-border border-dashed bg-card px-6 py-10 text-center shadow-sm">
-        <div className="flex h-14 w-14 items-center justify-center rounded-xl bg-primary/10 text-primary">
+        <div className="relative flex h-14 w-14 items-center justify-center rounded-xl bg-primary/10 text-primary">
           <FileText className="size-7" />
           {starred && (
-            <Star className="-mt-6 ml-9 size-4 fill-amber-400 text-amber-400" />
+            <span className="absolute -right-1.5 -top-1.5 grid size-5 place-items-center rounded-full bg-background shadow-sm ring-1 ring-border">
+              <Star className="size-3 fill-amber-400 text-amber-400" />
+            </span>
           )}
         </div>
         <div>

--- a/apps/docs/src/components/demos/dock-demo.tsx
+++ b/apps/docs/src/components/demos/dock-demo.tsx
@@ -29,7 +29,7 @@ const items: Item[] = [
 
 export function DockDemo() {
   return (
-    <div className="relative h-[380px] w-full overflow-hidden rounded-xl border border-border">
+    <div className="relative h-full min-h-[380px] w-full overflow-hidden rounded-xl border border-border">
       {/* Wallpaper */}
       <div className="absolute inset-0 bg-[linear-gradient(135deg,oklch(0.55_0.18_265),oklch(0.62_0.16_320)_45%,oklch(0.7_0.12_25))]" />
       <div className="absolute inset-0 bg-[radial-gradient(60%_50%_at_50%_0%,rgba(255,255,255,0.25),transparent)]" />

--- a/apps/docs/src/components/demos/globe-demo.tsx
+++ b/apps/docs/src/components/demos/globe-demo.tsx
@@ -38,7 +38,7 @@ const STATS = [
 
 export function GlobeDemo() {
   return (
-    <div className="relative w-full overflow-hidden rounded-none border-0 bg-[#04060f] [background:radial-gradient(120%_120%_at_50%_-20%,#13204a_0%,#04060f_55%)]">
+    <div className="relative flex h-full w-full flex-col overflow-hidden rounded-none border-0 bg-[#04060f] [background:radial-gradient(120%_120%_at_50%_-20%,#13204a_0%,#04060f_55%)]">
       {/* Faint grid that fades toward the globe. */}
       <div className="pointer-events-none absolute inset-0 [background-image:linear-gradient(to_right,rgba(255,255,255,0.04)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.04)_1px,transparent_1px)] [background-size:44px_44px] [mask-image:radial-gradient(100%_55%_at_50%_0%,black,transparent)]" />
 
@@ -83,8 +83,9 @@ export function GlobeDemo() {
         </div>
       </div>
 
-      {/* Globe sits at the bottom, glowing and masked into the band. */}
-      <div className="relative mx-auto -mt-4 h-[330px] w-full max-w-[560px] [mask-image:linear-gradient(to_bottom,black_62%,transparent)]">
+      {/* Globe fills the rest of the card, anchored to the bottom, glowing and
+          masked into the band. */}
+      <div className="relative mx-auto mt-auto w-full max-w-[620px] [mask-image:linear-gradient(to_bottom,black_62%,transparent)]">
         <div className="absolute left-1/2 top-12 size-[400px] -translate-x-1/2 rounded-full bg-[#2b50b8]/25 blur-3xl" />
         <Globe config={GLOBE_CONFIG} className="!max-w-none" />
       </div>

--- a/apps/docs/src/components/demos/image-trail-demo.tsx
+++ b/apps/docs/src/components/demos/image-trail-demo.tsx
@@ -16,7 +16,7 @@ export function ImageTrailDemo() {
     <ImageTrail
       images={IMAGES}
       size={150}
-      className="grid h-[26rem] w-full place-items-center"
+      className="grid h-full min-h-[26rem] w-full place-items-center"
     >
       <div className="pointer-events-none text-center">
         <h2 className="text-2xl font-semibold text-foreground">

--- a/apps/docs/src/components/demos/live-cursors-demo.tsx
+++ b/apps/docs/src/components/demos/live-cursors-demo.tsx
@@ -4,20 +4,25 @@ import { SimulatedCursors } from "@godui/components";
 
 export function LiveCursorsDemo() {
   return (
-    <div className="relative mx-auto h-[400px] w-full overflow-hidden rounded-2xl border border-border bg-[radial-gradient(oklch(0.7_0_0/0.12)_1px,transparent_1px)] [background-size:18px_18px]">
-      {/* A mock collaborative canvas */}
-      <div className="pointer-events-none absolute inset-0 p-6">
-        <div className="flex flex-wrap gap-4">
-          <div className="h-28 w-44 rounded-xl border border-border bg-card shadow-sm" />
-          <div className="h-28 w-60 rounded-xl border border-border bg-card shadow-sm" />
-          <div className="h-36 w-40 rounded-xl border border-border bg-card shadow-sm" />
-          <div className="h-24 w-52 rounded-xl border border-border bg-card shadow-sm" />
+    <div className="relative flex h-full w-full items-center justify-center overflow-hidden bg-[radial-gradient(oklch(0.7_0_0/0.12)_1px,transparent_1px)] px-6 [background-size:18px_18px]">
+      {/* Centered play area — kept clear of the stage header chrome (title,
+          breadcrumb, badges top-left; controls top-right) by living in a
+          vertically-centered band, and the cursors roam only inside it. */}
+      <div className="relative h-[64%] w-full max-w-2xl">
+        {/* A mock collaborative canvas */}
+        <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
+          <div className="flex flex-wrap justify-center gap-4">
+            <div className="h-28 w-44 rounded-xl border border-border bg-card shadow-sm" />
+            <div className="h-28 w-60 rounded-xl border border-border bg-card shadow-sm" />
+            <div className="h-36 w-40 rounded-xl border border-border bg-card shadow-sm" />
+            <div className="h-24 w-52 rounded-xl border border-border bg-card shadow-sm" />
+          </div>
+          <p className="mt-6 text-sm text-muted-foreground">
+            Four teammates are exploring this canvas in real time.
+          </p>
         </div>
-        <p className="mt-6 text-sm text-muted-foreground">
-          Four teammates are exploring this canvas in real time.
-        </p>
+        <SimulatedCursors names={["Ana", "Marco", "Priya", "Jules"]} />
       </div>
-      <SimulatedCursors names={["Ana", "Marco", "Priya", "Jules"]} />
     </div>
   );
 }

--- a/apps/docs/src/components/demos/morph-gallery-demo.tsx
+++ b/apps/docs/src/components/demos/morph-gallery-demo.tsx
@@ -17,6 +17,7 @@ const PHOTOS = [
 export function MorphGalleryDemo() {
   return (
     <MorphGallery
+      className="mx-auto max-w-lg"
       columns={3}
       items={PHOTOS.map((p) => ({
         src: `https://picsum.photos/id/${p.id}/900/900`,

--- a/apps/docs/src/components/demos/orbiting-circles-demo.tsx
+++ b/apps/docs/src/components/demos/orbiting-circles-demo.tsx
@@ -13,48 +13,43 @@ function Chip({ children }: { children: React.ReactNode }) {
 
 export function OrbitingCirclesDemo() {
   return (
-    <div className="relative flex h-[360px] w-full items-center justify-center">
+    <div className="relative my-auto flex h-[360px] w-full items-center justify-center">
       <span className="pointer-events-none z-raised rounded-xl bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-md">
         GodUI
       </span>
 
-      <OrbitingCircles
-        className="absolute"
-        radius={70}
-        duration={18}
-        iconSize={36}
-      >
-        <Chip>
-          <Box className="size-4" />
-        </Chip>
-        <Chip>
-          <Cloud className="size-4" />
-        </Chip>
-        <Chip>
-          <Cpu className="size-4" />
-        </Chip>
-      </OrbitingCircles>
+      {/* Both rings share one center: each sits in an absolutely-centered
+          wrapper so the different-sized boxes stay concentric. */}
+      <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
+        <OrbitingCircles radius={70} duration={18} iconSize={36}>
+          <Chip>
+            <Box className="size-4" />
+          </Chip>
+          <Chip>
+            <Cloud className="size-4" />
+          </Chip>
+          <Chip>
+            <Cpu className="size-4" />
+          </Chip>
+        </OrbitingCircles>
+      </div>
 
-      <OrbitingCircles
-        className="absolute"
-        radius={130}
-        duration={28}
-        iconSize={40}
-        reverse
-      >
-        <Chip>
-          <Hexagon className="size-5" />
-        </Chip>
-        <Chip>
-          <Layers className="size-5" />
-        </Chip>
-        <Chip>
-          <Zap className="size-5" />
-        </Chip>
-        <Chip>
-          <Box className="size-5" />
-        </Chip>
-      </OrbitingCircles>
+      <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
+        <OrbitingCircles radius={130} duration={28} iconSize={40} reverse>
+          <Chip>
+            <Hexagon className="size-5" />
+          </Chip>
+          <Chip>
+            <Layers className="size-5" />
+          </Chip>
+          <Chip>
+            <Zap className="size-5" />
+          </Chip>
+          <Chip>
+            <Box className="size-5" />
+          </Chip>
+        </OrbitingCircles>
+      </div>
     </div>
   );
 }

--- a/apps/docs/src/components/demos/scroll-text-reveal-demo.tsx
+++ b/apps/docs/src/components/demos/scroll-text-reveal-demo.tsx
@@ -1,33 +1,47 @@
 "use client";
 
 import { ScrollTextReveal } from "@godui/components";
+import { useRef } from "react";
 
 export function ScrollTextRevealDemo() {
+  // The preview stage is an inner scroll area, so the reveal tracks this
+  // container (not the window). Vertical runway lets each word scrub into focus.
+  const scrollRef = useRef<HTMLDivElement>(null);
+
   return (
-    <div className="mx-auto max-w-lg px-6 py-10">
-      <ScrollTextReveal
-        as="p"
-        className="text-balance text-center text-2xl font-semibold leading-relaxed text-foreground sm:text-3xl"
-      >
-        Great interfaces read like a sentence — one idea resolving into the
-        next. As you scroll, each word settles into focus, pacing attention
-        exactly where it belongs.
-      </ScrollTextReveal>
+    <div ref={scrollRef} className="h-[26rem] w-full overflow-y-auto">
+      <div className="mx-auto max-w-lg px-6 py-[55vh]">
+        <ScrollTextReveal
+          container={scrollRef}
+          as="p"
+          className="text-balance text-center text-2xl font-semibold leading-relaxed text-foreground sm:text-3xl"
+        >
+          Great interfaces read like a sentence — one idea resolving into the
+          next. As you scroll, each word settles into focus, pacing attention
+          exactly where it belongs.
+        </ScrollTextReveal>
+      </div>
     </div>
   );
 }
 
 export function ScrollTextRevealKeepDemo() {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
   return (
-    <div className="mx-auto max-w-lg px-6 py-10">
-      <ScrollTextReveal
-        as="p"
-        keepRevealed
-        className="text-balance text-center text-2xl font-semibold leading-relaxed text-foreground sm:text-3xl"
-      >
-        With keepRevealed, each word latches at full presence once it lands — so
-        the paragraph stays lit as you scroll back up instead of dimming again.
-      </ScrollTextReveal>
+    <div ref={scrollRef} className="h-[26rem] w-full overflow-y-auto">
+      <div className="mx-auto max-w-lg px-6 py-[55vh]">
+        <ScrollTextReveal
+          container={scrollRef}
+          as="p"
+          keepRevealed
+          className="text-balance text-center text-2xl font-semibold leading-relaxed text-foreground sm:text-3xl"
+        >
+          With keepRevealed, each word latches at full presence once it lands —
+          so the paragraph stays lit as you scroll back up instead of dimming
+          again.
+        </ScrollTextReveal>
+      </div>
     </div>
   );
 }

--- a/apps/docs/src/components/demos/scroll-timeline-demo.tsx
+++ b/apps/docs/src/components/demos/scroll-timeline-demo.tsx
@@ -1,52 +1,68 @@
 "use client";
 
 import { ScrollTimeline } from "@godui/components";
+import { useRef } from "react";
 
 export function ScrollTimelineDemo() {
+  // The preview stage is an inner scroll area, so the timeline tracks this
+  // container (not the window). Extra vertical runway gives the sticky rail real
+  // scroll distance to trace.
+  const scrollRef = useRef<HTMLDivElement>(null);
+
   return (
-    <ScrollTimeline
-      data={[
-        {
-          date: "2021",
-          title: "The first commit",
-          content: (
-            <p className="text-sm text-muted-foreground md:text-base">
-              A single component and a big idea — a design system that feels
-              alive, not templated.
-            </p>
-          ),
-        },
-        {
-          date: "2023",
-          title: "Ten thousand stars",
-          content: (
-            <p className="text-sm text-muted-foreground md:text-base">
-              The community took over. Contributions poured in and the library
-              tripled in a single quarter.
-            </p>
-          ),
-        },
-        {
-          date: "2025",
-          title: "One hundred components",
-          content: (
-            <p className="text-sm text-muted-foreground md:text-base">
-              From buttons to WebGL globes, every surface got the same obsessive
-              motion polish.
-            </p>
-          ),
-        },
-        {
-          date: "Today",
-          title: "Just getting started",
-          content: (
-            <p className="text-sm text-muted-foreground md:text-base">
-              Scroll back up and watch the line trace your journey. The next
-              chapter is yours to write.
-            </p>
-          ),
-        },
-      ]}
-    />
+    <div className="flex h-full w-full items-center justify-center p-4 sm:p-8">
+      <div
+        ref={scrollRef}
+        className="h-full max-h-[34rem] w-full max-w-3xl overflow-y-auto rounded-2xl border border-border bg-card/40 px-4 [scrollbar-width:thin] sm:px-8"
+      >
+        <div className="py-[22vh]">
+          <ScrollTimeline
+            container={scrollRef}
+            data={[
+              {
+                date: "2021",
+                title: "The first commit",
+                content: (
+                  <p className="text-sm text-muted-foreground md:text-base">
+                    A single component and a big idea — a design system that
+                    feels alive, not templated.
+                  </p>
+                ),
+              },
+              {
+                date: "2023",
+                title: "Ten thousand stars",
+                content: (
+                  <p className="text-sm text-muted-foreground md:text-base">
+                    The community took over. Contributions poured in and the
+                    library tripled in a single quarter.
+                  </p>
+                ),
+              },
+              {
+                date: "2025",
+                title: "One hundred components",
+                content: (
+                  <p className="text-sm text-muted-foreground md:text-base">
+                    From buttons to WebGL globes, every surface got the same
+                    obsessive motion polish.
+                  </p>
+                ),
+              },
+              {
+                date: "Today",
+                title: "Just getting started",
+                content: (
+                  <p className="text-sm text-muted-foreground md:text-base">
+                    Scroll back up and watch the line trace your journey. The
+                    next chapter is yours to write.
+                  </p>
+                ),
+              },
+            ]}
+          />
+        </div>
+      </div>
+    </div>
   );
 }

--- a/apps/docs/src/components/demos/sticky-scroll-demo.tsx
+++ b/apps/docs/src/components/demos/sticky-scroll-demo.tsx
@@ -34,5 +34,5 @@ const ITEMS: StickyScrollItem[] = [
 ];
 
 export function StickyScrollDemo() {
-  return <StickyScroll items={ITEMS} />;
+  return <StickyScroll items={ITEMS} className="my-auto" />;
 }

--- a/apps/docs/src/components/demos/three-d-marquee-demo.tsx
+++ b/apps/docs/src/components/demos/three-d-marquee-demo.tsx
@@ -23,7 +23,7 @@ const IMAGES = [
 
 export function ThreeDMarqueeDemo() {
   return (
-    <div className="mx-auto h-[26rem] w-full max-w-2xl">
+    <div className="mx-auto my-auto h-[26rem] w-full max-w-2xl">
       <ThreeDMarquee images={IMAGES} />
     </div>
   );

--- a/apps/docs/src/components/demos/world-map-demo.tsx
+++ b/apps/docs/src/components/demos/world-map-demo.tsx
@@ -4,7 +4,7 @@ import { WorldMap } from "@godui/components";
 
 export function WorldMapDemo() {
   return (
-    <div className="w-full px-4 py-10">
+    <div className="w-full px-4 pt-[12vh] pb-10">
       <div className="mx-auto max-w-3xl text-center">
         <h2 className="text-2xl font-semibold tracking-tight text-foreground md:text-3xl">
           Ship to every region

--- a/apps/docs/src/components/workbench/title-chip.tsx
+++ b/apps/docs/src/components/workbench/title-chip.tsx
@@ -24,7 +24,7 @@ export function TitleChip() {
   const { title, badges, breadcrumbs } = useWorkbenchMeta();
 
   return (
-    <div className="pointer-events-none flex max-w-[60vw] flex-col gap-1.5 sm:max-w-md">
+    <div className="pointer-events-none flex max-w-[42vw] flex-col gap-1.5 sm:max-w-md">
       {/* Breadcrumb is desktop-only — on mobile just the component title shows. */}
       <div className="pointer-events-auto hidden sm:block">
         <Breadcrumbs crumbs={breadcrumbs} />

--- a/apps/docs/src/components/workbench/workbench-client.tsx
+++ b/apps/docs/src/components/workbench/workbench-client.tsx
@@ -221,7 +221,7 @@ function WorkbenchInner({
             it restores contrast. Below the chrome (z-20), above the demo. */}
         <div
           aria-hidden
-          className="pointer-events-none absolute inset-x-0 top-0 z-10 h-40 bg-gradient-to-b from-fd-background/90 via-fd-background/60 to-transparent"
+          className="stage-scrim pointer-events-none absolute inset-x-0 top-0 z-10 h-40"
         />
 
         {/* Identity chip — top-left */}
@@ -234,7 +234,9 @@ function WorkbenchInner({
           icon-only bordered chips. Wraps on very narrow desktops. */}
         <div className="absolute top-4 right-4 z-20 flex flex-wrap items-center justify-end gap-1.5">
           {/* Static showcases (embedded background) have nothing to replay. */}
-          {copyValue === null ? <ReplayButton onReplay={replay} /> : null}
+          {copyValue === null ? (
+            <ReplayButton onReplay={replay} className="max-md:hidden" />
+          ) : null}
           <Segmented
             className="max-md:hidden"
             iconOnly
@@ -299,7 +301,7 @@ function WorkbenchInner({
               rel="noreferrer"
               aria-label="Playground"
               title="Playground"
-              className="inline-flex size-8 items-center justify-center rounded-[10px] border border-fd-border bg-fd-card text-fd-muted-foreground transition-colors hover:text-fd-foreground active:scale-95"
+              className="inline-flex size-8 items-center justify-center rounded-[10px] border border-fd-border bg-fd-card text-fd-muted-foreground transition-colors hover:text-fd-foreground active:scale-95 max-md:hidden"
             >
               <PlaygroundIcon />
             </a>
@@ -309,6 +311,7 @@ function WorkbenchInner({
             label={fullscreen ? "Exit fullscreen" : "Fullscreen"}
             active={fullscreen}
             onClick={() => setFullscreen((f) => !f)}
+            className="max-md:hidden"
           >
             {fullscreen ? (
               <Minimize2 className="size-4" aria-hidden />
@@ -396,7 +399,9 @@ function WorkbenchInner({
 }
 
 function RailDivider() {
-  return <span aria-hidden className="mx-0.5 h-5 w-px bg-fd-border" />;
+  return (
+    <span aria-hidden className="mx-0.5 h-5 w-px bg-fd-border max-md:hidden" />
+  );
 }
 
 /**
@@ -494,12 +499,14 @@ function ToolButton({
   disabled,
   onClick,
   children,
+  className,
 }: {
   label: string;
   active?: boolean;
   disabled?: boolean;
   onClick?: () => void;
   children: ReactNode;
+  className?: string;
 }) {
   return (
     <button
@@ -511,6 +518,7 @@ function ToolButton({
       onClick={onClick}
       className={cn(
         "inline-flex size-8 items-center justify-center rounded-[10px] border transition-colors active:scale-95 disabled:pointer-events-none disabled:opacity-40",
+        className,
         active
           ? "border-fd-primary/45 bg-fd-primary/10 text-fd-primary"
           : "border-fd-border bg-fd-card text-fd-muted-foreground hover:text-fd-foreground",

--- a/packages/components/src/beam-draw/beam-draw.tsx
+++ b/packages/components/src/beam-draw/beam-draw.tsx
@@ -14,6 +14,11 @@ export type BeamDrawProps = Omit<React.SVGProps<SVGSVGElement>, "ref"> & {
   paths?: string[];
   /** Stroke width of each beam. Defaults to 2. */
   strokeWidth?: number;
+  /**
+   * Track scroll of a scrollable element instead of the window. Pass a ref to
+   * the overflow container when the beam lives inside an inner scroll area.
+   */
+  container?: React.RefObject<HTMLElement | null>;
 };
 
 // SPRING.smooth — surfaces / shared-layout feel.
@@ -28,7 +33,10 @@ const DEFAULT_PATHS = [
 ];
 
 const BeamDraw = React.forwardRef<SVGSVGElement, BeamDrawProps>(
-  ({ paths = DEFAULT_PATHS, strokeWidth = 2, className, ...props }, ref) => {
+  (
+    { paths = DEFAULT_PATHS, strokeWidth = 2, container, className, ...props },
+    ref,
+  ) => {
     const reduce = useReducedMotion();
     const containerRef = React.useRef<SVGSVGElement>(null);
     React.useImperativeHandle(ref, () => containerRef.current as SVGSVGElement);
@@ -37,6 +45,8 @@ const BeamDraw = React.forwardRef<SVGSVGElement, BeamDrawProps>(
       // useScroll's target types expect an HTMLElement ref; the SVG root works
       // the same at runtime (getBoundingClientRect).
       target: containerRef as unknown as React.RefObject<HTMLElement>,
+      // Track an inner scroll container when provided; otherwise the window.
+      container,
       offset: ["start end", "end start"],
     });
     const pathLength = useSpring(

--- a/packages/components/src/scroll-text-reveal/scroll-text-reveal.tsx
+++ b/packages/components/src/scroll-text-reveal/scroll-text-reveal.tsx
@@ -74,6 +74,11 @@ export type ScrollTextRevealProps = Omit<
   keepRevealed?: boolean;
   /** Scroll offset that maps element position to progress (framer `useScroll`). */
   offset?: [string, string];
+  /**
+   * Track scroll of a scrollable element instead of the window. Pass a ref to
+   * the overflow container when the copy lives inside an inner scroll area.
+   */
+  container?: React.RefObject<HTMLElement | null>;
   /** Class applied to every segment span. */
   segmentClassName?: string;
 };
@@ -130,6 +135,7 @@ const ScrollTextReveal = React.forwardRef<HTMLElement, ScrollTextRevealProps>(
       dimOpacity = 0.15,
       keepRevealed = false,
       offset = ["start 0.85", "end 0.35"],
+      container,
       className,
       segmentClassName,
       ...props
@@ -148,6 +154,8 @@ const ScrollTextReveal = React.forwardRef<HTMLElement, ScrollTextRevealProps>(
 
     const { scrollYProgress } = useScroll({
       target: localRef as React.RefObject<HTMLElement>,
+      // Track an inner scroll container when provided; otherwise the window.
+      container,
       offset: offset as never,
     });
 

--- a/packages/components/src/scroll-timeline/scroll-timeline.tsx
+++ b/packages/components/src/scroll-timeline/scroll-timeline.tsx
@@ -20,10 +20,15 @@ export type TimelineEntry = {
 
 export type ScrollTimelineProps = React.HTMLAttributes<HTMLDivElement> & {
   data: TimelineEntry[];
+  /**
+   * Track scroll of a scrollable element instead of the window. Pass a ref to
+   * the overflow container when the timeline lives inside an inner scroll area.
+   */
+  container?: React.RefObject<HTMLElement | null>;
 };
 
 const ScrollTimeline = React.forwardRef<HTMLDivElement, ScrollTimelineProps>(
-  ({ data, className, ...props }, ref) => {
+  ({ data, container, className, ...props }, ref) => {
     const reduce = useReducedMotion();
     const rootRef = React.useRef<HTMLDivElement>(null);
     React.useImperativeHandle(ref, () => rootRef.current as HTMLDivElement);
@@ -40,10 +45,15 @@ const ScrollTimeline = React.forwardRef<HTMLDivElement, ScrollTimelineProps>(
       return () => ro.disconnect();
     }, []);
 
-    const { scrollYProgress } = useScroll({
-      target: trackRef,
-      offset: ["start 10%", "end 60%"],
-    });
+    // With an inner scroll container, drive the rail off that container's own
+    // scroll progress (0 at top → 1 at bottom) so the line grows linearly with
+    // scroll. On the page (no container) track the timeline through the viewport
+    // with the tuned offset — the original, page-scroll behavior.
+    const { scrollYProgress } = useScroll(
+      container
+        ? { container }
+        : { target: trackRef, offset: ["start 10%", "end 60%"] },
+    );
 
     // Spring-smooth the scroll scrub, then drive the rail with a GPU `scaleY`
     // transform (not `height`) so growth stays buttery. SPRING.smooth.


### PR DESCRIPTION
## Description

Polishes the Workbench docs preview and fixes the mobile component-page header. On mobile the title chip collided with the toolbar, so it's narrowed and the non-essential controls (replay / viewport / playground / fullscreen / dividers) are hidden; the floating aeo.js Human/AI widget is replaced by a desktop-only header button (before the search bar) that opens the AI view. Many full-bleed demos didn't use the stage height, sat under the header chrome, or were mis-centered — those layouts are fixed. Scroll-driven components (BeamDraw, ScrollTimeline, ScrollTextReveal) didn't animate because the stage is an inner scroll container while Motion's `useScroll` defaults to the window, so they gained an optional, non-breaking `container` prop and their demos now drive it.

## Type of change

- [x] 🐛 Bug fix (non-breaking change fixing an issue)
- [x] 🚀 Feature (non-breaking change adding functionality)
- [x] 🎨 Style / design polish

## Changes made

- Mobile header: shrink title chip; hide replay/viewport/playground/fullscreen + rail dividers; add desktop-only AI-view header button (hides the floating aeo.js widget via CSS).
- Give the stage canvas a hair of separation from the page bg via a shared `--workbench-canvas-bg` var; fade the top scrim from that same surface.
- Add optional `container` ref prop to `BeamDraw`, `ScrollTimeline`, `ScrollTextReveal` (defaults to window); `ScrollTimeline` uses the container's own scroll progress when provided.
- Fix preview demo layouts: full-height globe/dock/image-trail/live-cursors/comment-pin, concentric orbiting-circles rings, off-top marquee/orbiting/world-map/sticky, morph-gallery top clip, and the context-menu star badge.

## How to test

1. `pnpm dev`, open component docs pages (e.g. Beam Draw, Scroll Timeline, Orbiting Circles, Live Cursors, Comment Pin).
2. Scroll the preview stage — beam/timeline/text-reveal animate; check layouts at desktop + mobile widths and the header AI button.

## Screenshots / recordings

_Visual/motion changes — before/after captures to be added._

## Checklist

- [x] `pnpm check` passes (Biome lint + format)
- [ ] `pnpm test` passes
- [x] `pnpm lint` passes (type-check)
- [x] Commits follow Conventional Commits
- [x] Self-reviewed the diff; no stray logs, dead code, or commented-out blocks

### Component / registry PRs only

- [ ] Ran `pnpm build:registry` (component `container` prop added; registry rebuild pending)
- [x] Animations use `transform`/`opacity`/`filter` only (no layout/paint props)
