### PR TITLE
refactor(docs): unify Workbench demo layout with _kit primitives

### DIFF
--- a/.agents/skills/godui-component-creation/SKILL.md
+++ b/.agents/skills/godui-component-creation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: godui-component-creation
-description: Create new components for the GodUI design system in @godui/components. Use when adding a component, fixing missing Tailwind styles on components, wiring Storybook stories, or writing docs pages (main page + required Learn tab) with ComponentPreview and ComponentInstall.
+description: Create new components for the GodUI design system in @godui/components. Use when adding a component, fixing missing Tailwind styles on components, wiring Storybook stories, or writing docs pages (main page + required Learn tab) with Workbench/Example and ComponentInstall.
 ---
 
 # GodUI Component Creation
@@ -187,55 +187,84 @@ Include stories for each variant, sizes, and disabled state.
 Docs live under a **category subfolder** (e.g. `buttons/`, `text/`), and each component
 is its **own folder** so the Learn tab can sit beside it: create
 `apps/docs/content/docs/components/{category}/{name}/index.mdx` (the main page) — a Learn
-tab will be added as `learn.mdx` in the same folder (see §5.5). Use the Preview/Code tabs,
-then Installation, Usage, Props:
+tab will be added as `learn.mdx` in the same folder (see §5.5).
+
+Component pages are **Workbench-first**: stage examples as `<Example>` tabs, then
+Installation → Usage → Props in the Docs drawer.
 
 ```mdx
 ---
 title: My Component
 description: Short description.
 date: "2026-07-10"
+workbench: true
 ---
 
 import { MyComponent } from "@godui/components";
+import { MyComponentDemo } from "@/components/demos/my-component-demo";
 
-<ComponentPreview code={`import { MyComponent } from "@godui/components";
+<Workbench>
+
+One-sentence lead.
+
+<Example
+  label="Default"
+  story="category-mycomponent"
+  code={`import { MyComponent } from "@/components/godui/my-component";
 
 export function MyComponentDemo() {
   return <MyComponent variant="primary">Example</MyComponent>;
-}`}>
-  <MyComponent variant="primary">Example</MyComponent>
-</ComponentPreview>
+}`}
+>
+  <MyComponentDemo />
+</Example>
 
-The `date` frontmatter is the component's **creation date** (`YYYY-MM-DD`) and is
-**required for new components**. For one month after that date the sidebar nav
-shows a "New" badge (wired via `date` → `frontmatterSchema` in `source.config.ts`
-→ `newBadgePlugin` in `src/lib/source.ts`). Use today's date.
+{/* More variants = more <Example label="…"> tabs only — never ## headings between them */}
 
 ## Installation
-<ComponentInstall componentName="MyComponent" />
+<ComponentInstall name="my-component" />
 
 ## Usage
 \`\`\`tsx
-import { MyComponent } from "@godui/components";
+import { MyComponent } from "@/components/godui/my-component";
 \`\`\`
 
 ## Props
 | Prop | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |
 | `variant` | `"primary" \| "secondary"` | `"primary"` | Visual style |
+
+</Workbench>
 ```
 
-`ComponentPreview` and `ComponentInstall` are registered globally in `apps/docs/src/components/mdx.tsx`.
+The `date` frontmatter is the component's **creation date** (`YYYY-MM-DD`) and is
+**required for new components**. For one month after that date the sidebar nav
+shows a "New" badge (wired via `date` → `frontmatterSchema` in `source.config.ts`
+→ `newBadgePlugin` in `src/lib/source.ts`). Use today's date.
 
-**Mobile preview (required check).** `ComponentPreview` has a desktop/mobile toggle; mobile renders the demo inside a **360px** `<iframe>` so real `@media` queries fire. Demos must be fluid so they don't overflow it, **without changing the desktop rendering**:
+`Workbench`, `Example`, and `ComponentInstall` are registered globally in
+`apps/docs/src/components/mdx.tsx`.
+
+### Demo layout kit (`apps/docs/src/components/demos/_kit.tsx`)
+
+| Kit | When | Example `fullWidth` |
+| --- | --- | --- |
+| `DemoCenter` | Buttons, inputs, small cards | no |
+| `DemoMedia` | Image compare / accordion / galleries | no |
+| `DemoScrollPort variant="fill"` | Stage-fill scrubbers (container-scroll, hero-parallax, beam-draw) | **yes** |
+| `DemoScrollPort variant="framed"` | Mini readers (scroll-progress, scroll-text-reveal, scroll-reveal) | no |
+| `DemoScene` | Full-bleed scenes (backgrounds, dock, inertia gallery) | **yes** |
+
+Do **not** nest `max-w-*` under `fullWidth` unless the demo intentionally builds an inset scene.
+
+**Mobile preview (required check).** The Workbench stage has a desktop/mobile toggle; mobile renders the demo inside a **360px** `<iframe>` so real `@media` queries fire. Demos must be fluid so they don't overflow it, **without changing the desktop rendering**:
 
 - Swap a fixed `w-[26rem]` for `w-full max-w-[26rem]` — on the wide desktop container this still resolves to 26rem (identical), but shrinks below 360px on mobile.
 - Any padding/margin you add purely to keep the card off the mobile edges must be **mobile-only** — gate it with `max-sm:` (e.g. `max-sm:px-4`, `max-sm:mx-4`) so desktop stays byte-for-byte the same. Never add flat `px-4`/`mx-4` that also hits desktop.
 
 Always flip the toggle to mobile AND back to desktop: mobile must not clip or h-scroll, desktop must look exactly as before (see §8).
 
-**MDX `<p>`-in-`<p>` hydration trap (happens frequently).** Inside `ComponentPreview`
+**MDX `<p>`-in-`<p>` hydration trap (happens frequently).** Inside Example
 children, any text sitting on **its own line** inside a block element gets wrapped by MDX
 in an extra `<p>`. If that element is itself a `<p>` (or the preview already lives inside
 prose), you get `<p>` nested in `<p>` → `In HTML, <p> cannot be a descendant of <p>` and a
@@ -375,12 +404,12 @@ slug.
 - **NEVER** invent spring/duration/easing numbers — use the motion tokens (see "Motion"). Match the documented values inline.
 - **NEVER** ship an animation without a reduced-motion path, and **never** `transition: all`.
 - **NEVER** use arbitrary z-index — use the scale: `z-base`, `z-raised`, `z-overlay`, `z-sticky`, `z-popover`, `z-modal`, `z-toast`.
-- **NEVER** put bare text on its own line inside a block tag in `ComponentPreview` children — MDX wraps it in a `<p>`, causing `<p>`-in-`<p>` hydration errors. Keep text inline (see §5).
+- **NEVER** put bare text on its own line inside a block tag in `Example` children — MDX wraps it in a `<p>`, causing `<p>`-in-`<p>` hydration errors. Keep text inline (see §5).
 - **NEVER** rely on folder auto-nav for docs — register the page in the root `apps/docs/content/docs/meta.json` (slug `components/{category}/{name}`) and add a `<PreviewCard>` in `components/index.mdx`, or it won't appear (see §5).
 - **NEVER** ship a component without a Learn tab — every component needs `{name}/learn.mdx`, built via the `godui-learn-article` skill (see §5.5).
 - **NEVER** use fixed-luminance colors (`bg-black/*`, `bg-white/*`, `border-white/*`, `text-white`, hex) in a Learn scene — they only contrast in one theme. Use theme tokens and verify light **and** dark (see §5.5).
 - **NEVER** ship a `<PreviewCard>` without its placeholder preview — create `card-previews/previews/{name}.tsx` (filename = href slug) and add the slug to `CURATED_SLUGS`, or the card renders text-only and breaks the uniform grid (see §6).
-- **NEVER** give a demo (or the component itself) a fixed width wider than the mobile preview — `ComponentPreview` has a mobile toggle that renders the demo in a **360px** iframe, so a hard `w-[26rem]`/`w-96`/`min-w-[...]` overflows and clips. Use fluid widths: `w-full max-w-[26rem]` (shrinks on mobile, still 26rem on desktop). Gate any extra edge padding/margin to mobile with `max-sm:` so **desktop stays unchanged** — never add flat `px-4`/`mx-4` that also alters desktop (see §5).
+- **NEVER** give a demo (or the component itself) a fixed width wider than the mobile preview — the Workbench stage has a mobile toggle that renders the demo in a **360px** iframe, so a hard `w-[26rem]`/`w-96`/`min-w-[...]` overflows and clips. Use fluid widths: `w-full max-w-[26rem]` (shrinks on mobile, still 26rem on desktop). Gate any extra edge padding/margin to mobile with `max-sm:` so **desktop stays unchanged** — never add flat `px-4`/`mx-4` that also alters desktop (see §5).
 
 ## 9. Theme tokens
 
@@ -400,14 +429,14 @@ slug.
 - [ ] Styles authored as inline Tailwind utilities — no CSS file / no `@layer components` (only `@keyframes` + `@theme` may touch `styles.css`)
 - [ ] Motion uses the guideline tokens (DURATION/EASE/SPRING/STAGGER/ENTER/EXIT) inline — no invented numbers; transform/opacity only; reduced-motion handled (see "Motion")
 - [ ] Storybook story with `tags: ["autodocs"]`
-- [ ] Docs MDX under `components/{category}/{name}/index.mdx` with ComponentPreview + ComponentInstall
+- [ ] Docs MDX under `components/{category}/{name}/index.mdx` with Workbench + Example + ComponentInstall
 - [ ] Learn tab `components/{category}/{name}/learn.mdx` built via the `godui-learn-article` skill — scenes use the black/white pattern and are verified in **both** light and dark theme (see §5.5)
 - [ ] Motion Score section in the Learn article (`## Motion Score` + `<MotionScorePanel name="{name}" />` before The result, plus a `MOTION_SCORE_PANELS` registry entry) — grade matches the docs Motion badge; **skip for static (`STATIC_COMPONENTS`) components** (see learn skill §6.5)
 - [ ] `date: YYYY-MM-DD` (today) in the MDX frontmatter — required; drives the "New" sidebar badge for one month
-- [ ] ComponentPreview children: text inline in its tag (no `<p>`-in-`<p>` — see §5)
+- [ ] Example children: text inline in its tag (no `<p>`-in-`<p>` — see §5)
 - [ ] Registered in root `apps/docs/content/docs/meta.json` as `components/{category}/{name}`
 - [ ] `<PreviewCard>` added to its section in `components/index.mdx`
 - [ ] Placeholder preview `card-previews/previews/{name}.tsx` (kit skeleton, `group-hover` motion) + slug in `CURATED_SLUGS` (see §6)
 - [ ] Static Tailwind classes only (no dynamic class construction)
-- [ ] Demo is fluid — `w-full max-w-[...]`, no fixed width wider than 360px; verified via the ComponentPreview mobile toggle (see §8)
+- [ ] Demo is fluid — `w-full max-w-[...]`, no fixed width wider than 360px; verified via the Workbench mobile toggle (see §8); use demos/_kit layout primitives
 - [ ] Verified styles in Storybook and docs after dev server restart

--- a/.agents/skills/godui-component-creation/SKILL.md
+++ b/.agents/skills/godui-component-creation/SKILL.md
@@ -257,6 +257,23 @@ shows a "New" badge (wired via `date` → `frontmatterSchema` in `source.config.
 
 Do **not** nest `max-w-*` under `fullWidth` unless the demo intentionally builds an inset scene.
 
+### Example content standard (stage tabs)
+
+Every component page should feel like it was authored with the same taste — not a
+mix of “Press me” fillers and full desktop scenes.
+
+| Tab | Content |
+| --- | --- |
+| **Default** | One intentional product moment. Real verbs / labels (`Get started`, `Hold to delete`, `Email address`). Not a variant matrix. Not “Press/Hover/Push me”. Optional companion CTA only when the component is naturally a pair (e.g. primary + outline). |
+| **Variants / Masks / …** | Prop galleries. Distinct product labels per item (`Continue` / `Save draft` / `View docs`) — or Short/Medium/Large for sizes. Never make Default *be* this gallery when the tab also exists. |
+| **Feature tabs** | Only unique behaviors (Loading, Squash, Async, Static Label). Drop tabs that re-show Default. |
+| **Disabled** | Same label as Default + `disabled`. |
+
+**Polish ceiling:** bare control centered on the stage is the default. Reserve
+`DemoScene` / habitat chrome (wallpaper, menu bars) for environmental components
+(dock, backgrounds, pointer playgrounds) — don’t under-author buttons to look
+random, and don’t over-author every control into a fake desktop.
+
 **Mobile preview (required check).** The Workbench stage has a desktop/mobile toggle; mobile renders the demo inside a **360px** `<iframe>` so real `@media` queries fire. Demos must be fluid so they don't overflow it, **without changing the desktop rendering**:
 
 - Swap a fixed `w-[26rem]` for `w-full max-w-[26rem]` — on the wide desktop container this still resolves to 26rem (identical), but shrinks below 360px on mobile.

--- a/apps/docs/content/docs/components/backgrounds/pixel-grid/index.mdx
+++ b/apps/docs/content/docs/components/backgrounds/pixel-grid/index.mdx
@@ -64,7 +64,7 @@ animate. With the default `cursorReveal="hidden"`, the rest stay invisible — a
 spotlight that follows the pointer.
 
 <Example
-  label="Cursor Reveal"
+  label="Cursor"
   fullWidth
   code={`import { PixelGrid } from "@/components/godui/pixel-grid";
 
@@ -89,7 +89,7 @@ export function PixelGridCursor() {
 opacity, so the cursor lights up an already-present grid.
 
 <Example
-  label="Cursor Reveal Over A Dim Field"
+  label="Dim Reveal"
   fullWidth
   code={`import { PixelGrid } from "@/components/godui/pixel-grid";
 
@@ -113,7 +113,7 @@ export function PixelGridCursorDim() {
 Pass any CSS color string to `color` to override the theme token.
 
 <Example
-  label="Custom Color"
+  label="Color"
   fullWidth
   code={`import { PixelGrid } from "@/components/godui/pixel-grid";
 
@@ -135,7 +135,7 @@ export function PixelGridColored() {
 Smaller `squareSize` and `gridGap` pack the field tighter.
 
 <Example
-  label="Dense Grid"
+  label="Dense"
   fullWidth
   code={`import { PixelGrid } from "@/components/godui/pixel-grid";
 

--- a/apps/docs/content/docs/components/buttons/gooey-fab/index.mdx
+++ b/apps/docs/content/docs/components/buttons/gooey-fab/index.mdx
@@ -68,16 +68,16 @@ export function GooeyFabDemo() {
   code={`<GooeyFab
   size="lg"
   actions={[
-    { label: "Camera", icon: <CameraIcon /> },
-    { label: "Image", icon: <ImageIcon /> },
+    { label: "Take photo", icon: <CameraIcon /> },
+    { label: "Upload image", icon: <ImageIcon /> },
   ]}
 />`}
 >
   <GooeyFab
     size="lg"
     actions={[
-      { label: "Camera", icon: <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="size-[45%]"><path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3l-2.5-3Z" /><circle cx="12" cy="13" r="3" /></svg> },
-      { label: "Image", icon: <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="size-[45%]"><rect x="3" y="3" width="18" height="18" rx="2" /><circle cx="9" cy="9" r="2" /><path d="m21 15-3.09-3.09a2 2 0 0 0-2.82 0L6 21" /></svg> },
+      { label: "Take photo", icon: <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="size-[45%]"><path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3l-2.5-3Z" /><circle cx="12" cy="13" r="3" /></svg> },
+      { label: "Upload image", icon: <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="size-[45%]"><rect x="3" y="3" width="18" height="18" rx="2" /><circle cx="9" cy="9" r="2" /><path d="m21 15-3.09-3.09a2 2 0 0 0-2.82 0L6 21" /></svg> },
     ]}
   />
 </Example>

--- a/apps/docs/content/docs/components/buttons/hold-confirm-button/index.mdx
+++ b/apps/docs/content/docs/components/buttons/hold-confirm-button/index.mdx
@@ -27,21 +27,34 @@ export function HoldConfirmButtonDemo() {
 </Example>
 
 <Example
-  label="Variants"
+  label="Publish"
   code={`import { HoldConfirmButton } from "@/components/godui/hold-confirm-button";
 
-export function HoldConfirmButtonVariants() {
+export function HoldConfirmButtonPublish() {
   return (
-    <div className="flex flex-wrap items-center justify-center gap-4">
-      <HoldConfirmButton variant="destructive">Hold to delete</HoldConfirmButton>
-      <HoldConfirmButton variant="default" duration={1400}>Hold to publish</HoldConfirmButton>
-    </div>
+    <HoldConfirmButton variant="default" duration={1400}>
+      Hold to publish
+    </HoldConfirmButton>
   );
 }`}
 >
+  <HoldConfirmButton variant="default" duration={1400}>
+    Hold to publish
+  </HoldConfirmButton>
+</Example>
+
+<Example
+  label="Sizes"
+  code={`<div className="flex flex-wrap items-center justify-center gap-4">
+  <HoldConfirmButton size="sm">Hold to delete</HoldConfirmButton>
+  <HoldConfirmButton size="md">Hold to delete</HoldConfirmButton>
+  <HoldConfirmButton size="lg">Hold to delete</HoldConfirmButton>
+</div>`}
+>
   <div className="flex flex-wrap items-center justify-center gap-4">
-    <HoldConfirmButton variant="destructive">Hold to delete</HoldConfirmButton>
-    <HoldConfirmButton variant="default" duration={1400}>Hold to publish</HoldConfirmButton>
+    <HoldConfirmButton size="sm">Hold to delete</HoldConfirmButton>
+    <HoldConfirmButton size="md">Hold to delete</HoldConfirmButton>
+    <HoldConfirmButton size="lg">Hold to delete</HoldConfirmButton>
   </div>
 </Example>
 

--- a/apps/docs/content/docs/components/buttons/jelly-button/index.mdx
+++ b/apps/docs/content/docs/components/buttons/jelly-button/index.mdx
@@ -17,35 +17,34 @@ A squishy button that deforms on press and springs back with a jelly wobble — 
   code={`import { JellyButton } from "@/components/godui/jelly-button";
 
 export function JellyButtonDemo() {
-  return (
-    <div className="flex flex-wrap items-center justify-center gap-6">
-      <JellyButton variant="primary">Press me</JellyButton>
-      <JellyButton variant="secondary">Press me</JellyButton>
-      <JellyButton variant="outline">Press me</JellyButton>
-    </div>
-  );
+  return <JellyButton variant="primary">Get started</JellyButton>;
 }`}
 >
+  <JellyButton variant="primary">Get started</JellyButton>
+</Example>
+
+<Example
+  label="Variants"
+  code={`<div className="flex flex-wrap items-center justify-center gap-6">
+  <JellyButton variant="primary">Continue</JellyButton>
+  <JellyButton variant="secondary">Save draft</JellyButton>
+  <JellyButton variant="outline">View docs</JellyButton>
+</div>`}
+>
   <div className="flex flex-wrap items-center justify-center gap-6">
-    <JellyButton variant="primary">Press me</JellyButton>
-    <JellyButton variant="secondary">Press me</JellyButton>
-    <JellyButton variant="outline">Press me</JellyButton>
+    <JellyButton variant="primary">Continue</JellyButton>
+    <JellyButton variant="secondary">Save draft</JellyButton>
+    <JellyButton variant="outline">View docs</JellyButton>
   </div>
 </Example>
 
 <Example
   label="Sizes"
-  code={`import { JellyButton } from "@/components/godui/jelly-button";
-
-export function JellyButtonSizes() {
-  return (
-    <div className="flex flex-wrap items-center justify-center gap-6">
-      <JellyButton size="sm">Small</JellyButton>
-      <JellyButton size="md">Medium</JellyButton>
-      <JellyButton size="lg">Large</JellyButton>
-    </div>
-  );
-}`}
+  code={`<div className="flex flex-wrap items-center justify-center gap-6">
+  <JellyButton size="sm">Small</JellyButton>
+  <JellyButton size="md">Medium</JellyButton>
+  <JellyButton size="lg">Large</JellyButton>
+</div>`}
 >
   <div className="flex flex-wrap items-center justify-center gap-6">
     <JellyButton size="sm">Small</JellyButton>
@@ -56,17 +55,11 @@ export function JellyButtonSizes() {
 
 <Example
   label="Squash"
-  code={`import { JellyButton } from "@/components/godui/jelly-button";
-
-export function JellyButtonSquash() {
-  return (
-    <div className="flex flex-wrap items-center justify-center gap-6">
-      <JellyButton squash={0.2}>Subtle</JellyButton>
-      <JellyButton squash={0.6}>Default</JellyButton>
-      <JellyButton squash={1}>Extra squishy</JellyButton>
-    </div>
-  );
-}`}
+  code={`<div className="flex flex-wrap items-center justify-center gap-6">
+  <JellyButton squash={0.2}>Subtle</JellyButton>
+  <JellyButton squash={0.6}>Default</JellyButton>
+  <JellyButton squash={1}>Extra squishy</JellyButton>
+</div>`}
 >
   <div className="flex flex-wrap items-center justify-center gap-6">
     <JellyButton squash={0.2}>Subtle</JellyButton>
@@ -77,13 +70,9 @@ export function JellyButtonSquash() {
 
 <Example
   label="Disabled"
-  code={`import { JellyButton } from "@/components/godui/jelly-button";
-
-export function JellyButtonDisabled() {
-  return <JellyButton disabled>Press me</JellyButton>;
-}`}
+  code={`<JellyButton disabled>Get started</JellyButton>`}
 >
-  <JellyButton disabled>Press me</JellyButton>
+  <JellyButton disabled>Get started</JellyButton>
 </Example>
 
 ## Installation
@@ -97,7 +86,7 @@ import { JellyButton } from "@/components/godui/jelly-button";
 ```
 
 ```tsx
-<JellyButton variant="primary">Press me</JellyButton>
+<JellyButton variant="primary">Get started</JellyButton>
 ```
 
 The `squash` prop (`0`–`1`) sets how hard the button deforms on press. Lower is subtle, higher is bouncier.

--- a/apps/docs/content/docs/components/buttons/magic-button/index.mdx
+++ b/apps/docs/content/docs/components/buttons/magic-button/index.mdx
@@ -16,33 +16,32 @@ A pushable 3D button with a rainbow edge animation and a solid front face.
   code={`import { MagicButton } from "@/components/godui/magic-button";
 
 export function MagicButtonDemo() {
-  return (
-    <div className="flex flex-wrap items-center justify-center gap-6">
-      <MagicButton variant="default">Push me</MagicButton>
-      <MagicButton variant="secondary">Push me</MagicButton>
-    </div>
-  );
+  return <MagicButton variant="default">Get started</MagicButton>;
 }`}
 >
+  <MagicButton variant="default">Get started</MagicButton>
+</Example>
+
+<Example
+  label="Variants"
+  code={`<div className="flex flex-wrap items-center justify-center gap-6">
+  <MagicButton variant="default">Continue</MagicButton>
+  <MagicButton variant="secondary">Learn more</MagicButton>
+</div>`}
+>
   <div className="flex flex-wrap items-center justify-center gap-6">
-    <MagicButton variant="default">Push me</MagicButton>
-    <MagicButton variant="secondary">Push me</MagicButton>
+    <MagicButton variant="default">Continue</MagicButton>
+    <MagicButton variant="secondary">Learn more</MagicButton>
   </div>
 </Example>
 
 <Example
   label="Sizes"
-  code={`import { MagicButton } from "@/components/godui/magic-button";
-
-export function MagicButtonSizes() {
-  return (
-    <div className="flex flex-wrap items-center justify-center gap-6">
-      <MagicButton size="sm">Small</MagicButton>
-      <MagicButton size="md">Medium</MagicButton>
-      <MagicButton size="lg">Large</MagicButton>
-    </div>
-  );
-}`}
+  code={`<div className="flex flex-wrap items-center justify-center gap-6">
+  <MagicButton size="sm">Small</MagicButton>
+  <MagicButton size="md">Medium</MagicButton>
+  <MagicButton size="lg">Large</MagicButton>
+</div>`}
 >
   <div className="flex flex-wrap items-center justify-center gap-6">
     <MagicButton size="sm">Small</MagicButton>
@@ -53,32 +52,24 @@ export function MagicButtonSizes() {
 
 <Example
   label="No Rainbow"
-  code={`import { MagicButton } from "@/components/godui/magic-button";
-
-export function MagicButtonPlain() {
-  return (
-    <div className="flex flex-wrap items-center justify-center gap-6">
-      <MagicButton rainbow={false}>Push me</MagicButton>
-      <MagicButton variant="secondary" rainbow={false}>Push me</MagicButton>
-    </div>
-  );
-}`}
+  code={`<div className="flex flex-wrap items-center justify-center gap-6">
+  <MagicButton rainbow={false}>Get started</MagicButton>
+  <MagicButton variant="secondary" rainbow={false}>Learn more</MagicButton>
+</div>`}
 >
   <div className="flex flex-wrap items-center justify-center gap-6">
-    <MagicButton rainbow={false}>Push me</MagicButton>
-    <MagicButton variant="secondary" rainbow={false}>Push me</MagicButton>
+    <MagicButton rainbow={false}>Get started</MagicButton>
+    <MagicButton variant="secondary" rainbow={false}>
+      Learn more
+    </MagicButton>
   </div>
 </Example>
 
 <Example
   label="Disabled"
-  code={`import { MagicButton } from "@/components/godui/magic-button";
-
-export function MagicButtonDisabled() {
-  return <MagicButton disabled>Push me</MagicButton>;
-}`}
+  code={`<MagicButton disabled>Get started</MagicButton>`}
 >
-  <MagicButton disabled>Push me</MagicButton>
+  <MagicButton disabled>Get started</MagicButton>
 </Example>
 
 ## Installation
@@ -92,7 +83,7 @@ import { MagicButton } from "@/components/godui/magic-button";
 ```
 
 ```tsx
-<MagicButton variant="default">Push me</MagicButton>
+<MagicButton variant="default">Get started</MagicButton>
 ```
 
 Set `rainbow={false}` for a static 3D edge that uses the variant color instead of the animated gradient.
@@ -102,7 +93,7 @@ Set `rainbow={false}` for a static 3D edge that uses the variant color instead o
 | Prop | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |
 | `variant` | `"default" \| "secondary"` | `"default"` | Front face color scheme |
-| `size` | `"sm" \| "default" \| "lg"` | `"default"` | Button padding and text size |
+| `size` | `"sm" \| "md" \| "lg"` | `"md"` | Button padding and text size |
 | `rainbow` | `boolean` | `true` | Animate the 3D edge and shadow with a rainbow gradient |
 
 </Workbench>

--- a/apps/docs/content/docs/components/buttons/magnetic-button/index.mdx
+++ b/apps/docs/content/docs/components/buttons/magnetic-button/index.mdx
@@ -24,23 +24,9 @@ export function MagneticButtonDemo() {
         Get started
         <ArrowRight className="size-4" strokeWidth={2.5} />
       </MagneticButton>
-      <MagneticButton
-        variant="outline"
-        size="lg"
-        range={36}
-        onClick={() =>
-          window.open(
-            "https://github.com/LucasBassetti/godui",
-            "_blank",
-            "noopener,noreferrer",
-          )
-        }
-      >
+      <MagneticButton variant="outline" size="lg" range={36}>
         <Star className="size-4" strokeWidth={2.5} />
         Star on GitHub
-      </MagneticButton>
-      <MagneticButton variant="secondary" size="lg" range={44} staticLabel>
-        Label stays centered
       </MagneticButton>
     </div>
   );
@@ -51,28 +37,28 @@ export function MagneticButtonDemo() {
 
 <Example
   label="Variants"
-  code={`<div className="flex items-center gap-4">
-  <MagneticButton variant="default">Default</MagneticButton>
-  <MagneticButton variant="secondary">Secondary</MagneticButton>
-  <MagneticButton variant="outline">Outline</MagneticButton>
+  code={`<div className="flex flex-wrap items-center justify-center gap-4">
+  <MagneticButton variant="default">Continue</MagneticButton>
+  <MagneticButton variant="secondary">Save draft</MagneticButton>
+  <MagneticButton variant="outline">View docs</MagneticButton>
 </div>`}
 >
-  <div className="flex items-center gap-4">
-    <MagneticButton variant="default">Default</MagneticButton>
-    <MagneticButton variant="secondary">Secondary</MagneticButton>
-    <MagneticButton variant="outline">Outline</MagneticButton>
+  <div className="flex flex-wrap items-center justify-center gap-4">
+    <MagneticButton variant="default">Continue</MagneticButton>
+    <MagneticButton variant="secondary">Save draft</MagneticButton>
+    <MagneticButton variant="outline">View docs</MagneticButton>
   </div>
 </Example>
 
 <Example
   label="Sizes"
-  code={`<div className="flex items-center gap-4">
+  code={`<div className="flex flex-wrap items-center justify-center gap-4">
   <MagneticButton size="sm">Small</MagneticButton>
   <MagneticButton size="md">Medium</MagneticButton>
   <MagneticButton size="lg">Large</MagneticButton>
 </div>`}
 >
-  <div className="flex items-center gap-4">
+  <div className="flex flex-wrap items-center justify-center gap-4">
     <MagneticButton size="sm">Small</MagneticButton>
     <MagneticButton size="md">Medium</MagneticButton>
     <MagneticButton size="lg">Large</MagneticButton>
@@ -81,27 +67,37 @@ export function MagneticButtonDemo() {
 
 <Example
   label="Stronger Pull"
-  code={`<MagneticButton strength={0.8} range={48} size="lg">Pull me</MagneticButton>`}
+  code={`<MagneticButton strength={0.8} range={48} size="lg">
+  Explore docs
+</MagneticButton>`}
 >
-  <MagneticButton strength={0.8} range={48} size="lg">Pull me</MagneticButton>
+  <MagneticButton strength={0.8} range={48} size="lg">
+    Explore docs
+  </MagneticButton>
 </Example>
 
 <Example
   label="Static Label"
-  code={`<div className="flex items-center gap-4">
+  code={`<div className="flex flex-wrap items-center justify-center gap-4">
   <MagneticButton size="lg" range={44}>Parallax label</MagneticButton>
-  <MagneticButton variant="secondary" size="lg" range={44} staticLabel>Centered label</MagneticButton>
+  <MagneticButton variant="secondary" size="lg" range={44} staticLabel>
+    Centered label
+  </MagneticButton>
 </div>`}
 >
-  <div className="flex items-center gap-4">
-    <MagneticButton size="lg" range={44}>Parallax label</MagneticButton>
-    <MagneticButton variant="secondary" size="lg" range={44} staticLabel>Centered label</MagneticButton>
+  <div className="flex flex-wrap items-center justify-center gap-4">
+    <MagneticButton size="lg" range={44}>
+      Parallax label
+    </MagneticButton>
+    <MagneticButton variant="secondary" size="lg" range={44} staticLabel>
+      Centered label
+    </MagneticButton>
   </div>
 </Example>
 
 ## Installation
 
-<ComponentInstall componentName="MagneticButton" />
+<ComponentInstall name="magnetic-button" />
 
 `MagneticButton` wraps the button in an invisible sensor. As the pointer moves
 inside that area, the button spring-translates toward the cursor by `strength`,

--- a/apps/docs/content/docs/components/buttons/mask-button/index.mdx
+++ b/apps/docs/content/docs/components/buttons/mask-button/index.mdx
@@ -13,49 +13,54 @@ A button whose face wipes away on hover via an animated CSS sprite-sheet mask, r
 <Example
   label="Default"
   story="buttons-mask-button"
-  code={`import { MaskButton } from "@godui/components";
+  code={`import { MaskButton } from "@/components/godui/mask-button";
 
 export function MaskButtonDemo() {
-  return (
-    <div className="flex flex-wrap items-center justify-center gap-6">
-      <MaskButton mask="nature">Hover me</MaskButton>
-      <MaskButton mask="urban">Hover me</MaskButton>
-      <MaskButton mask="forest">Hover me</MaskButton>
-    </div>
-  );
+  return <MaskButton mask="nature">Explore</MaskButton>;
 }`}
 >
+  <MaskButton mask="nature">Explore</MaskButton>
+</Example>
+
+<Example
+  label="Masks"
+  code={`<div className="flex flex-wrap items-center justify-center gap-6">
+  <MaskButton mask="nature">Explore</MaskButton>
+  <MaskButton mask="urban">Book a demo</MaskButton>
+  <MaskButton mask="forest">See gallery</MaskButton>
+</div>`}
+>
   <div className="flex flex-wrap items-center justify-center gap-6">
-    <MaskButton mask="nature">Hover me</MaskButton>
-    <MaskButton mask="urban">Hover me</MaskButton>
-    <MaskButton mask="forest">Hover me</MaskButton>
+    <MaskButton mask="nature">Explore</MaskButton>
+    <MaskButton mask="urban">Book a demo</MaskButton>
+    <MaskButton mask="forest">See gallery</MaskButton>
   </div>
 </Example>
 
 <Example
-  label="Secondary"
-  code={`import { MaskButton } from "@godui/components";
-
-export function MaskButtonSecondary() {
-  return <MaskButton mask="nature" variant="secondary">Hover me</MaskButton>;
-}`}
+  label="Variants"
+  code={`<div className="flex flex-wrap items-center justify-center gap-6">
+  <MaskButton mask="nature" variant="primary">Continue</MaskButton>
+  <MaskButton mask="nature" variant="secondary">Learn more</MaskButton>
+</div>`}
 >
-  <MaskButton mask="nature" variant="secondary">Hover me</MaskButton>
+  <div className="flex flex-wrap items-center justify-center gap-6">
+    <MaskButton mask="nature" variant="primary">
+      Continue
+    </MaskButton>
+    <MaskButton mask="nature" variant="secondary">
+      Learn more
+    </MaskButton>
+  </div>
 </Example>
 
 <Example
   label="Sizes"
-  code={`import { MaskButton } from "@godui/components";
-
-export function MaskButtonSizes() {
-  return (
-    <div className="flex flex-wrap items-center justify-center gap-6">
-      <MaskButton size="sm">Small</MaskButton>
-      <MaskButton size="md">Medium</MaskButton>
-      <MaskButton size="lg">Large</MaskButton>
-    </div>
-  );
-}`}
+  code={`<div className="flex flex-wrap items-center justify-center gap-6">
+  <MaskButton size="sm">Small</MaskButton>
+  <MaskButton size="md">Medium</MaskButton>
+  <MaskButton size="lg">Large</MaskButton>
+</div>`}
 >
   <div className="flex flex-wrap items-center justify-center gap-6">
     <MaskButton size="sm">Small</MaskButton>
@@ -66,13 +71,9 @@ export function MaskButtonSizes() {
 
 <Example
   label="Disabled"
-  code={`import { MaskButton } from "@godui/components";
-
-export function MaskButtonDisabled() {
-  return <MaskButton disabled>Hover me</MaskButton>;
-}`}
+  code={`<MaskButton disabled>Explore</MaskButton>`}
 >
-  <MaskButton disabled>Hover me</MaskButton>
+  <MaskButton disabled>Explore</MaskButton>
 </Example>
 
 ## Installation
@@ -82,7 +83,7 @@ the component and CSS, but the masks ship as static assets — download them int
 your app's `public/masks/` folder (the Manual tab links them directly).
 
 <ComponentInstall
-  componentName="MaskButton"
+  name="mask-button"
   assetsTarget="public/masks/"
   assets={[
     { label: "mask-nature.png", href: "/masks/mask-nature.png" },
@@ -94,11 +95,11 @@ your app's `public/masks/` folder (the Manual tab links them directly).
 ## Usage
 
 ```tsx
-import { MaskButton } from "@godui/components";
+import { MaskButton } from "@/components/godui/mask-button";
 ```
 
 ```tsx
-<MaskButton mask="nature">Hover me</MaskButton>
+<MaskButton mask="nature">Explore</MaskButton>
 ```
 
 The primary face is masked by a horizontal sprite-sheet image. On hover the

--- a/apps/docs/content/docs/components/buttons/progress-fold-button/index.mdx
+++ b/apps/docs/content/docs/components/buttons/progress-fold-button/index.mdx
@@ -16,56 +16,49 @@ A 3D button whose front face folds back to reveal a controlled progress bar whil
   code={`import { ProgressFoldButton } from "@/components/godui/progress-fold-button";
 
 export function ProgressFoldButtonDemo() {
-  return (
-    <div className="flex flex-wrap items-center justify-center gap-6">
-      <ProgressFoldButton variant="primary">Submit</ProgressFoldButton>
-      <ProgressFoldButton variant="secondary">Submit</ProgressFoldButton>
-    </div>
-  );
+  return <ProgressFoldButton variant="primary">Publish</ProgressFoldButton>;
 }`}
 >
+  <ProgressFoldButton variant="primary">Publish</ProgressFoldButton>
+</Example>
+
+<Example
+  label="Variants"
+  code={`<div className="flex flex-wrap items-center justify-center gap-6">
+  <ProgressFoldButton variant="primary">Publish</ProgressFoldButton>
+  <ProgressFoldButton variant="secondary">Save draft</ProgressFoldButton>
+</div>`}
+>
   <div className="flex flex-wrap items-center justify-center gap-6">
-    <ProgressFoldButton variant="primary">Submit</ProgressFoldButton>
-    <ProgressFoldButton variant="secondary">Submit</ProgressFoldButton>
+    <ProgressFoldButton variant="primary">Publish</ProgressFoldButton>
+    <ProgressFoldButton variant="secondary">Save draft</ProgressFoldButton>
   </div>
 </Example>
 
 <Example
   label="Loading"
-  code={`import { ProgressFoldButton } from "@/components/godui/progress-fold-button";
-
-export function ProgressFoldButtonLoading() {
-  return (
-    <div className="flex flex-wrap items-center justify-center gap-6">
-      <ProgressFoldButton status="loading">Indeterminate</ProgressFoldButton>
-      <ProgressFoldButton status="loading" progress={60}>
-        Determinate
-      </ProgressFoldButton>
-    </div>
-  );
-}`}
+  code={`<div className="flex flex-wrap items-center justify-center gap-6">
+  <ProgressFoldButton status="loading">Uploading…</ProgressFoldButton>
+  <ProgressFoldButton status="loading" progress={60}>
+    Exporting…
+  </ProgressFoldButton>
+</div>`}
 >
   <div className="flex flex-wrap items-center justify-center gap-6">
-    <ProgressFoldButton status="loading">Indeterminate</ProgressFoldButton>
+    <ProgressFoldButton status="loading">Uploading…</ProgressFoldButton>
     <ProgressFoldButton status="loading" progress={60}>
-      Determinate
+      Exporting…
     </ProgressFoldButton>
   </div>
 </Example>
 
 <Example
   label="Sizes"
-  code={`import { ProgressFoldButton } from "@/components/godui/progress-fold-button";
-
-export function ProgressFoldButtonSizes() {
-  return (
-    <div className="flex flex-wrap items-center justify-center gap-6">
-      <ProgressFoldButton size="sm">Small</ProgressFoldButton>
-      <ProgressFoldButton size="md">Medium</ProgressFoldButton>
-      <ProgressFoldButton size="lg">Large</ProgressFoldButton>
-    </div>
-  );
-}`}
+  code={`<div className="flex flex-wrap items-center justify-center gap-6">
+  <ProgressFoldButton size="sm">Small</ProgressFoldButton>
+  <ProgressFoldButton size="md">Medium</ProgressFoldButton>
+  <ProgressFoldButton size="lg">Large</ProgressFoldButton>
+</div>`}
 >
   <div className="flex flex-wrap items-center justify-center gap-6">
     <ProgressFoldButton size="sm">Small</ProgressFoldButton>
@@ -76,18 +69,14 @@ export function ProgressFoldButtonSizes() {
 
 <Example
   label="Disabled"
-  code={`import { ProgressFoldButton } from "@/components/godui/progress-fold-button";
-
-export function ProgressFoldButtonDisabled() {
-  return <ProgressFoldButton disabled>Submit</ProgressFoldButton>;
-}`}
+  code={`<ProgressFoldButton disabled>Publish</ProgressFoldButton>`}
 >
-  <ProgressFoldButton disabled>Submit</ProgressFoldButton>
+  <ProgressFoldButton disabled>Publish</ProgressFoldButton>
 </Example>
 
 ## Installation
 
-<ComponentInstall componentName="ProgressFoldButton" />
+<ComponentInstall name="progress-fold-button" />
 
 ## Usage
 
@@ -97,7 +86,7 @@ import { ProgressFoldButton } from "@/components/godui/progress-fold-button";
 
 ```tsx
 <ProgressFoldButton status="loading" progress={40}>
-  Submit
+  Publish
 </ProgressFoldButton>
 ```
 
@@ -118,16 +107,22 @@ import { ProgressFoldButton } from "@/components/godui/progress-fold-button";
 
 export function Example() {
   const [status, setStatus] = React.useState<"idle" | "loading">("idle");
+  const [progress, setProgress] = React.useState(0);
 
-  const handleClick = async () => {
+  async function handleClick() {
     setStatus("loading");
-    await doWork();
+    setProgress(0);
+    // …drive progress, then:
     setStatus("idle");
-  };
+  }
 
   return (
-    <ProgressFoldButton status={status} onClick={handleClick}>
-      Submit
+    <ProgressFoldButton
+      status={status}
+      progress={status === "loading" ? progress : undefined}
+      onClick={handleClick}
+    >
+      Publish
     </ProgressFoldButton>
   );
 }
@@ -135,16 +130,11 @@ export function Example() {
 
 ## Props
 
-Accepts all native `<button>` attributes.
-
 | Prop | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |
-| `variant` | `"primary" \| "secondary"` | `"primary"` | Theme color scheme of the front face |
-| `size` | `"sm" \| "md" \| "lg"` | `"md"` | Button size |
-| `status` | `"idle" \| "loading"` | `"idle"` | Loading lifecycle; `"loading"` folds open and runs the bar |
-| `progress` | `number` | — | 0–100; makes `loading` determinate (omit for indeterminate) |
-| `children` | `ReactNode` | — | Button label |
-| `disabled` | `boolean` | `false` | Disable the button and its animations |
-| `onClick` | `(e) => void` | — | Fires on click; flip `status` from here to start loading |
+| `variant` | `"primary" \| "secondary"` | `"primary"` | Front face color scheme |
+| `size` | `"sm" \| "md" \| "lg"` | `"md"` | Button padding and text size |
+| `status` | `"idle" \| "loading"` | `"idle"` | Fold open and show the progress bar while loading |
+| `progress` | `number` | — | 0–100; makes loading determinate (omit for indeterminate) |
 
 </Workbench>

--- a/apps/docs/content/docs/components/buttons/shimmer-button/index.mdx
+++ b/apps/docs/content/docs/components/buttons/shimmer-button/index.mdx
@@ -16,35 +16,34 @@ A button with an animated shimmering border light effect.
   code={`import { ShimmerButton } from "@/components/godui/shimmer-button";
 
 export function ShimmerButtonDemo() {
-  return (
-    <div className="flex flex-wrap items-center justify-center gap-4">
-      <ShimmerButton variant="primary">Primary</ShimmerButton>
-      <ShimmerButton variant="secondary">Secondary</ShimmerButton>
-      <ShimmerButton variant="outline">Outline</ShimmerButton>
-    </div>
-  );
+  return <ShimmerButton variant="primary">Get started</ShimmerButton>;
 }`}
 >
+  <ShimmerButton variant="primary">Get started</ShimmerButton>
+</Example>
+
+<Example
+  label="Variants"
+  code={`<div className="flex flex-wrap items-center justify-center gap-4">
+  <ShimmerButton variant="primary">Continue</ShimmerButton>
+  <ShimmerButton variant="secondary">Learn more</ShimmerButton>
+  <ShimmerButton variant="outline">View pricing</ShimmerButton>
+</div>`}
+>
   <div className="flex flex-wrap items-center justify-center gap-4">
-    <ShimmerButton variant="primary">Primary</ShimmerButton>
-    <ShimmerButton variant="secondary">Secondary</ShimmerButton>
-    <ShimmerButton variant="outline">Outline</ShimmerButton>
+    <ShimmerButton variant="primary">Continue</ShimmerButton>
+    <ShimmerButton variant="secondary">Learn more</ShimmerButton>
+    <ShimmerButton variant="outline">View pricing</ShimmerButton>
   </div>
 </Example>
 
 <Example
   label="Sizes"
-  code={`import { ShimmerButton } from "@/components/godui/shimmer-button";
-
-export function ShimmerButtonSizes() {
-  return (
-    <div className="flex flex-wrap items-center justify-center gap-4">
-      <ShimmerButton size="sm">Small</ShimmerButton>
-      <ShimmerButton size="md">Medium</ShimmerButton>
-      <ShimmerButton size="lg">Large</ShimmerButton>
-    </div>
-  );
-}`}
+  code={`<div className="flex flex-wrap items-center justify-center gap-4">
+  <ShimmerButton size="sm">Small</ShimmerButton>
+  <ShimmerButton size="md">Medium</ShimmerButton>
+  <ShimmerButton size="lg">Large</ShimmerButton>
+</div>`}
 >
   <div className="flex flex-wrap items-center justify-center gap-4">
     <ShimmerButton size="sm">Small</ShimmerButton>
@@ -55,29 +54,21 @@ export function ShimmerButtonSizes() {
 
 <Example
   label="Static"
-  code={`import { ShimmerButton } from "@/components/godui/shimmer-button";
-
-export function ShimmerButtonStatic() {
-  return <ShimmerButton shimmer={false}>No shimmer</ShimmerButton>;
-}`}
+  code={`<ShimmerButton shimmer={false}>Get started</ShimmerButton>`}
 >
-  <ShimmerButton shimmer={false}>No shimmer</ShimmerButton>
+  <ShimmerButton shimmer={false}>Get started</ShimmerButton>
 </Example>
 
 <Example
   label="Disabled"
-  code={`import { ShimmerButton } from "@/components/godui/shimmer-button";
-
-export function ShimmerButtonDisabled() {
-  return <ShimmerButton disabled>Disabled</ShimmerButton>;
-}`}
+  code={`<ShimmerButton disabled>Get started</ShimmerButton>`}
 >
-  <ShimmerButton disabled>Disabled</ShimmerButton>
+  <ShimmerButton disabled>Get started</ShimmerButton>
 </Example>
 
 ## Installation
 
-<ComponentInstall componentName="ShimmerButton" />
+<ComponentInstall name="shimmer-button" />
 
 ## Usage
 
@@ -86,7 +77,7 @@ import { ShimmerButton } from "@/components/godui/shimmer-button";
 ```
 
 ```tsx
-<ShimmerButton variant="primary">Click me</ShimmerButton>
+<ShimmerButton variant="primary">Get started</ShimmerButton>
 ```
 
 Set `shimmer={false}` to keep the button styling without the animated border light.
@@ -96,10 +87,7 @@ Set `shimmer={false}` to keep the button styling without the animated border lig
 | Prop | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |
 | `variant` | `"primary" \| "secondary" \| "outline"` | `"primary"` | Visual style of the button |
-| `size` | `"sm" \| "default" \| "lg"` | `"default"` | Button padding and text size |
+| `size` | `"sm" \| "md" \| "lg"` | `"md"` | Button padding and text size |
 | `shimmer` | `boolean` | `true` | Animate the button with a shimmering border light effect |
-| `shimmerColor` | `string` | variant default | Color of the shimmering light |
-| `shimmerDuration` | `string` | `"3s"` | Duration of the shimmer animation |
-| `background` | `string` | variant default | Background color override |
 
 </Workbench>

--- a/apps/docs/content/docs/components/effects/scroll-progress/index.mdx
+++ b/apps/docs/content/docs/components/effects/scroll-progress/index.mdx
@@ -25,11 +25,6 @@ export function ScrollProgressDemo() {
   <ScrollProgressDemo />
 </Example>
 
-## Circle variant
-
-`variant="circle"` renders a circular progress ring that fades in past
-`showAfter` and scrolls back to top on click.
-
 <Example
   label="Circle Variant"
   code={`import { ScrollProgress } from "@/components/godui/scroll-progress";
@@ -52,6 +47,9 @@ import { ScrollProgress } from "@godui/components";
 
 // Whole-page reading bar
 <ScrollProgress />;
+
+// Circular ring that fades in past showAfter and scrolls back to top on click
+<ScrollProgress variant="circle" showAfter={0.05} />;
 
 // Track a specific section
 const ref = useRef<HTMLElement>(null);

--- a/apps/docs/content/docs/components/effects/scroll-reveal/index.mdx
+++ b/apps/docs/content/docs/components/effects/scroll-reveal/index.mdx
@@ -4,11 +4,15 @@ description: Reveals its children with a spring as they scroll into view, with o
 workbench: true
 ---
 
-import { ScrollReveal } from "@godui/components";
+import {
+  ScrollRevealDemo,
+  ScrollRevealLeftDemo,
+  ScrollRevealStaggerDemo,
+} from "@/components/demos/scroll-reveal-demo";
 
 <Workbench>
 
-Reveals its children with a spring as they scroll into view, with optional velocity skew.
+Reveals its children with a spring as they scroll into view, with optional velocity skew. Scroll the preview to trigger the reveal.
 
 <Example
   label="Default"
@@ -18,14 +22,40 @@ Reveals its children with a spring as they scroll into view, with optional veloc
 export function ScrollRevealDemo() {
   return (
     <ScrollReveal>
-      <div className="rounded-xl border border-border bg-card p-8 text-lg font-semibold text-foreground shadow-sm">I reveal on scroll</div>
+      <div className="rounded-xl border border-border bg-card p-8 text-lg font-semibold text-foreground shadow-sm">
+        I reveal on scroll
+      </div>
     </ScrollReveal>
   );
 }`}
 >
-  <ScrollReveal>
-    <div className="rounded-xl border border-border bg-card p-8 text-lg font-semibold text-foreground shadow-sm">I reveal on scroll</div>
-  </ScrollReveal>
+  <ScrollRevealDemo />
+</Example>
+
+<Example
+  label="Staggered Grid"
+  code={`<div className="grid grid-cols-3 gap-3">
+  {items.map((item, i) => (
+    <ScrollReveal key={item} delay={i * 0.1}>
+      <div className="rounded-xl border border-border bg-card p-5 text-sm font-medium text-foreground shadow-sm">
+        {item}
+      </div>
+    </ScrollReveal>
+  ))}
+</div>`}
+>
+  <ScrollRevealStaggerDemo />
+</Example>
+
+<Example
+  label="From The Left"
+  code={`<ScrollReveal direction="left" distance={80} blur={false}>
+  <div className="rounded-xl border border-border bg-card p-8 text-lg font-semibold text-foreground shadow-sm">
+    Slides in from the left
+  </div>
+</ScrollReveal>`}
+>
+  <ScrollRevealLeftDemo />
 </Example>
 
 ## Installation
@@ -71,44 +101,6 @@ Use `delay` on adjacent reveals to stagger them.
 <ScrollReveal delay={0.1} />
 <ScrollReveal delay={0.2} />
 ```
-
-## Examples
-
-### Staggered grid
-
-Reveal a set of cards in sequence as the group scrolls into view.
-
-<Example
-  label="Staggered Grid"
-  code={`<div className="grid grid-cols-3 gap-3">
-  {items.map((item, i) => (
-    <ScrollReveal key={item} delay={i * 0.1}>
-      <div className="rounded-xl border border-border bg-card p-5 text-sm font-medium text-foreground shadow-sm">{item}</div>
-    </ScrollReveal>
-  ))}
-</div>`}
->
-  <div className="grid grid-cols-3 gap-3">
-    {["Plan", "Build", "Ship", "Measure", "Iterate", "Scale"].map((item, i) => (
-      <ScrollReveal key={item} delay={i * 0.1}>
-        <div className="rounded-xl border border-border bg-card p-5 text-sm font-medium text-foreground shadow-sm">{item}</div>
-      </ScrollReveal>
-    ))}
-  </div>
-</Example>
-
-### From the left, no blur
-
-<Example
-  label="From The Left"
-  code={`<ScrollReveal direction="left" distance={80} blur={false}>
-  <div className="rounded-xl border border-border bg-card p-8 text-lg font-semibold text-foreground shadow-sm">Slides in from the left</div>
-</ScrollReveal>`}
->
-  <ScrollReveal direction="left" distance={80} blur={false}>
-    <div className="rounded-xl border border-border bg-card p-8 text-lg font-semibold text-foreground shadow-sm">Slides in from the left</div>
-  </ScrollReveal>
-</Example>
 
 ## Props
 

--- a/apps/docs/content/docs/components/inputs/magic-input/index.mdx
+++ b/apps/docs/content/docs/components/inputs/magic-input/index.mdx
@@ -17,84 +17,54 @@ A 3D layered text input that lifts on focus with an optional rainbow edge animat
 
 export function MagicInputDemo() {
   return (
-    <div className="flex w-full max-w-xs flex-col gap-6">
-      <MagicInput placeholder="Focus me" />
-      <MagicInput rainbow={false} placeholder="Primary" />
-      <MagicInput variant="secondary" rainbow={false} placeholder="Secondary" />
+    <div className="w-full max-w-xs">
+      <MagicInput placeholder="Email address" />
     </div>
   );
 }`}
 >
-  <div className="flex w-full max-w-xs flex-col gap-6">
-    <MagicInput placeholder="Focus me" />
-    <MagicInput rainbow={false} placeholder="Primary" />
-    <MagicInput variant="secondary" rainbow={false} placeholder="Secondary" />
+  <div className="w-full max-w-xs">
+    <MagicInput placeholder="Email address" />
   </div>
 </Example>
-
-## Variants
-
-The `variant` tints the 3D edge. It shows when `rainbow={false}` (the rainbow
-gradient otherwise overrides the edge while focused).
 
 <Example
   label="Variants"
-  code={`import { MagicInput } from "@/components/godui/magic-input";
-
-export function MagicInputVariants() {
-  return (
-    <div className="flex w-full max-w-xs flex-col gap-6">
-      <MagicInput variant="primary" rainbow={false} placeholder="Primary" />
-      <MagicInput variant="secondary" rainbow={false} placeholder="Secondary" />
-    </div>
-  );
-}`}
+  code={`<div className="flex w-full max-w-xs flex-col gap-6">
+  <MagicInput variant="primary" rainbow={false} placeholder="Email address" />
+  <MagicInput variant="secondary" rainbow={false} placeholder="Workspace name" />
+</div>`}
 >
   <div className="flex w-full max-w-xs flex-col gap-6">
-    <MagicInput variant="primary" rainbow={false} placeholder="Primary" />
-    <MagicInput variant="secondary" rainbow={false} placeholder="Secondary" />
+    <MagicInput variant="primary" rainbow={false} placeholder="Email address" />
+    <MagicInput
+      variant="secondary"
+      rainbow={false}
+      placeholder="Workspace name"
+    />
   </div>
 </Example>
 
-## Depth
-
-`depth="focus"` (default) stays flat until focused. `depth="always"` keeps the
-raised 3D look at rest.
-
 <Example
   label="Depth"
-  code={`import { MagicInput } from "@/components/godui/magic-input";
-
-export function MagicInputDepth() {
-  return (
-    <div className="flex w-full max-w-xs flex-col gap-6">
-      <MagicInput depth="focus" placeholder="On focus" />
-      <MagicInput depth="always" placeholder="Always raised" />
-    </div>
-  );
-}`}
+  code={`<div className="flex w-full max-w-xs flex-col gap-6">
+  <MagicInput depth="focus" placeholder="Email address" />
+  <MagicInput depth="always" placeholder="Always raised" />
+</div>`}
 >
   <div className="flex w-full max-w-xs flex-col gap-6">
-    <MagicInput depth="focus" placeholder="On focus" />
+    <MagicInput depth="focus" placeholder="Email address" />
     <MagicInput depth="always" placeholder="Always raised" />
   </div>
 </Example>
 
-## Sizes
-
 <Example
   label="Sizes"
-  code={`import { MagicInput } from "@/components/godui/magic-input";
-
-export function MagicInputSizes() {
-  return (
-    <div className="flex w-full max-w-xs flex-col gap-6">
-      <MagicInput size="sm" placeholder="Small" />
-      <MagicInput size="md" placeholder="Medium" />
-      <MagicInput size="lg" placeholder="Large" />
-    </div>
-  );
-}`}
+  code={`<div className="flex w-full max-w-xs flex-col gap-6">
+  <MagicInput size="sm" placeholder="Small" />
+  <MagicInput size="md" placeholder="Medium" />
+  <MagicInput size="lg" placeholder="Large" />
+</div>`}
 >
   <div className="flex w-full max-w-xs flex-col gap-6">
     <MagicInput size="sm" placeholder="Small" />
@@ -103,85 +73,40 @@ export function MagicInputSizes() {
   </div>
 </Example>
 
-## Submit button
-
-Pass `onSubmit` to render an arrow button on the right. It fires with the
-current value on click or when <kbd>Enter</kbd> is pressed. Without `onSubmit`,
-set `submitButton` to render a `type="submit"` button for an enclosing form.
-
 <Example
   label="Submit Button"
-  code={`import { MagicInput } from "@/components/godui/magic-input";
-
-export function MagicInputSubmit() {
-  return (
-    <div className="flex w-full max-w-xs flex-col gap-6">
-      <MagicInput placeholder="Type and submit" onSubmit={(v) => alert(v)} />
-      <MagicInput size="lg" placeholder="Larger" onSubmit={(v) => alert(v)} />
-    </div>
-  );
-}`}
+  code={`<div className="flex w-full max-w-xs flex-col gap-6">
+  <MagicInput placeholder="Search docs" onSubmit={(v) => alert(v)} />
+  <MagicInput size="lg" placeholder="Ask AI anything" onSubmit={(v) => alert(v)} />
+</div>`}
 >
   <div className="flex w-full max-w-xs flex-col gap-6">
-    <MagicInput placeholder="Type and submit" submitButton />
-    <MagicInput size="lg" placeholder="Larger" submitButton />
+    <MagicInput placeholder="Search docs" submitButton />
+    <MagicInput size="lg" placeholder="Ask AI anything" submitButton />
   </div>
 </Example>
-
-## Submit lifecycle
-
-`status` and `progress` are fully controlled. While `status="loading"` the
-rainbow hides, the 3D depth locks in, and a progress bar runs along the bottom —
-determinate when you pass `progress`, otherwise an indeterminate segment bounces
-end to end. The arrow turns into a circular progress / spinner. `success` and
-`error` flash a green / red sweep with a check / X icon.
 
 <Example
   label="Submit Lifecycle"
-  code={`import { MagicInput } from "@/components/godui/magic-input";
-
-export function MagicInputStatus() {
-  return (
-    <div className="flex w-full max-w-xs flex-col gap-6">
-      <MagicInput placeholder="Indeterminate" onSubmit={() => {}} status="loading" />
-      <MagicInput placeholder="Determinate" onSubmit={() => {}} status="loading" progress={60} />
-      <MagicInput placeholder="Success" onSubmit={() => {}} status="success" />
-      <MagicInput placeholder="Error" onSubmit={() => {}} status="error" />
-    </div>
-  );
-}`}
+  code={`<div className="flex w-full max-w-xs flex-col gap-6">
+  <MagicInput placeholder="Uploading…" onSubmit={() => {}} status="loading" />
+  <MagicInput placeholder="Exporting…" onSubmit={() => {}} status="loading" progress={60} />
+  <MagicInput placeholder="Invite sent" onSubmit={() => {}} status="success" />
+  <MagicInput placeholder="Try again" onSubmit={() => {}} status="error" />
+</div>`}
 >
   <div className="flex w-full max-w-xs flex-col gap-6">
-    <MagicInput placeholder="Indeterminate" submitButton status="loading" />
-    <MagicInput placeholder="Determinate" submitButton status="loading" progress={60} />
-    <MagicInput placeholder="Success" submitButton status="success" />
-    <MagicInput placeholder="Error" submitButton status="error" />
+    <MagicInput placeholder="Uploading…" submitButton status="loading" />
+    <MagicInput
+      placeholder="Exporting…"
+      submitButton
+      status="loading"
+      progress={60}
+    />
+    <MagicInput placeholder="Invite sent" submitButton status="success" />
+    <MagicInput placeholder="Try again" submitButton status="error" />
   </div>
 </Example>
-
-You drive it from your submit handler:
-
-```tsx
-const [status, setStatus] = useState<MagicInputStatus>("idle");
-const [progress, setProgress] = useState(0);
-
-async function handleSubmit(value: string) {
-  setStatus("loading");
-  try {
-    await upload(value, setProgress); // call setProgress(0..100) as it runs
-    setStatus("success");
-  } catch {
-    setStatus("error");
-  }
-  setTimeout(() => setStatus("idle"), 1600);
-}
-
-<MagicInput
-  status={status}
-  progress={status === "loading" ? progress : undefined}
-  onSubmit={handleSubmit}
-/>;
-```
 
 ## Installation
 
@@ -194,7 +119,7 @@ import { MagicInput } from "@/components/godui/magic-input";
 ```
 
 ```tsx
-<MagicInput placeholder="Focus me" />
+<MagicInput placeholder="Email address" />
 ```
 
 By default the input is flat and lifts into the 3D effect only while focused.
@@ -202,7 +127,39 @@ Set `depth="always"` to keep the raised look at rest, and `rainbow={false}` to
 disable the animated rainbow edge.
 
 ```tsx
-<MagicInput depth="always" rainbow={false} placeholder="Always raised" />
+<MagicInput depth="always" rainbow={false} placeholder="Workspace name" />
+```
+
+Pass `onSubmit` to render an arrow button on the right. It fires with the
+current value on click or when <kbd>Enter</kbd> is pressed. Without `onSubmit`,
+set `submitButton` to render a `type="submit"` button for an enclosing form.
+
+`status` and `progress` are fully controlled. While `status="loading"` the
+rainbow hides, the 3D depth locks in, and a progress bar runs along the bottom —
+determinate when you pass `progress`, otherwise an indeterminate segment bounces
+end to end. The arrow turns into a circular progress / spinner. `success` and
+`error` flash a green / red sweep with a check / X icon.
+
+```tsx
+const [status, setStatus] = useState<MagicInputStatus>("idle");
+const [progress, setProgress] = useState(0);
+
+async function handleSubmit(value: string) {
+  setStatus("loading");
+  try {
+    await upload(value, setProgress);
+    setStatus("success");
+  } catch {
+    setStatus("error");
+  }
+  setTimeout(() => setStatus("idle"), 1600);
+}
+
+<MagicInput
+  status={status}
+  progress={status === "loading" ? progress : undefined}
+  onSubmit={handleSubmit}
+/>;
 ```
 
 ## Props

--- a/apps/docs/content/docs/components/layout/image-compare/index.mdx
+++ b/apps/docs/content/docs/components/layout/image-compare/index.mdx
@@ -31,8 +31,6 @@ export function ImageCompareDemo() {
   <ImageCompareDemo />
 </Example>
 
-## Vertical
-
 <Example
   label="Vertical"
   code={`import { ImageCompare } from "@/components/godui/image-compare";

--- a/apps/docs/content/docs/components/layout/stepper/index.mdx
+++ b/apps/docs/content/docs/components/layout/stepper/index.mdx
@@ -38,11 +38,6 @@ export function StepperDemo() {
   </div>
 </Example>
 
-## Interactive
-
-Drive `active` from state to walk through the steps — the line fills and each
-completed step morphs its number into a checkmark.
-
 <Example
   label="Interactive"
   code={`import { useState } from "react";
@@ -65,8 +60,6 @@ export function StepperInteractive() {
 >
   <StepperInteractiveDemo />
 </Example>
-
-## Vertical
 
 <Example
   label="Vertical"

--- a/apps/docs/content/docs/components/layout/sticky-scroll/index.mdx
+++ b/apps/docs/content/docs/components/layout/sticky-scroll/index.mdx
@@ -12,7 +12,6 @@ Text scrolls in the left column while a pinned panel on the right swaps to match
 
 <Example
   label="Default"
-  fullWidth
   story="layout-sticky-scroll"
   code={`import { StickyScroll } from "@/components/godui/sticky-scroll";
 

--- a/apps/docs/content/docs/components/layout/three-d-marquee/index.mdx
+++ b/apps/docs/content/docs/components/layout/three-d-marquee/index.mdx
@@ -12,7 +12,6 @@ A wall of images laid on a tilted 3D plane, its columns drifting up and down in 
 
 <Example
   label="Default"
-  fullWidth
   story="layout-three-d-marquee"
   code={`import { ThreeDMarquee } from "@/components/godui/three-d-marquee";
 

--- a/apps/docs/content/docs/components/overlays/toast/index.mdx
+++ b/apps/docs/content/docs/components/overlays/toast/index.mdx
@@ -18,8 +18,38 @@ import { ToastProvider, toast } from "@/components/godui/toast";
 
 export function ToastDemo() {
   return (
-    <div>
-      <button onClick={() => toast({ title: "Event created", description: "Friday at 5pm" })} className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground">Show toast</button>
+    <div className="flex flex-wrap items-center justify-center gap-3">
+      <button
+        type="button"
+        onClick={() =>
+          toast({ title: "Event created", description: "Friday at 5pm" })
+        }
+        className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground"
+      >
+        Create event
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          toast.success({ title: "Saved", description: "Your changes are live." })
+        }
+        className="rounded-lg bg-muted px-4 py-2 text-sm font-medium text-foreground"
+      >
+        Save changes
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          toast({
+            title: "Deleted file",
+            description: "report.pdf",
+            action: { label: "Undo", onClick: () => {} },
+          })
+        }
+        className="rounded-lg bg-muted px-4 py-2 text-sm font-medium text-foreground"
+      >
+        Delete file
+      </button>
       <ToastProvider />
     </div>
   );
@@ -30,7 +60,7 @@ export function ToastDemo() {
 
 ## Installation
 
-<ComponentInstall componentName="Toast" />
+<ComponentInstall name="toast" />
 
 Render a single `<ToastProvider />` near the root of your app, then call `toast()`
 from anywhere. Toasts spring in, auto-dismiss, pause on hover, and can be swiped away.

--- a/apps/docs/content/docs/components/visualizations/scroll-timeline/index.mdx
+++ b/apps/docs/content/docs/components/visualizations/scroll-timeline/index.mdx
@@ -12,7 +12,6 @@ A vertical timeline built for storytelling: a progress line traces down the rail
 
 <Example
   label="Default"
-  fullWidth
   story="visualizations-scroll-timeline"
   code={`import { ScrollTimeline } from "@/components/godui/scroll-timeline";
 

--- a/apps/docs/src/app/globals.css
+++ b/apps/docs/src/app/globals.css
@@ -311,12 +311,35 @@ p.docs-lead {
   z-index: 1;
 }
 
-/* Workbench stage canvas — a hair off the page background so the card reads as
-   a distinct surface (lighter in dark, darker in light) without real contrast.
-   The color lives on a var (see .stage-frame) so the top scrim fades the same
+/* Workbench stage canvas — same dotted grid as ComponentPreview / PreviewCard
+   so the index and every component page share one surface language. The base
+   color sits a hair off the page background (lighter in dark, darker in light)
+   via --workbench-canvas-bg (see .stage-frame) so the top scrim fades the same
    surface. */
 .workbench-canvas {
   background-color: var(--workbench-canvas-bg);
+  background-image: radial-gradient(
+    color-mix(in srgb, var(--color-fd-border) 70%, transparent) 1px,
+    transparent 1px
+  );
+  background-size: 16px 16px;
+}
+
+.workbench-canvas::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(
+    120% 120% at 50% 0%,
+    transparent 60%,
+    color-mix(in srgb, var(--workbench-canvas-bg) 55%, transparent)
+  );
+}
+
+.workbench-canvas > * {
+  position: relative;
+  z-index: 1;
 }
 
 /* Top scrim — fades the card surface (not the page bg) to transparent so the

--- a/apps/docs/src/components/demos/_kit.tsx
+++ b/apps/docs/src/components/demos/_kit.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { forwardRef, type ReactNode } from "react";
+import { cn } from "@/lib/cn";
+
+type MaxWidth = "sm" | "md" | "lg" | "xl" | "2xl" | "3xl" | "none";
+
+const maxWidthClass: Record<MaxWidth, string> = {
+  sm: "max-w-sm",
+  md: "max-w-md",
+  lg: "max-w-lg",
+  xl: "max-w-xl",
+  "2xl": "max-w-2xl",
+  "3xl": "max-w-3xl",
+  none: "",
+};
+
+/**
+ * Center a compact demo in the stage. Use with the default (non-fullWidth)
+ * Example layout — buttons, inputs, cards, small widgets.
+ */
+export function DemoCenter({
+  children,
+  className,
+  max = "none",
+}: {
+  children: ReactNode;
+  className?: string;
+  /** Optional max-width on the centering shell. */
+  max?: MaxWidth;
+}) {
+  return (
+    <div
+      className={cn(
+        "mx-auto flex w-full items-center justify-center",
+        maxWidthClass[max],
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+type MediaAspect = "square" | "video" | "photo" | "portrait" | "wide";
+
+const aspectClass: Record<MediaAspect, string> = {
+  square: "aspect-square",
+  video: "aspect-video",
+  photo: "aspect-[4/3]",
+  portrait: "aspect-[3/4]",
+  wide: "aspect-[5/2]",
+};
+
+/**
+ * Media / image demos — one width + aspect language across compare, accordion,
+ * galleries, and tilt/holo cards. Stays centered (no Example fullWidth).
+ */
+export function DemoMedia({
+  children,
+  className,
+  max = "md",
+  aspect,
+}: {
+  children: ReactNode;
+  className?: string;
+  max?: Exclude<MaxWidth, "none">;
+  aspect?: MediaAspect;
+}) {
+  return (
+    <div
+      className={cn(
+        "mx-auto w-full",
+        maxWidthClass[max],
+        aspect ? aspectClass[aspect] : null,
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+type ScrollPortVariant = "fill" | "framed";
+
+type DemoScrollPortProps = {
+  children: ReactNode;
+  className?: string;
+  /**
+   * `fill` — fills the stage (pair with Example `fullWidth`).
+   * `framed` — fixed-height bordered card, centered (no `fullWidth`).
+   */
+  variant?: ScrollPortVariant;
+  /** Height for the framed variant (CSS length). Default `26rem`. */
+  height?: string;
+  /** Max width for the framed variant. Default `md`. */
+  max?: Exclude<MaxWidth, "none">;
+  /** Sticky cue at the top of the port (e.g. "Scroll to reveal"). */
+  hint?: string;
+};
+
+/**
+ * Scroll viewport for scroll-driven demos. Forward the ref into the component's
+ * `scrollContainer` / `container` prop so the preview stage (not the window)
+ * drives the scrub.
+ */
+function ScrollHint({ hint }: { hint: string }) {
+  return (
+    <div className="sticky top-0 z-10 flex justify-center bg-gradient-to-b from-card/90 to-transparent py-3">
+      <span className="rounded-full border border-border/60 bg-card/80 px-2.5 py-1 font-medium text-[11px] text-muted-foreground backdrop-blur-sm">
+        {hint}
+      </span>
+    </div>
+  );
+}
+
+export const DemoScrollPort = forwardRef<HTMLDivElement, DemoScrollPortProps>(
+  function DemoScrollPort(
+    {
+      children,
+      className,
+      variant = "fill",
+      height = "26rem",
+      max = "md",
+      hint,
+    },
+    ref,
+  ) {
+    if (variant === "framed") {
+      return (
+        <div
+          ref={ref}
+          data-scroll-container
+          className={cn(
+            "relative mx-auto w-full overflow-x-hidden overflow-y-auto rounded-2xl border border-border bg-card/40 [scrollbar-width:thin]",
+            maxWidthClass[max],
+            className,
+          )}
+          style={{ height }}
+        >
+          {hint ? <ScrollHint hint={hint} /> : null}
+          {children}
+        </div>
+      );
+    }
+
+    return (
+      <div
+        ref={ref}
+        data-scroll-container
+        className={cn(
+          "relative h-full min-h-0 w-full overflow-x-hidden overflow-y-auto",
+          className,
+        )}
+      >
+        {hint ? <ScrollHint hint={hint} /> : null}
+        {children}
+      </div>
+    );
+  },
+);
+
+/**
+ * Vertical runway inside a scroll port so scrubbing demos have distance to
+ * travel before / after the focal content.
+ */
+export function DemoScrollRunway({
+  children,
+  className,
+  pad = "lg",
+}: {
+  children: ReactNode;
+  className?: string;
+  pad?: "md" | "lg" | "xl";
+}) {
+  const padClass = {
+    md: "py-[22vh]",
+    lg: "py-[40vh]",
+    xl: "py-[55vh]",
+  }[pad];
+
+  return (
+    <div className={cn("mx-auto w-full", padClass, className)}>{children}</div>
+  );
+}
+
+/**
+ * Full-bleed scene that fills the stage. Pair with Example `fullWidth` —
+ * backgrounds, docks, pointer playgrounds, glass surfaces.
+ */
+export function DemoScene({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "relative flex h-full min-h-0 w-full flex-1 flex-col",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/apps/docs/src/components/demos/beam-draw-demo.tsx
+++ b/apps/docs/src/components/demos/beam-draw-demo.tsx
@@ -2,6 +2,7 @@
 
 import { BeamDraw } from "@godui/components";
 import { useRef } from "react";
+import { DemoScrollPort, DemoScrollRunway } from "@/components/demos/_kit";
 
 // Right-hand nodes, positioned at the y-fractions where the default beams end
 // (40, 150, 250, 360 on the 400-tall viewBox).
@@ -22,13 +23,15 @@ function Chip({ children }: { children: React.ReactNode }) {
 }
 
 export function BeamDrawDemo() {
-  // The preview stage is an inner scroll area, so the beam tracks this container
-  // (not the window) to scrub as you scroll.
+  // Stage-fill scrubber — pair with Example fullWidth.
   const scrollRef = useRef<HTMLDivElement>(null);
 
   return (
-    <div ref={scrollRef} className="h-full w-full overflow-y-auto">
-      <div className="flex min-h-[260vh] flex-col items-center justify-center gap-12 py-[60vh]">
+    <DemoScrollPort ref={scrollRef}>
+      <DemoScrollRunway
+        pad="xl"
+        className="flex min-h-[260vh] flex-col items-center justify-center gap-12"
+      >
         <div className="text-center">
           <h3 className="text-2xl font-bold text-foreground md:text-3xl">
             Your entire stack, connected
@@ -45,15 +48,13 @@ export function BeamDrawDemo() {
             className="absolute inset-0 size-full"
           />
 
-          {/* Core node — the left endpoint the beams fan out from. */}
-          <div className="absolute left-0 top-1/2 flex -translate-y-1/2 items-center gap-2 rounded-xl border border-border bg-background px-4 py-3 shadow-lg">
+          <div className="absolute top-1/2 left-0 flex -translate-y-1/2 items-center gap-2 rounded-xl border border-border bg-background px-4 py-3 shadow-lg">
             <span className="size-2.5 rounded-full bg-primary shadow-[0_0_10px_var(--primary)]" />
-            <span className="text-sm font-semibold text-foreground">
+            <span className="font-semibold text-foreground text-sm">
               API Core
             </span>
           </div>
 
-          {/* Destination nodes at each beam's right endpoint. */}
           {NODES.map((node) => (
             <div
               key={node.label}
@@ -64,7 +65,7 @@ export function BeamDrawDemo() {
             </div>
           ))}
         </div>
-      </div>
-    </div>
+      </DemoScrollRunway>
+    </DemoScrollPort>
   );
 }

--- a/apps/docs/src/components/demos/container-scroll-demo.tsx
+++ b/apps/docs/src/components/demos/container-scroll-demo.tsx
@@ -2,18 +2,14 @@
 
 import { ContainerScroll } from "@godui/components";
 import { useRef } from "react";
+import { DemoScrollPort } from "@/components/demos/_kit";
 
 export function ContainerScrollDemo() {
-  // Scroll-driven, so it needs its own scroll room. Inside the workbench stage
-  // the window never scrolls — give the demo a self-contained scroll frame and
-  // point `scrollContainer` at it so scrolling the preview drives the animation.
+  // Scroll-driven — own scroll room via DemoScrollPort (stage doesn't scroll
+  // the window). Pair with Example fullWidth.
   const ref = useRef<HTMLDivElement>(null);
   return (
-    <div
-      ref={ref}
-      data-scroll-container
-      className="relative h-full w-full overflow-y-auto overflow-x-hidden"
-    >
+    <DemoScrollPort ref={ref}>
       <ContainerScroll
         scrollContainer={ref}
         header={
@@ -29,6 +25,6 @@ export function ContainerScrollDemo() {
       >
         <img src="https://picsum.photos/id/1005/1200/750" alt="Dashboard" />
       </ContainerScroll>
-    </div>
+    </DemoScrollPort>
   );
 }

--- a/apps/docs/src/components/demos/cover-flow-demo.tsx
+++ b/apps/docs/src/components/demos/cover-flow-demo.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { CoverFlow } from "@godui/components";
+import { DemoCenter } from "@/components/demos/_kit";
 
 const COVERS = [
   { title: "Nightfall", artist: "Aurora Grey", img: "1043" },
@@ -29,10 +30,12 @@ function Cover({ title, artist, img }: (typeof COVERS)[number]) {
 
 export function CoverFlowDemo() {
   return (
-    <CoverFlow defaultIndex={2} itemWidth={220} itemHeight={220}>
-      {COVERS.map((c) => (
-        <Cover key={c.title} {...c} />
-      ))}
-    </CoverFlow>
+    <DemoCenter className="w-full">
+      <CoverFlow defaultIndex={2} itemWidth={220} itemHeight={220}>
+        {COVERS.map((c) => (
+          <Cover key={c.title} {...c} />
+        ))}
+      </CoverFlow>
+    </DemoCenter>
   );
 }

--- a/apps/docs/src/components/demos/dock-demo.tsx
+++ b/apps/docs/src/components/demos/dock-demo.tsx
@@ -1,15 +1,7 @@
 "use client";
 
 import { Dock, DockItem } from "@godui/components";
-import {
-  Calendar,
-  Folder,
-  Home,
-  Mail,
-  Search,
-  Settings,
-  Wifi,
-} from "lucide-react";
+import { Calendar, Folder, Home, Mail, Search, Settings } from "lucide-react";
 import type { ComponentType } from "react";
 import { DemoScene } from "@/components/demos/_kit";
 
@@ -30,84 +22,66 @@ const items: Item[] = [
 
 export function DockDemo() {
   return (
-    <DemoScene className="min-h-[380px] overflow-hidden rounded-xl border border-border">
-      {/* Wallpaper */}
-      <div className="absolute inset-0 bg-[linear-gradient(135deg,oklch(0.55_0.18_265),oklch(0.62_0.16_320)_45%,oklch(0.7_0.12_25))]" />
-      <div className="absolute inset-0 bg-[radial-gradient(60%_50%_at_50%_0%,rgba(255,255,255,0.25),transparent)]" />
-
-      {/* Menu bar */}
-      <div className="absolute inset-x-0 top-0 z-10 flex items-center justify-between px-4 py-1.5 font-medium text-white/95 text-xs [text-shadow:0_1px_2px_rgba(0,0,0,0.25)]">
-        <div className="flex items-center gap-4">
-          <span className="font-semibold"></span>
-          <span className="font-semibold">Finder</span>
-          <span className="hidden sm:inline">File</span>
-          <span className="hidden sm:inline">Edit</span>
-          <span className="hidden sm:inline">View</span>
-        </div>
-        <div className="flex items-center gap-3">
-          <Wifi className="size-4" strokeWidth={2} />
-          <Search className="size-4" strokeWidth={2} />
-          <span className="tabular-nums">9:41</span>
-        </div>
-      </div>
-
-      {/* Floating window */}
-      <div className="absolute left-1/2 top-14 w-[78%] max-w-lg -translate-x-1/2 overflow-hidden rounded-xl border border-white/20 bg-card/90 shadow-2xl backdrop-blur-md">
-        <div className="flex items-center gap-2 border-b border-border px-3 py-2">
-          <span className="size-3 rounded-full bg-red-400" />
-          <span className="size-3 rounded-full bg-amber-400" />
-          <span className="size-3 rounded-full bg-emerald-400" />
-          <span className="ml-2 text-xs font-medium text-muted-foreground">
-            Overview
-          </span>
-        </div>
-        <div className="flex">
-          <div className="hidden w-32 shrink-0 space-y-1.5 border-r border-border p-3 sm:block">
-            {["Dashboard", "Projects", "Team", "Reports"].map((s, i) => (
-              <div
-                key={s}
-                className={`rounded-md px-2 py-1 text-xs ${i === 0 ? "bg-primary/10 font-medium text-primary" : "text-muted-foreground"}`}
-              >
-                {s}
-              </div>
-            ))}
+    <DemoScene className="min-h-[380px]">
+      {/* Mid-stage content — padded below workbench title/tools, above the dock */}
+      <div className="relative z-[1] flex min-h-0 flex-1 flex-col items-center justify-center px-5 pt-36 pb-4 sm:pt-40">
+        <div className="w-full max-w-md overflow-hidden rounded-xl border border-border bg-card shadow-2xl">
+          <div className="flex items-center gap-2 border-border border-b px-3 py-2">
+            <span className="size-3 rounded-full bg-red-400" />
+            <span className="size-3 rounded-full bg-amber-400" />
+            <span className="size-3 rounded-full bg-emerald-400" />
+            <span className="ml-2 font-medium text-muted-foreground text-xs">
+              Overview
+            </span>
           </div>
-          <div className="flex-1 space-y-3 p-4">
-            <div className="grid grid-cols-3 gap-2">
-              {[
-                { k: "MRR", v: "$48.2k" },
-                { k: "Users", v: "12,840" },
-                { k: "Churn", v: "1.2%" },
-              ].map((stat) => (
+          <div className="flex">
+            <div className="hidden w-28 shrink-0 space-y-1.5 border-border border-r p-3 sm:block">
+              {["Dashboard", "Projects", "Team", "Reports"].map((s, i) => (
                 <div
-                  key={stat.k}
-                  className="rounded-lg border border-border p-2"
+                  key={s}
+                  className={`rounded-md px-2 py-1 text-xs ${i === 0 ? "bg-primary/10 font-medium text-primary" : "text-muted-foreground"}`}
                 >
-                  <div className="text-[10px] uppercase text-muted-foreground">
-                    {stat.k}
-                  </div>
-                  <div className="text-sm font-semibold tabular-nums text-foreground">
-                    {stat.v}
-                  </div>
+                  {s}
                 </div>
               ))}
             </div>
-            <div className="flex h-16 items-end gap-1.5">
-              {[45, 62, 50, 78, 64, 90, 72, 84].map((h, i) => (
-                <div
-                  // biome-ignore lint/suspicious/noArrayIndexKey: static chart
-                  key={`${h}-${i}`}
-                  className="flex-1 rounded-sm bg-primary/70"
-                  style={{ height: `${h}%` }}
-                />
-              ))}
+            <div className="flex-1 space-y-3 p-4">
+              <div className="grid grid-cols-3 gap-2">
+                {[
+                  { k: "MRR", v: "$48.2k" },
+                  { k: "Users", v: "12,840" },
+                  { k: "Churn", v: "1.2%" },
+                ].map((stat) => (
+                  <div
+                    key={stat.k}
+                    className="rounded-lg border border-border p-2"
+                  >
+                    <div className="text-[10px] text-muted-foreground uppercase">
+                      {stat.k}
+                    </div>
+                    <div className="font-semibold text-foreground text-sm tabular-nums">
+                      {stat.v}
+                    </div>
+                  </div>
+                ))}
+              </div>
+              <div className="flex h-14 items-end gap-1.5">
+                {[45, 62, 50, 78, 64, 90, 72, 84].map((h, i) => (
+                  <div
+                    // biome-ignore lint/suspicious/noArrayIndexKey: static chart
+                    key={`${h}-${i}`}
+                    className="flex-1 rounded-sm bg-primary/70"
+                    style={{ height: `${h}%` }}
+                  />
+                ))}
+              </div>
             </div>
           </div>
         </div>
       </div>
 
       {/* Dock */}
-      <div className="absolute inset-x-0 bottom-4 z-10 flex justify-center px-4">
+      <div className="relative z-10 flex shrink-0 justify-center px-4 pb-5 pt-2">
         <Dock>
           {items.map(({ label, color, Icon }) => (
             <DockItem key={label} label={label}>

--- a/apps/docs/src/components/demos/dock-demo.tsx
+++ b/apps/docs/src/components/demos/dock-demo.tsx
@@ -11,6 +11,7 @@ import {
   Wifi,
 } from "lucide-react";
 import type { ComponentType } from "react";
+import { DemoScene } from "@/components/demos/_kit";
 
 type Item = {
   label: string;
@@ -29,13 +30,13 @@ const items: Item[] = [
 
 export function DockDemo() {
   return (
-    <div className="relative h-full min-h-[380px] w-full overflow-hidden rounded-xl border border-border">
+    <DemoScene className="min-h-[380px] overflow-hidden rounded-xl border border-border">
       {/* Wallpaper */}
       <div className="absolute inset-0 bg-[linear-gradient(135deg,oklch(0.55_0.18_265),oklch(0.62_0.16_320)_45%,oklch(0.7_0.12_25))]" />
       <div className="absolute inset-0 bg-[radial-gradient(60%_50%_at_50%_0%,rgba(255,255,255,0.25),transparent)]" />
 
       {/* Menu bar */}
-      <div className="absolute inset-x-0 top-0 flex items-center justify-between px-4 py-1.5 text-xs font-medium text-white/95 [text-shadow:0_1px_2px_rgba(0,0,0,0.25)]">
+      <div className="absolute inset-x-0 top-0 z-10 flex items-center justify-between px-4 py-1.5 font-medium text-white/95 text-xs [text-shadow:0_1px_2px_rgba(0,0,0,0.25)]">
         <div className="flex items-center gap-4">
           <span className="font-semibold"></span>
           <span className="font-semibold">Finder</span>
@@ -106,7 +107,7 @@ export function DockDemo() {
       </div>
 
       {/* Dock */}
-      <div className="absolute inset-x-0 bottom-4 flex justify-center px-4">
+      <div className="absolute inset-x-0 bottom-4 z-10 flex justify-center px-4">
         <Dock>
           {items.map(({ label, color, Icon }) => (
             <DockItem key={label} label={label}>
@@ -115,6 +116,6 @@ export function DockDemo() {
           ))}
         </Dock>
       </div>
-    </div>
+    </DemoScene>
   );
 }

--- a/apps/docs/src/components/demos/hero-parallax-demo.tsx
+++ b/apps/docs/src/components/demos/hero-parallax-demo.tsx
@@ -2,6 +2,7 @@
 
 import { HeroParallax } from "@godui/components";
 import { useRef } from "react";
+import { DemoScrollPort } from "@/components/demos/_kit";
 
 const PRODUCTS = [
   "1015",
@@ -26,18 +27,12 @@ const PRODUCTS = [
 }));
 
 export function HeroParallaxDemo() {
-  // The parallax maps scroll progress onto the plane, so it needs its own tall
-  // scroll room. Inside the workbench stage the window never scrolls, so give
-  // the demo a self-contained scroll frame and point `scrollContainer` at it —
-  // now scrolling the preview drives the animation.
+  // Parallax maps scroll progress onto the plane — DemoScrollPort gives it a
+  // self-contained runway. Pair with Example fullWidth.
   const ref = useRef<HTMLDivElement>(null);
   return (
-    <div
-      ref={ref}
-      data-scroll-container
-      className="relative h-full w-full overflow-y-auto overflow-x-hidden"
-    >
+    <DemoScrollPort ref={ref}>
       <HeroParallax products={PRODUCTS} scrollContainer={ref} />
-    </div>
+    </DemoScrollPort>
   );
 }

--- a/apps/docs/src/components/demos/holographic-card-demo.tsx
+++ b/apps/docs/src/components/demos/holographic-card-demo.tsx
@@ -2,30 +2,33 @@
 
 import { HolographicCard } from "@godui/components";
 import { Sparkles } from "lucide-react";
+import { DemoCenter } from "@/components/demos/_kit";
 
 export function HolographicCardDemo() {
   return (
-    <HolographicCard variant="rainbow" className="h-96 w-72 p-6">
-      <div className="flex items-center justify-between">
-        <span className="text-xs font-medium uppercase tracking-widest text-white/60">
-          Founding Member
-        </span>
-        <span className="flex size-8 items-center justify-center rounded-lg bg-white/15 text-white ring-1 ring-white/20 backdrop-blur">
-          <Sparkles className="size-4" />
-        </span>
-      </div>
-      <div className="mt-32">
-        <h3 className="text-2xl font-semibold tracking-tight text-white">
-          GodUI
-        </h3>
-        <p className="mt-2 text-sm leading-relaxed text-white/70">
-          Move your pointer across the card — the foil, glare, and glitter catch
-          the light as it tilts.
-        </p>
-      </div>
-      <div className="mt-6 font-mono text-xs tracking-widest text-white/50">
-        NO. 001 / 500
-      </div>
-    </HolographicCard>
+    <DemoCenter>
+      <HolographicCard variant="rainbow" className="h-96 w-72 p-6">
+        <div className="flex items-center justify-between">
+          <span className="font-medium text-white/60 text-xs uppercase tracking-widest">
+            Founding Member
+          </span>
+          <span className="flex size-8 items-center justify-center rounded-lg bg-white/15 text-white ring-1 ring-white/20 backdrop-blur">
+            <Sparkles className="size-4" />
+          </span>
+        </div>
+        <div className="mt-32">
+          <h3 className="font-semibold text-2xl text-white tracking-tight">
+            GodUI
+          </h3>
+          <p className="mt-2 text-sm text-white/70 leading-relaxed">
+            Move your pointer across the card — the foil, glare, and glitter
+            catch the light as it tilts.
+          </p>
+        </div>
+        <div className="mt-6 font-mono text-white/50 text-xs tracking-widest">
+          NO. 001 / 500
+        </div>
+      </HolographicCard>
+    </DemoCenter>
   );
 }

--- a/apps/docs/src/components/demos/image-accordion-demo.tsx
+++ b/apps/docs/src/components/demos/image-accordion-demo.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ImageAccordion } from "@godui/components";
+import { DemoMedia } from "@/components/demos/_kit";
 
 const PANELS = [
   {
@@ -32,10 +33,8 @@ const PANELS = [
 
 export function ImageAccordionDemo() {
   return (
-    <ImageAccordion
-      panels={PANELS}
-      className="w-full max-w-2xl"
-      height="24rem"
-    />
+    <DemoMedia max="2xl" className="h-[24rem]">
+      <ImageAccordion panels={PANELS} className="size-full" height="24rem" />
+    </DemoMedia>
   );
 }

--- a/apps/docs/src/components/demos/image-compare-demo.tsx
+++ b/apps/docs/src/components/demos/image-compare-demo.tsx
@@ -1,31 +1,32 @@
 "use client";
 
 import { ImageCompare } from "@godui/components";
+import { DemoMedia } from "@/components/demos/_kit";
 
 const SRC_A = "https://picsum.photos/id/1015/800/600";
 const SRC_B = "https://picsum.photos/id/1025/800/600";
 
 export function ImageCompareDemo() {
   return (
-    <div className="aspect-[4/3] w-full max-w-md">
+    <DemoMedia max="md" aspect="photo">
       <ImageCompare
         beforeLabel="Color"
         afterLabel="B&W"
         before={<img src={SRC_A} alt="Color" />}
         after={<img src={SRC_A} alt="Black and white" className="grayscale" />}
       />
-    </div>
+    </DemoMedia>
   );
 }
 
 export function ImageCompareVerticalDemo() {
   return (
-    <div className="aspect-[4/3] w-full max-w-md">
+    <DemoMedia max="md" aspect="photo">
       <ImageCompare
         orientation="vertical"
         before={<img src={SRC_B} alt="Color" />}
         after={<img src={SRC_B} alt="Black and white" className="grayscale" />}
       />
-    </div>
+    </DemoMedia>
   );
 }

--- a/apps/docs/src/components/demos/inertia-gallery-demo.tsx
+++ b/apps/docs/src/components/demos/inertia-gallery-demo.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { InertiaGallery } from "@godui/components";
+import { DemoScene } from "@/components/demos/_kit";
 
 const SHOTS = [
   { label: "Dune", img: "1018" },
@@ -20,7 +21,7 @@ function Shot({ label, img }: (typeof SHOTS)[number]) {
         className="absolute inset-0 size-full object-cover"
         draggable={false}
       />
-      <span className="absolute bottom-3 left-3 rounded-md bg-black/50 px-2 py-0.5 text-xs font-medium text-white backdrop-blur">
+      <span className="absolute bottom-3 left-3 rounded-md bg-black/50 px-2 py-0.5 font-medium text-white text-xs backdrop-blur">
         {label}
       </span>
     </div>
@@ -28,13 +29,14 @@ function Shot({ label, img }: (typeof SHOTS)[number]) {
 }
 
 export function InertiaGalleryDemo() {
+  // Full-bleed horizontal scene — pair with Example fullWidth.
   return (
-    <div className="flex w-full flex-1 flex-col justify-center">
+    <DemoScene className="justify-center">
       <InertiaGallery snap defaultIndex={2} itemWidth={200} gap={24}>
         {SHOTS.map((s) => (
           <Shot key={s.label} {...s} />
         ))}
       </InertiaGallery>
-    </div>
+    </DemoScene>
   );
 }

--- a/apps/docs/src/components/demos/liquid-image-demo.tsx
+++ b/apps/docs/src/components/demos/liquid-image-demo.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { LiquidImage } from "@godui/components";
+import { DemoMedia } from "@/components/demos/_kit";
 
 const IMAGES = [
   { src: "https://picsum.photos/id/1018/640/640", alt: "Mountain landscape" },
@@ -10,15 +11,17 @@ const IMAGES = [
 
 export function LiquidImageDemo() {
   return (
-    <div className="grid w-full max-w-3xl grid-cols-1 gap-5 sm:grid-cols-3">
-      {IMAGES.map((img) => (
-        <LiquidImage
-          key={img.src}
-          src={img.src}
-          alt={img.alt}
-          className="aspect-square w-full shadow-lg"
-        />
-      ))}
-    </div>
+    <DemoMedia max="3xl">
+      <div className="grid w-full grid-cols-1 gap-5 sm:grid-cols-3">
+        {IMAGES.map((img) => (
+          <LiquidImage
+            key={img.src}
+            src={img.src}
+            alt={img.alt}
+            className="aspect-square w-full shadow-lg"
+          />
+        ))}
+      </div>
+    </DemoMedia>
   );
 }

--- a/apps/docs/src/components/demos/magnetic-button-demo.tsx
+++ b/apps/docs/src/components/demos/magnetic-button-demo.tsx
@@ -3,40 +3,29 @@
 import { MagneticButton } from "@godui/components";
 import { ArrowRight, Star } from "lucide-react";
 
+/** Default stage — one primary + one secondary product CTA. */
 export function MagneticButtonDemo() {
   return (
-    <div className="flex flex-col items-center gap-10">
-      <div className="flex flex-wrap items-center justify-center gap-5">
-        <MagneticButton size="lg" range={36}>
-          Get started
-          <ArrowRight className="size-4" strokeWidth={2.5} />
-        </MagneticButton>
-        <MagneticButton
-          variant="outline"
-          size="lg"
-          range={36}
-          onClick={() =>
-            window.open(
-              "https://github.com/LucasBassetti/godui",
-              "_blank",
-              "noopener,noreferrer",
-            )
-          }
-        >
-          <Star className="size-4" strokeWidth={2.5} />
-          Star on GitHub
-        </MagneticButton>
-      </div>
-
-      <div className="flex flex-col items-center gap-2.5">
-        <MagneticButton variant="secondary" size="lg" range={44} staticLabel>
-          Label stays centered
-        </MagneticButton>
-        <span className="text-xs text-muted-foreground">
-          <code className="font-mono">staticLabel</code> — label rides with the
-          button, no parallax drift
-        </span>
-      </div>
+    <div className="flex flex-wrap items-center justify-center gap-5">
+      <MagneticButton size="lg" range={36}>
+        Get started
+        <ArrowRight className="size-4" strokeWidth={2.5} />
+      </MagneticButton>
+      <MagneticButton
+        variant="outline"
+        size="lg"
+        range={36}
+        onClick={() =>
+          window.open(
+            "https://github.com/LucasBassetti/godui",
+            "_blank",
+            "noopener,noreferrer",
+          )
+        }
+      >
+        <Star className="size-4" strokeWidth={2.5} />
+        Star on GitHub
+      </MagneticButton>
     </div>
   );
 }

--- a/apps/docs/src/components/demos/morph-gallery-demo.tsx
+++ b/apps/docs/src/components/demos/morph-gallery-demo.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { MorphGallery } from "@godui/components";
+import { DemoMedia } from "@/components/demos/_kit";
 
 const PHOTOS = [
   { id: "1002", caption: "Coastline at dawn" },
@@ -16,14 +17,16 @@ const PHOTOS = [
 
 export function MorphGalleryDemo() {
   return (
-    <MorphGallery
-      className="mx-auto max-w-lg"
-      columns={3}
-      items={PHOTOS.map((p) => ({
-        src: `https://picsum.photos/id/${p.id}/900/900`,
-        alt: p.caption,
-        caption: p.caption,
-      }))}
-    />
+    <DemoMedia max="lg">
+      <MorphGallery
+        className="w-full"
+        columns={3}
+        items={PHOTOS.map((p) => ({
+          src: `https://picsum.photos/id/${p.id}/900/900`,
+          alt: p.caption,
+          caption: p.caption,
+        }))}
+      />
+    </DemoMedia>
   );
 }

--- a/apps/docs/src/components/demos/orbit-carousel-demo.tsx
+++ b/apps/docs/src/components/demos/orbit-carousel-demo.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { OrbitCarousel } from "@godui/components";
+import { DemoCenter } from "@/components/demos/_kit";
 
 const CARDS = [
   { title: "Aurora", img: "1041" },
@@ -28,10 +29,12 @@ function OrbitCard({ title, img }: (typeof CARDS)[number]) {
 
 export function OrbitCarouselDemo() {
   return (
-    <OrbitCarousel defaultIndex={2} radius={230} angleStep={26}>
-      {CARDS.map((c) => (
-        <OrbitCard key={c.title} {...c} />
-      ))}
-    </OrbitCarousel>
+    <DemoCenter className="w-full">
+      <OrbitCarousel defaultIndex={2} radius={230} angleStep={26}>
+        {CARDS.map((c) => (
+          <OrbitCard key={c.title} {...c} />
+        ))}
+      </OrbitCarousel>
+    </DemoCenter>
   );
 }

--- a/apps/docs/src/components/demos/scroll-progress-demo.tsx
+++ b/apps/docs/src/components/demos/scroll-progress-demo.tsx
@@ -2,25 +2,28 @@
 
 import { ScrollProgress } from "@godui/components";
 import * as React from "react";
+import { DemoScrollPort } from "@/components/demos/_kit";
 
 const filler = Array.from({ length: 14 });
 
 function ScrollBox({ variant }: { variant: "bar" | "circle" }) {
   const ref = React.useRef<HTMLDivElement>(null);
   return (
-    <div
+    <DemoScrollPort
       ref={ref}
-      data-scroll-container
-      className="relative h-72 w-full max-w-md overflow-y-auto rounded-xl border border-border bg-card"
+      variant="framed"
+      height="18rem"
+      max="md"
+      className="rounded-xl bg-card"
     >
       {variant === "bar" && <ScrollProgress container={ref} />}
       <div className="space-y-4 p-6">
-        <p className="text-sm font-medium text-foreground">Scroll this panel</p>
+        <p className="font-medium text-foreground text-sm">Scroll this panel</p>
         {filler.map((_, i) => (
           <p
             // biome-ignore lint/suspicious/noArrayIndexKey: static filler copy
             key={i}
-            className="text-sm leading-relaxed text-muted-foreground"
+            className="text-muted-foreground text-sm leading-relaxed"
           >
             The progress indicator tracks this scroll container. Keep scrolling
             to watch it fill — paragraph {i + 1} of {filler.length}.
@@ -35,7 +38,7 @@ function ScrollBox({ variant }: { variant: "bar" | "circle" }) {
           position="bottom-left"
         />
       )}
-    </div>
+    </DemoScrollPort>
   );
 }
 

--- a/apps/docs/src/components/demos/scroll-reveal-demo.tsx
+++ b/apps/docs/src/components/demos/scroll-reveal-demo.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { ScrollReveal } from "@godui/components";
+import { DemoScrollPort, DemoScrollRunway } from "@/components/demos/_kit";
+
+const GRID = ["Plan", "Build", "Ship", "Measure", "Iterate", "Scale"];
+
+export function ScrollRevealDemo() {
+  // Framed mini-scroller so the reveal fires as content scrolls into the stage.
+  return (
+    <DemoScrollPort
+      variant="framed"
+      height="26rem"
+      max="lg"
+      hint="Scroll to reveal"
+    >
+      <DemoScrollRunway pad="xl" className="flex flex-col items-center px-6">
+        <ScrollReveal>
+          <div className="rounded-xl border border-border bg-card p-8 font-semibold text-foreground text-lg shadow-sm">
+            I reveal on scroll
+          </div>
+        </ScrollReveal>
+      </DemoScrollRunway>
+    </DemoScrollPort>
+  );
+}
+
+export function ScrollRevealStaggerDemo() {
+  return (
+    <DemoScrollPort
+      variant="framed"
+      height="26rem"
+      max="lg"
+      hint="Scroll to reveal"
+    >
+      <DemoScrollRunway pad="xl" className="px-6">
+        <div className="grid grid-cols-3 gap-3">
+          {GRID.map((item, i) => (
+            <ScrollReveal key={item} delay={i * 0.1}>
+              <div className="rounded-xl border border-border bg-card p-5 font-medium text-foreground text-sm shadow-sm">
+                {item}
+              </div>
+            </ScrollReveal>
+          ))}
+        </div>
+      </DemoScrollRunway>
+    </DemoScrollPort>
+  );
+}
+
+export function ScrollRevealLeftDemo() {
+  return (
+    <DemoScrollPort
+      variant="framed"
+      height="26rem"
+      max="lg"
+      hint="Scroll to reveal"
+    >
+      <DemoScrollRunway pad="xl" className="flex flex-col items-center px-6">
+        <ScrollReveal direction="left" distance={80} blur={false}>
+          <div className="rounded-xl border border-border bg-card p-8 font-semibold text-foreground text-lg shadow-sm">
+            Slides in from the left
+          </div>
+        </ScrollReveal>
+      </DemoScrollRunway>
+    </DemoScrollPort>
+  );
+}

--- a/apps/docs/src/components/demos/scroll-stack-demo.tsx
+++ b/apps/docs/src/components/demos/scroll-stack-demo.tsx
@@ -2,6 +2,7 @@
 
 import { ScrollStack } from "@godui/components";
 import { BarChart3, GitBranch, Rocket } from "lucide-react";
+import { DemoCenter } from "@/components/demos/_kit";
 
 const CARDS = [
   {
@@ -31,39 +32,44 @@ const CARDS = [
 ];
 
 export function ScrollStackDemo() {
+  // Component-owned scroller — centered framed card (no Example fullWidth).
   return (
-    <ScrollStack
-      height="30rem"
-      pinTop="10%"
-      className="w-full max-w-md rounded-2xl border border-border bg-muted/30"
-    >
-      {CARDS.map(({ icon: Icon, ...c }) => (
-        <article
-          key={c.title}
-          className="flex w-full flex-col overflow-hidden rounded-2xl border border-border bg-card p-8 shadow-[0_24px_60px_-24px_rgba(0,0,0,0.45)]"
-        >
-          <div className="flex items-center gap-3">
-            <span className="grid size-9 place-items-center rounded-xl bg-primary/10 text-primary ring-1 ring-primary/15 ring-inset">
-              <Icon className="size-[18px]" strokeWidth={2} />
-            </span>
-            <span className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-              {c.eyebrow}
-            </span>
-          </div>
-          <h3 className="mt-6 text-2xl font-semibold tracking-tight text-foreground">
-            {c.title}
-          </h3>
-          <p className="mt-2.5 text-[15px] leading-relaxed text-muted-foreground">
-            {c.body}
-          </p>
-          <div className="mt-7 flex items-baseline gap-2 border-t border-border pt-5">
-            <span className="text-2xl font-semibold tracking-tight tabular-nums text-foreground">
-              {c.stat}
-            </span>
-            <span className="text-sm text-muted-foreground">{c.statLabel}</span>
-          </div>
-        </article>
-      ))}
-    </ScrollStack>
+    <DemoCenter max="md">
+      <ScrollStack
+        height="30rem"
+        pinTop="10%"
+        className="w-full rounded-2xl border border-border bg-muted/30"
+      >
+        {CARDS.map(({ icon: Icon, ...c }) => (
+          <article
+            key={c.title}
+            className="flex w-full flex-col overflow-hidden rounded-2xl border border-border bg-card p-8 shadow-[0_24px_60px_-24px_rgba(0,0,0,0.45)]"
+          >
+            <div className="flex items-center gap-3">
+              <span className="grid size-9 place-items-center rounded-xl bg-primary/10 text-primary ring-1 ring-primary/15 ring-inset">
+                <Icon className="size-[18px]" strokeWidth={2} />
+              </span>
+              <span className="font-semibold text-muted-foreground text-xs uppercase tracking-[0.14em]">
+                {c.eyebrow}
+              </span>
+            </div>
+            <h3 className="mt-6 font-semibold text-2xl text-foreground tracking-tight">
+              {c.title}
+            </h3>
+            <p className="mt-2.5 text-[15px] text-muted-foreground leading-relaxed">
+              {c.body}
+            </p>
+            <div className="mt-7 flex items-baseline gap-2 border-border border-t pt-5">
+              <span className="font-semibold text-2xl text-foreground tabular-nums tracking-tight">
+                {c.stat}
+              </span>
+              <span className="text-muted-foreground text-sm">
+                {c.statLabel}
+              </span>
+            </div>
+          </article>
+        ))}
+      </ScrollStack>
+    </DemoCenter>
   );
 }

--- a/apps/docs/src/components/demos/scroll-text-reveal-demo.tsx
+++ b/apps/docs/src/components/demos/scroll-text-reveal-demo.tsx
@@ -2,26 +2,32 @@
 
 import { ScrollTextReveal } from "@godui/components";
 import { useRef } from "react";
+import { DemoScrollPort, DemoScrollRunway } from "@/components/demos/_kit";
 
 export function ScrollTextRevealDemo() {
-  // The preview stage is an inner scroll area, so the reveal tracks this
-  // container (not the window). Vertical runway lets each word scrub into focus.
+  // Framed mini-scroller — centered (no Example fullWidth).
   const scrollRef = useRef<HTMLDivElement>(null);
 
   return (
-    <div ref={scrollRef} className="h-[26rem] w-full overflow-y-auto">
-      <div className="mx-auto max-w-lg px-6 py-[55vh]">
+    <DemoScrollPort
+      ref={scrollRef}
+      variant="framed"
+      height="26rem"
+      max="lg"
+      hint="Scroll to reveal"
+    >
+      <DemoScrollRunway pad="xl" className="max-w-lg px-6">
         <ScrollTextReveal
           container={scrollRef}
           as="p"
-          className="text-balance text-center text-2xl font-semibold leading-relaxed text-foreground sm:text-3xl"
+          className="text-balance text-center font-semibold text-2xl text-foreground leading-relaxed sm:text-3xl"
         >
           Great interfaces read like a sentence — one idea resolving into the
           next. As you scroll, each word settles into focus, pacing attention
           exactly where it belongs.
         </ScrollTextReveal>
-      </div>
-    </div>
+      </DemoScrollRunway>
+    </DemoScrollPort>
   );
 }
 
@@ -29,19 +35,25 @@ export function ScrollTextRevealKeepDemo() {
   const scrollRef = useRef<HTMLDivElement>(null);
 
   return (
-    <div ref={scrollRef} className="h-[26rem] w-full overflow-y-auto">
-      <div className="mx-auto max-w-lg px-6 py-[55vh]">
+    <DemoScrollPort
+      ref={scrollRef}
+      variant="framed"
+      height="26rem"
+      max="lg"
+      hint="Scroll to reveal"
+    >
+      <DemoScrollRunway pad="xl" className="max-w-lg px-6">
         <ScrollTextReveal
           container={scrollRef}
           as="p"
           keepRevealed
-          className="text-balance text-center text-2xl font-semibold leading-relaxed text-foreground sm:text-3xl"
+          className="text-balance text-center font-semibold text-2xl text-foreground leading-relaxed sm:text-3xl"
         >
           With keepRevealed, each word latches at full presence once it lands —
           so the paragraph stays lit as you scroll back up instead of dimming
           again.
         </ScrollTextReveal>
-      </div>
-    </div>
+      </DemoScrollRunway>
+    </DemoScrollPort>
   );
 }

--- a/apps/docs/src/components/demos/scroll-timeline-demo.tsx
+++ b/apps/docs/src/components/demos/scroll-timeline-demo.tsx
@@ -2,67 +2,68 @@
 
 import { ScrollTimeline } from "@godui/components";
 import { useRef } from "react";
+import { DemoScrollPort, DemoScrollRunway } from "@/components/demos/_kit";
 
 export function ScrollTimelineDemo() {
-  // The preview stage is an inner scroll area, so the timeline tracks this
-  // container (not the window). Extra vertical runway gives the sticky rail real
-  // scroll distance to trace.
+  // Framed mini-scroller — centered on the stage (no Example fullWidth).
   const scrollRef = useRef<HTMLDivElement>(null);
 
   return (
-    <div className="flex h-full w-full items-center justify-center p-4 sm:p-8">
-      <div
-        ref={scrollRef}
-        className="h-full max-h-[34rem] w-full max-w-3xl overflow-y-auto rounded-2xl border border-border bg-card/40 px-4 [scrollbar-width:thin] sm:px-8"
-      >
-        <div className="py-[22vh]">
-          <ScrollTimeline
-            container={scrollRef}
-            data={[
-              {
-                date: "2021",
-                title: "The first commit",
-                content: (
-                  <p className="text-sm text-muted-foreground md:text-base">
-                    A single component and a big idea — a design system that
-                    feels alive, not templated.
-                  </p>
-                ),
-              },
-              {
-                date: "2023",
-                title: "Ten thousand stars",
-                content: (
-                  <p className="text-sm text-muted-foreground md:text-base">
-                    The community took over. Contributions poured in and the
-                    library tripled in a single quarter.
-                  </p>
-                ),
-              },
-              {
-                date: "2025",
-                title: "One hundred components",
-                content: (
-                  <p className="text-sm text-muted-foreground md:text-base">
-                    From buttons to WebGL globes, every surface got the same
-                    obsessive motion polish.
-                  </p>
-                ),
-              },
-              {
-                date: "Today",
-                title: "Just getting started",
-                content: (
-                  <p className="text-sm text-muted-foreground md:text-base">
-                    Scroll back up and watch the line trace your journey. The
-                    next chapter is yours to write.
-                  </p>
-                ),
-              },
-            ]}
-          />
-        </div>
-      </div>
-    </div>
+    <DemoScrollPort
+      ref={scrollRef}
+      variant="framed"
+      height="34rem"
+      max="3xl"
+      hint="Scroll the timeline"
+      className="px-4 sm:px-8"
+    >
+      <DemoScrollRunway pad="md">
+        <ScrollTimeline
+          container={scrollRef}
+          data={[
+            {
+              date: "2021",
+              title: "The first commit",
+              content: (
+                <p className="text-muted-foreground text-sm md:text-base">
+                  A single component and a big idea — a design system that feels
+                  alive, not templated.
+                </p>
+              ),
+            },
+            {
+              date: "2023",
+              title: "Ten thousand stars",
+              content: (
+                <p className="text-muted-foreground text-sm md:text-base">
+                  The community took over. Contributions poured in and the
+                  library tripled in a single quarter.
+                </p>
+              ),
+            },
+            {
+              date: "2025",
+              title: "One hundred components",
+              content: (
+                <p className="text-muted-foreground text-sm md:text-base">
+                  From buttons to WebGL globes, every surface got the same
+                  obsessive motion polish.
+                </p>
+              ),
+            },
+            {
+              date: "Today",
+              title: "Just getting started",
+              content: (
+                <p className="text-muted-foreground text-sm md:text-base">
+                  Scroll back up and watch the line trace your journey. The next
+                  chapter is yours to write.
+                </p>
+              ),
+            },
+          ]}
+        />
+      </DemoScrollRunway>
+    </DemoScrollPort>
   );
 }

--- a/apps/docs/src/components/demos/sticky-scroll-demo.tsx
+++ b/apps/docs/src/components/demos/sticky-scroll-demo.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { StickyScroll, type StickyScrollItem } from "@godui/components";
+import { DemoCenter } from "@/components/demos/_kit";
 
 const ITEMS: StickyScrollItem[] = [
   {
@@ -8,7 +9,7 @@ const ITEMS: StickyScrollItem[] = [
     description:
       "Cursors, comments, and presence keep the whole team on the same page.",
     content: (
-      <div className="flex size-full items-center justify-center bg-gradient-to-br from-primary/20 to-primary/5 text-2xl font-semibold text-foreground">
+      <div className="flex size-full items-center justify-center bg-gradient-to-br from-primary/20 to-primary/5 font-semibold text-2xl text-foreground">
         Collaborate
       </div>
     ),
@@ -17,7 +18,7 @@ const ITEMS: StickyScrollItem[] = [
     title: "Ship with confidence",
     description: "Preview every change and roll out when it feels right.",
     content: (
-      <div className="flex size-full items-center justify-center bg-gradient-to-br from-primary/30 to-transparent text-2xl font-semibold text-foreground">
+      <div className="flex size-full items-center justify-center bg-gradient-to-br from-primary/30 to-transparent font-semibold text-2xl text-foreground">
         Ship
       </div>
     ),
@@ -26,7 +27,7 @@ const ITEMS: StickyScrollItem[] = [
     title: "Scale calmly",
     description: "Infrastructure that grows with you, never against you.",
     content: (
-      <div className="flex size-full items-center justify-center bg-gradient-to-br from-primary/10 to-primary/25 text-2xl font-semibold text-foreground">
+      <div className="flex size-full items-center justify-center bg-gradient-to-br from-primary/10 to-primary/25 font-semibold text-2xl text-foreground">
         Scale
       </div>
     ),
@@ -34,5 +35,10 @@ const ITEMS: StickyScrollItem[] = [
 ];
 
 export function StickyScrollDemo() {
-  return <StickyScroll items={ITEMS} className="my-auto" />;
+  // Component-owned framed scroller — centered (no Example fullWidth).
+  return (
+    <DemoCenter max="none" className="max-w-5xl">
+      <StickyScroll items={ITEMS} className="w-full" />
+    </DemoCenter>
+  );
 }

--- a/apps/docs/src/components/demos/three-d-marquee-demo.tsx
+++ b/apps/docs/src/components/demos/three-d-marquee-demo.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ThreeDMarquee } from "@godui/components";
+import { DemoMedia } from "@/components/demos/_kit";
 
 const IMAGES = [
   "1015",
@@ -22,9 +23,10 @@ const IMAGES = [
 ].map((id) => `https://picsum.photos/id/${id}/400/400`);
 
 export function ThreeDMarqueeDemo() {
+  // Image showcase — centered media band (no Example fullWidth).
   return (
-    <div className="mx-auto my-auto h-[26rem] w-full max-w-2xl">
+    <DemoMedia max="2xl" className="h-[26rem]">
       <ThreeDMarquee images={IMAGES} />
-    </div>
+    </DemoMedia>
   );
 }

--- a/apps/docs/src/components/demos/tilt-card-demo.tsx
+++ b/apps/docs/src/components/demos/tilt-card-demo.tsx
@@ -2,23 +2,26 @@
 
 import { TiltCard } from "@godui/components";
 import { Sparkles } from "lucide-react";
+import { DemoCenter } from "@/components/demos/_kit";
 
 export function TiltCardDemo() {
   return (
-    <TiltCard className="w-72 p-6">
-      <div className="flex size-10 items-center justify-center rounded-xl bg-primary text-primary-foreground shadow-sm">
-        <Sparkles className="size-5" />
-      </div>
-      <h3 className="mt-4 text-lg font-semibold text-foreground">
-        Designed in 3D
-      </h3>
-      <p className="mt-2 text-sm text-muted-foreground">
-        Move your pointer across the card — it tilts toward you with parallax
-        depth and a specular glare that tracks the cursor.
-      </p>
-      <div className="mt-5 inline-flex rounded-lg bg-accent px-3 py-1.5 text-xs font-medium text-accent-foreground">
-        Hover me
-      </div>
-    </TiltCard>
+    <DemoCenter>
+      <TiltCard className="w-72 p-6">
+        <div className="flex size-10 items-center justify-center rounded-xl bg-primary text-primary-foreground shadow-sm">
+          <Sparkles className="size-5" />
+        </div>
+        <h3 className="mt-4 font-semibold text-foreground text-lg">
+          Designed in 3D
+        </h3>
+        <p className="mt-2 text-muted-foreground text-sm">
+          Move your pointer across the card — it tilts toward you with parallax
+          depth and a specular glare that tracks the cursor.
+        </p>
+        <div className="mt-5 inline-flex rounded-lg bg-accent px-3 py-1.5 font-medium text-accent-foreground text-xs">
+          Hover me
+        </div>
+      </TiltCard>
+    </DemoCenter>
   );
 }

--- a/apps/docs/src/components/demos/toast-demo.tsx
+++ b/apps/docs/src/components/demos/toast-demo.tsx
@@ -4,15 +4,15 @@ import { ToastProvider, toast } from "@godui/components";
 
 export function ToastDemo() {
   return (
-    <div className="flex flex-wrap gap-3">
+    <div className="flex flex-wrap items-center justify-center gap-3">
       <button
         type="button"
         onClick={() =>
           toast({ title: "Event created", description: "Friday at 5pm" })
         }
-        className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground"
+        className="rounded-lg bg-primary px-4 py-2 font-medium text-primary-foreground text-sm"
       >
-        Show toast
+        Create event
       </button>
       <button
         type="button"
@@ -22,9 +22,9 @@ export function ToastDemo() {
             description: "Your changes are live.",
           })
         }
-        className="rounded-lg bg-muted px-4 py-2 text-sm font-medium text-foreground"
+        className="rounded-lg bg-muted px-4 py-2 font-medium text-foreground text-sm"
       >
-        Success
+        Save changes
       </button>
       <button
         type="button"
@@ -35,9 +35,9 @@ export function ToastDemo() {
             action: { label: "Undo", onClick: () => {} },
           })
         }
-        className="rounded-lg bg-muted px-4 py-2 text-sm font-medium text-foreground"
+        className="rounded-lg bg-muted px-4 py-2 font-medium text-foreground text-sm"
       >
-        With action
+        Delete file
       </button>
       <ToastProvider />
     </div>

--- a/apps/docs/src/components/workbench/example.tsx
+++ b/apps/docs/src/components/workbench/example.tsx
@@ -15,8 +15,13 @@ export type ExampleProps = {
    */
   story?: string;
   /**
-   * When true the demo fills the stage edge-to-edge instead of sitting centered
-   * in a padded canvas. Use for full-bleed UI (docks, nav bars, heroes).
+   * Stage layout mode:
+   * - `false` (default) — padded canvas, demo centered. Use for buttons,
+   *   inputs, cards, image/media demos, and framed mini-scrollers.
+   * - `true` — edge-to-edge. Use for backgrounds, docks, pointer playgrounds,
+   *   and stage-fill scroll ports (`DemoScrollPort variant="fill"` /
+   *   `DemoScene`). Do **not** nest `max-w-*` under fullWidth unless the demo
+   *   intentionally builds an inset scene.
    */
   fullWidth?: boolean;
 };
@@ -26,6 +31,10 @@ export type ExampleProps = {
  * own — <Workbench> reads its props (and `children` as the live demo), turning
  * each <Example> into a stage tab. Kept as a stable module identity so
  * `child.type === Example` matches across the server-MDX → client boundary.
+ *
+ * Structure rule: put every stage variant as an `<Example label="…">` — never
+ * wrap them in `##` headings before Installation (headings land in the Docs
+ * drawer, not as stage chrome).
  */
 export function Example(_props: ExampleProps): null {
   return null;

--- a/apps/docs/src/components/workbench/stage.tsx
+++ b/apps/docs/src/components/workbench/stage.tsx
@@ -9,8 +9,14 @@ export type StageView = "desktop" | "mobile";
 
 /**
  * The live preview stage: a dotted-grid canvas that renders the active example.
- * `bg` swaps only the canvas backdrop (light / dark / tinted) — it never touches
- * the site theme, so the demo keeps rendering in the real theme.
+ *
+ * Layout contract:
+ * - default — padded, children centered (buttons, inputs, media, framed scroll)
+ * - `fullWidth` — edge-to-edge, no pad; demo owns the surface (backgrounds,
+ *   stage-fill scroll ports, docks). Overflow is clipped so nested scrollports
+ *   don't fight the stage.
+ *
+ * `bg` swaps only the canvas backdrop hint — it never touches the site theme.
  */
 export function Stage({
   children,
@@ -29,7 +35,8 @@ export function Stage({
     <div
       data-bg={bg}
       className={cn(
-        "workbench-canvas relative flex h-full w-full flex-col items-center justify-center overflow-auto",
+        "workbench-canvas relative flex h-full min-h-0 w-full flex-col items-center justify-center",
+        fullWidth ? "overflow-hidden" : "overflow-auto",
         view === "mobile" ? "p-6" : fullWidth ? "p-0" : "p-6 md:p-12",
       )}
     >
@@ -43,7 +50,7 @@ export function Stage({
           className={cn(
             "flex w-full max-w-full",
             fullWidth
-              ? "min-h-full flex-1 flex-col self-stretch"
+              ? "h-full min-h-0 flex-1 flex-col self-stretch"
               : "items-center justify-center",
           )}
         >

--- a/apps/docs/src/components/workbench/workbench-client.tsx
+++ b/apps/docs/src/components/workbench/workbench-client.tsx
@@ -332,12 +332,12 @@ function WorkbenchInner({
                 onSelect={selectExample}
               />
             </div>
-            {/* Desktop: a segmented tab strip. Few variants → equal-width
-                <Segmented>. Many (e.g. combobox) would collide/overflow, so use
-                a horizontally-scrollable, content-width strip instead of a lone
-                dropdown. Wrappers control visibility — Segmented's own
-                `inline-grid` would beat a `hidden` on the control itself. */}
-            {examples.length > 5 ? (
+            {/* Desktop: a segmented tab strip. Few short variants → equal-width
+                <Segmented>. 5+ tabs (or long labels) collide in equal columns, so
+                use a horizontally-scrollable, content-width strip instead.
+                Wrappers control visibility — Segmented's own `inline-grid`
+                would beat a `hidden` on the control itself. */}
+            {examples.length > 4 ? (
               <div className="hidden max-w-full sm:block">
                 <ScrollableSegmented
                   tabs={examples.map((ex, i) => ({


### PR DESCRIPTION
## Description

Component docs demos each rolled their own width, aspect, and scroll-runway wrappers, so the Workbench stage looked inconsistent page to page. This adds a shared demo-layout kit and migrates every demo onto it, and formalizes the `Example`/`Stage` `fullWidth` contract so scenes vs. centered widgets behave predictably.

## Type of change

- [x] ♻️ Refactor (no functional change)
- [x] 🎨 Style / design polish
- [x] 📝 Docs

## Changes made

- Add `apps/docs/src/components/demos/_kit.tsx` — `DemoCenter`, `DemoMedia`, `DemoScrollPort` (`fill`/`framed`), `DemoScrollRunway`, `DemoScene`; migrate all demos onto them.
- Formalize the `fullWidth` contract in `Example`/`Stage`: padded-centered default, edge-to-edge for scenes and stage-fill scroll ports; clip overflow under `fullWidth` so nested scroll ports don't fight the stage.
- Give the Workbench canvas the same dotted grid + top scrim as the index/`PreviewCard` surfaces (`globals.css`).
- Fold per-variant `## heading` examples into `<Example>` stage tabs (scroll-reveal, scroll-progress, image-compare, stepper); drop stale `fullWidth` on sticky-scroll, three-d-marquee, scroll-timeline.
- Extract `scroll-reveal-demo.tsx` and update the `godui-component-creation` SKILL with the layout-kit table and Workbench-first guidance.

## How to test

1. `pnpm dev` in `apps/docs`.
2. Open the component pages (scroll-reveal, scroll-progress, container-scroll, hero-parallax, dock, tilt-card, image-compare, etc.).
3. Confirm each Workbench stage renders correctly, dotted-grid canvas shows, scroll-driven demos scrub inside their port, and the desktop/mobile toggle neither clips nor h-scrolls.

## Checklist

- [x] `pnpm check` passes (Biome lint + format)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Self-reviewed the diff; no stray logs, dead code, or commented-out blocks

Docs-only refactor — no `registry.json` / component source changes.