### PR TITLE
feat(docs): expand home page into a scrollable landing page

### DIFF
--- a/apps/docs/src/app/_home/animated-install.tsx
+++ b/apps/docs/src/app/_home/animated-install.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { useEffect, useState } from "react";
+import { CopyButton } from "@/components/copy-button";
+
+// Real registry slugs (public/r/<slug>.json) — the command stays runnable
+// whichever name is on screen when someone copies it.
+const SLUGS = [
+  "jelly-button",
+  "aurora-text",
+  "globe",
+  "dynamic-island",
+  "dock",
+  "world-map",
+  "orbiting-circles",
+  "text-scramble",
+];
+
+const PREFIX = 'npx shadcn@latest add "https://godui.design/r/';
+const SUFFIX = '.json"';
+const INTERVAL_MS = 2200;
+
+export function AnimatedInstall() {
+  const [index, setIndex] = useState(0);
+  const reduceMotion = useReducedMotion();
+  const slug = SLUGS[index];
+  const command = `${PREFIX}${slug}${SUFFIX}`;
+
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      setIndex((i) => (i + 1) % SLUGS.length);
+    }, INTERVAL_MS);
+    return () => window.clearInterval(id);
+  }, []);
+
+  return (
+    <div className="flex w-full max-w-xl items-center gap-3 rounded-2xl border border-fd-border bg-fd-background px-5 py-4 text-left shadow-sm">
+      <span aria-hidden="true" className="font-mono text-fd-primary text-sm">
+        $
+      </span>
+      {/* sr-only carries the full current command; the visible split is
+          aria-hidden so only the component name animates on screen. */}
+      <code className="flex min-w-0 flex-1 items-baseline overflow-hidden font-mono text-fd-muted-foreground text-sm sm:text-base">
+        <span className="sr-only">{command}</span>
+        <span aria-hidden="true" className="truncate">
+          {PREFIX}
+        </span>
+        <span aria-hidden="true" className="relative inline-flex">
+          <AnimatePresence mode="wait" initial={false}>
+            <motion.span
+              key={slug}
+              initial={
+                reduceMotion
+                  ? { opacity: 0 }
+                  : { opacity: 0, y: 8, filter: "blur(6px)" }
+              }
+              animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
+              exit={
+                reduceMotion
+                  ? { opacity: 0 }
+                  : { opacity: 0, y: -8, filter: "blur(6px)" }
+              }
+              transition={{ duration: 0.35, ease: [0.16, 1, 0.3, 1] }}
+              className="whitespace-nowrap font-semibold text-fd-foreground"
+            >
+              {slug}
+            </motion.span>
+          </AnimatePresence>
+        </span>
+        <span aria-hidden="true">{SUFFIX}</span>
+      </code>
+      <CopyButton value={command} className="size-8 shrink-0 rounded-md" />
+    </div>
+  );
+}

--- a/apps/docs/src/app/_home/community-section.tsx
+++ b/apps/docs/src/app/_home/community-section.tsx
@@ -1,0 +1,68 @@
+import { siteConfig } from "@/lib/site-config";
+
+function GitHubIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className="size-5"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+    </svg>
+  );
+}
+
+function XIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className="size-[18px]"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    </svg>
+  );
+}
+
+const pillButton =
+  "inline-flex items-center gap-2.5 rounded-full border border-fd-border bg-fd-card px-6 py-3.5 font-semibold text-fd-foreground transition-transform duration-150 will-change-transform hover:-translate-y-0.5 active:scale-[0.98]";
+
+export function CommunitySection() {
+  return (
+    <section className="relative z-10 mx-auto flex w-full max-w-3xl flex-col items-center gap-6 px-4 py-24 text-center sm:py-32">
+      <span className="inline-flex items-center gap-2 rounded-full border border-fd-border bg-fd-card px-3.5 py-1.5 font-medium text-fd-muted-foreground text-sm">
+        <span className="size-2 rounded-full bg-fd-primary" />
+        Work in progress
+      </span>
+      <h2 className="max-w-2xl text-balance font-bold text-4xl text-fd-foreground tracking-tight sm:text-5xl md:text-6xl">
+        {siteConfig.name} is being built in the open.
+      </h2>
+      <p className="max-w-xl text-pretty text-fd-muted-foreground text-lg">
+        The collection is still growing, and new components land regularly.
+        Follow the journey on X and star the project on GitHub to keep up.
+      </p>
+      <div className="mt-2 flex flex-col items-center gap-3 sm:flex-row sm:gap-4">
+        <a
+          href={siteConfig.x}
+          target="_blank"
+          rel="noreferrer noopener"
+          className={pillButton}
+        >
+          <XIcon />
+          Follow the journey
+        </a>
+        <a
+          href={siteConfig.github}
+          target="_blank"
+          rel="noreferrer noopener"
+          className={pillButton}
+        >
+          <GitHubIcon />
+          Star on GitHub
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/apps/docs/src/app/_home/features-section.tsx
+++ b/apps/docs/src/app/_home/features-section.tsx
@@ -1,0 +1,85 @@
+import type { LucideIcon } from "lucide-react";
+import {
+  Bot,
+  Braces,
+  Clipboard,
+  Heart,
+  Sparkles,
+  Terminal,
+} from "lucide-react";
+import { SectionHeading } from "./section-heading";
+
+type Feature = {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+};
+
+const features: Feature[] = [
+  {
+    icon: Clipboard,
+    title: "Copy-paste, own the code",
+    description:
+      "Every component lands in your codebase as plain source. No black-box dependency, no version lock-in — tweak anything.",
+  },
+  {
+    icon: Terminal,
+    title: "shadcn registry",
+    description:
+      "Add any component with a single shadcn CLI command. Wired to your existing registry workflow.",
+  },
+  {
+    icon: Bot,
+    title: "MCP-native",
+    description:
+      "Your AI agent installs components by name through the GodUI MCP server — no context-switching.",
+  },
+  {
+    icon: Sparkles,
+    title: "Motion, done right",
+    description:
+      "Built on Motion with a strict transform/opacity performance budget, so every animation stays at 60fps.",
+  },
+  {
+    icon: Braces,
+    title: "Typed end to end",
+    description:
+      "Written in TypeScript with fully typed props and Tailwind v4 tokens that respect your theme.",
+  },
+  {
+    icon: Heart,
+    title: "Open source",
+    description:
+      "MIT licensed and free forever. Use it in personal and commercial work without a second thought.",
+  },
+];
+
+export function FeaturesSection() {
+  return (
+    <section className="relative z-10 mx-auto w-full max-w-6xl px-4 py-20 sm:py-28">
+      <SectionHeading
+        eyebrow="Why GodUI"
+        title="Everything you need, nothing you don't"
+        description="A component library designed for modern React stacks and the AI tools you already build with."
+      />
+      <div className="mt-14 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {features.map(({ icon: Icon, title, description }) => (
+          <div
+            key={title}
+            className="group rounded-2xl border border-fd-border bg-fd-card p-6 transition-transform duration-200 will-change-transform hover:-translate-y-1"
+          >
+            <div className="inline-flex size-10 items-center justify-center rounded-xl border border-fd-border bg-fd-background text-fd-primary transition-transform duration-200 group-hover:scale-110">
+              <Icon className="size-5" aria-hidden="true" />
+            </div>
+            <h3 className="mt-4 font-semibold text-fd-foreground text-lg">
+              {title}
+            </h3>
+            <p className="mt-2 text-fd-muted-foreground text-sm leading-relaxed">
+              {description}
+            </p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/docs/src/app/_home/footer.tsx
+++ b/apps/docs/src/app/_home/footer.tsx
@@ -1,0 +1,140 @@
+import Link from "next/link";
+import { siteConfig } from "@/lib/site-config";
+import { GoduiLogo } from "../docs/_components/godui-logo";
+
+// Kept in sync with ANIMATED_ICONS_URL in docs/_components/docs-header.tsx.
+const ANIMATED_ICONS_URL = "https://svg-animated-icons.vercel.app/";
+
+type FooterLink = { label: string; href: string; external?: boolean };
+
+const columns: { heading: string; links: FooterLink[] }[] = [
+  {
+    heading: "Product",
+    links: [
+      { label: "Components", href: "/docs/components" },
+      { label: "Installation", href: "/docs/installation" },
+      { label: "Animated Icons", href: ANIMATED_ICONS_URL, external: true },
+    ],
+  },
+  {
+    heading: "Resources",
+    links: [
+      { label: "Documentation", href: "/docs" },
+      { label: "MCP Server", href: "/docs/mcp" },
+      { label: "Guidelines", href: "/docs/guidelines/principles" },
+      { label: "Sitemap", href: "/sitemap.xml" },
+    ],
+  },
+];
+
+function GitHubIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className="size-4"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+    </svg>
+  );
+}
+
+function XIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className="size-[15px]"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    </svg>
+  );
+}
+
+const socialButton =
+  "inline-flex size-9 items-center justify-center rounded-full border border-fd-border bg-fd-background text-fd-muted-foreground transition-colors hover:border-fd-primary/40 hover:text-fd-foreground";
+
+function FooterLinkItem({ link }: { link: FooterLink }) {
+  const className =
+    "text-fd-muted-foreground text-sm transition-colors hover:text-fd-foreground";
+  return link.external ? (
+    <a
+      href={link.href}
+      target="_blank"
+      rel="noreferrer noopener"
+      className={className}
+    >
+      {link.label}
+    </a>
+  ) : (
+    <Link href={link.href} className={className}>
+      {link.label}
+    </Link>
+  );
+}
+
+export function Footer() {
+  const year = new Date().getFullYear();
+
+  return (
+    <footer className="relative z-10 mt-10 w-full border-fd-border/70 border-t bg-fd-card">
+      <div className="mx-auto flex w-full max-w-[90rem] flex-col gap-10 px-4 py-16 lg:flex-row lg:justify-between lg:gap-16">
+        <div className="flex flex-col gap-4">
+          <Link
+            href="/"
+            className="inline-flex items-center gap-2 font-bold text-[0.9375rem] text-fd-foreground"
+          >
+            <GoduiLogo className="h-6 w-6" width={24} height={24} />
+            {siteConfig.name}
+          </Link>
+          <p className="max-w-xs text-fd-muted-foreground text-sm leading-relaxed">
+            An open-source collection of beautifully crafted motion components
+            for modern React interfaces.
+          </p>
+          <div className="flex items-center gap-2">
+            <a
+              href={siteConfig.github}
+              target="_blank"
+              rel="noreferrer noopener"
+              aria-label="GitHub"
+              className={socialButton}
+            >
+              <GitHubIcon />
+            </a>
+            <a
+              href={siteConfig.x}
+              target="_blank"
+              rel="noreferrer noopener"
+              aria-label="X / Twitter"
+              className={socialButton}
+            >
+              <XIcon />
+            </a>
+          </div>
+        </div>
+        <div className="grid grid-cols-2 gap-10 sm:gap-16 lg:gap-20">
+          {columns.map((column) => (
+            <nav key={column.heading} className="flex flex-col gap-3">
+              <h3 className="font-semibold text-fd-foreground text-sm">
+                {column.heading}
+              </h3>
+              {column.links.map((link) => (
+                <FooterLinkItem key={link.label} link={link} />
+              ))}
+            </nav>
+          ))}
+        </div>
+      </div>
+      <div className="border-fd-border/60 border-t">
+        <div className="mx-auto flex w-full max-w-[90rem] flex-col items-center justify-between gap-2 px-4 py-6 text-fd-muted-foreground text-xs sm:flex-row">
+          <p>
+            © {year} {siteConfig.name}. MIT Licensed.
+          </p>
+          <p>Built with React, TypeScript, Tailwind CSS &amp; Motion.</p>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/apps/docs/src/app/_home/mcp-section.tsx
+++ b/apps/docs/src/app/_home/mcp-section.tsx
@@ -1,0 +1,37 @@
+import { ArrowUpRight } from "lucide-react";
+import Link from "next/link";
+import { MCPInstall } from "@/components/mcp-install";
+import { SectionHeading } from "./section-heading";
+
+/**
+ * The MCP story — GodUI's biggest differentiator vs. peer libraries. Server
+ * wrapper; the interactive install panel (MCPInstall) is the only client leaf.
+ */
+export function McpSection() {
+  return (
+    <section className="relative z-10 mx-auto w-full max-w-3xl px-4 py-20 sm:py-28">
+      <SectionHeading
+        eyebrow="AI-native"
+        title="Install components with your agent"
+        description="GodUI ships an MCP server, so Cursor, Claude, Windsurf and friends can browse the library and drop components straight into your project — no copy-paste round trips."
+      />
+      <MCPInstall />
+      <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm">
+        <Link
+          href="/docs/mcp"
+          className="group inline-flex items-center gap-1 font-medium text-fd-foreground transition-colors hover:text-fd-primary"
+        >
+          MCP docs
+          <ArrowUpRight className="size-3.5 transition-transform group-hover:-translate-y-px group-hover:translate-x-px" />
+        </Link>
+        <Link
+          href="/docs/installation"
+          className="group inline-flex items-center gap-1 font-medium text-fd-muted-foreground transition-colors hover:text-fd-foreground"
+        >
+          Manual install
+          <ArrowUpRight className="size-3.5 transition-transform group-hover:-translate-y-px group-hover:translate-x-px" />
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/apps/docs/src/app/_home/section-heading.tsx
+++ b/apps/docs/src/app/_home/section-heading.tsx
@@ -1,0 +1,42 @@
+import type { ReactNode } from "react";
+
+/**
+ * Shared marketing section header: small eyebrow label + balanced title +
+ * optional lead paragraph. Keeps every landing section on the same rhythm.
+ */
+export function SectionHeading({
+  eyebrow,
+  title,
+  description,
+  align = "center",
+}: {
+  eyebrow: string;
+  title: ReactNode;
+  description?: ReactNode;
+  align?: "center" | "left";
+}) {
+  const isCenter = align === "center";
+  return (
+    <div
+      className={
+        isCenter ? "mx-auto max-w-2xl text-center" : "max-w-2xl text-left"
+      }
+    >
+      <span className="inline-flex items-center rounded-full border border-fd-border bg-fd-card px-3 py-1 font-medium text-fd-muted-foreground text-xs uppercase tracking-wider">
+        {eyebrow}
+      </span>
+      <h2 className="mt-4 text-balance font-semibold text-3xl text-fd-foreground tracking-tight sm:text-4xl">
+        {title}
+      </h2>
+      {description ? (
+        <p
+          className={`mt-4 text-pretty text-fd-muted-foreground sm:text-lg ${
+            isCenter ? "mx-auto max-w-xl" : ""
+          }`}
+        >
+          {description}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/docs/src/app/page.tsx
+++ b/apps/docs/src/app/page.tsx
@@ -1,28 +1,32 @@
 import { MagicButton } from "@godui/components";
 import { DocsLayout } from "fumadocs-ui/layouts/docs";
+import { ChevronDown } from "lucide-react";
 import Link from "next/link";
 import type { CSSProperties } from "react";
 import { baseOptions } from "@/lib/layout.shared";
+import { siteConfig } from "@/lib/site-config";
 import { source } from "@/lib/source";
+import { AnimatedInstall } from "./_home/animated-install";
+import { CommunitySection } from "./_home/community-section";
+import { FeaturesSection } from "./_home/features-section";
+import { Footer } from "./_home/footer";
+import { McpSection } from "./_home/mcp-section";
 import { HomeHeader } from "./docs/_components/home-header";
 import { MobileMenu } from "./docs/_components/mobile-menu";
 import { NullNavTitle } from "./docs/_components/null-nav-title";
 import { HeroGrid } from "./hero-grid";
-
-const SITE_URL = "https://godui.design";
 
 const structuredData = {
   "@context": "https://schema.org",
   "@graph": [
     {
       "@type": "WebPage",
-      "@id": `${SITE_URL}/#webpage`,
-      url: SITE_URL,
+      "@id": `${siteConfig.url}/#webpage`,
+      url: siteConfig.url,
       name: "GodUI — UI Collection for Modern Interfaces",
-      description:
-        "An open-source collection of beautifully crafted motion components built with React, TypeScript, Tailwind CSS, Motion, and shadcn/ui.",
-      isPartOf: { "@id": `${SITE_URL}/#website` },
-      about: { "@id": `${SITE_URL}/#organization` },
+      description: siteConfig.description,
+      isPartOf: { "@id": `${siteConfig.url}/#website` },
+      about: { "@id": `${siteConfig.url}/#organization` },
     },
   ],
 };
@@ -46,8 +50,10 @@ export default function Home() {
         // while sharing the docs drawer on mobile.
         sidebar={{ collapsible: false, className: "md:hidden" }}
         links={[{ type: "custom", on: "menu", children: <MobileMenu /> }]}
+        // min-h-svh (not h-svh + overflow-hidden): the landing now scrolls
+        // through its marketing sections, so the document owns the scroll.
         containerProps={{
-          className: "min-h-svh md:h-svh md:min-h-0 md:overflow-hidden",
+          className: "min-h-svh",
           style: homeLayoutStyle,
         }}
         slots={{
@@ -56,12 +62,14 @@ export default function Home() {
           searchTrigger: false,
         }}
       >
-        <main className="relative flex min-h-svh flex-col [grid-area:main] md:min-h-0">
-          <HeroGrid />
-          <section className="relative z-10 flex flex-1 flex-col items-center justify-center gap-8 px-4 text-center">
+        <main className="relative flex flex-col [grid-area:main]">
+          {/* Hero — screen 1. HeroGrid lives INSIDE this section so its
+              absolute backdrop is scoped to the hero, not the sections below. */}
+          <section className="relative flex min-h-[calc(100svh-3.5rem)] flex-col items-center justify-center gap-8 overflow-hidden px-4 text-center">
+            <HeroGrid />
             <Link
               href="/docs/components/buttons/jelly-button"
-              className="group inline-flex items-center gap-2 rounded-full border bg-fd-card px-3 py-1 font-medium text-fd-muted-foreground text-xs transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
+              className="group relative z-10 inline-flex items-center gap-2 rounded-full border bg-fd-card px-3 py-1 font-medium text-fd-muted-foreground text-xs transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
             >
               <span className="relative flex size-2">
                 <span className="absolute inline-flex size-full animate-ping rounded-full bg-fd-primary opacity-75" />
@@ -75,10 +83,10 @@ export default function Home() {
                 →
               </span>
             </Link>
-            <h1 className="max-w-3xl text-balance font-semibold text-4xl text-fd-foreground tracking-tight sm:text-5xl md:text-6xl">
+            <h1 className="relative z-10 max-w-3xl text-balance font-semibold text-4xl text-fd-foreground tracking-tight sm:text-5xl md:text-6xl">
               UI Collection for Modern Interfaces
             </h1>
-            <p className="max-w-md text-balance text-fd-muted-foreground text-sm sm:text-base">
+            <p className="relative z-10 max-w-md text-balance text-fd-muted-foreground text-sm sm:text-base">
               An open-source collection of beautifully crafted motion components
               built with{" "}
               <span className="font-semibold text-fd-foreground">React</span>,{" "}
@@ -96,14 +104,17 @@ export default function Home() {
               </span>
               .
             </p>
-            <div className="flex flex-col items-center gap-4 sm:flex-row sm:gap-5">
+            <div className="relative z-10 flex w-full justify-center">
+              <AnimatedInstall />
+            </div>
+            <div className="relative z-10 flex flex-col items-center gap-4 sm:flex-row sm:gap-5">
               <Link href="/docs/components" className="inline-block">
                 <MagicButton size="lg" tabIndex={-1}>
                   Browse Components
                 </MagicButton>
               </Link>
               <a
-                href="https://github.com/LucasBassetti/godui"
+                href={siteConfig.github}
                 target="_blank"
                 rel="noreferrer noopener"
                 className="inline-block"
@@ -128,9 +139,22 @@ export default function Home() {
                 </MagicButton>
               </a>
             </div>
+            {/* Scroll cue — content continues below the fold now. */}
+            <span
+              aria-hidden="true"
+              className="-translate-x-1/2 absolute bottom-8 left-1/2 z-10 animate-bounce text-fd-muted-foreground max-md:hidden"
+            >
+              <ChevronDown className="size-5" />
+            </span>
           </section>
+
+          <McpSection />
+          <FeaturesSection />
+          <CommunitySection />
         </main>
       </DocsLayout>
+      {/* Outside #nd-docs-layout (max-w 96rem) so the footer bg is full-bleed. */}
+      <Footer />
       <script
         type="application/ld+json"
         // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD requires raw script injection.

--- a/apps/docs/src/app/sitemap.ts
+++ b/apps/docs/src/app/sitemap.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from "next";
+import { siteConfig } from "@/lib/site-config";
+import { source } from "@/lib/source";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const docs = source.getPages().map((page) => ({
+    url: `${siteConfig.url}${page.url}`,
+    lastModified: page.data.date ? new Date(page.data.date) : undefined,
+  }));
+
+  return [{ url: siteConfig.url, lastModified: new Date() }, ...docs];
+}

--- a/apps/docs/src/lib/site-config.ts
+++ b/apps/docs/src/lib/site-config.ts
@@ -1,0 +1,19 @@
+/**
+ * Single source of truth for site identity + social links. Previously these
+ * were duplicated inline across layout.tsx, page.tsx and docs-header.tsx.
+ */
+export const siteConfig = {
+  name: "GodUI",
+  url: "https://godui.design",
+  description:
+    "An open-source collection of beautifully crafted motion components built with React, TypeScript, Tailwind CSS, Motion, and shadcn/ui.",
+  github: "https://github.com/LucasBassetti/godui",
+  x: "https://x.com/LucasBassetti",
+  xHandle: "@LucasBassetti",
+  // Keep in sync with the card-previews registry
+  // (apps/docs/src/components/card-previews/registry.tsx) and the component
+  // category folders under content/docs/components/. Hardcoded so the marketing
+  // sections don't pull the client-only previews bundle just to read a count.
+  componentCount: 107,
+  categoryCount: 12,
+} as const;


### PR DESCRIPTION
## What

Grows the docs home page from a single-viewport hero into a full scrollable landing page.

### Sections (top → bottom)
- **Hero** — kept, now with an **animated install command** (the component name cycles through real registry slugs with a fade/blur swap) placed above the CTAs, plus a scroll cue.
- **MCP** — highlights the MCP server; reuses the existing `MCPInstall` panel.
- **Features** — six value-prop cards.
- **Community** — "built in the open" block with Follow-on-X / Star-on-GitHub.
- **Footer** — full-bleed band (rendered outside the docs grid), content capped at the header width (`90rem`); product/resource link columns, social icons, copyright.

### Supporting
- New `lib/site-config.ts` — single source of truth for name/url/description/GitHub/X/counts (removes inline duplication).
- New `sitemap.ts` route (linked from the footer).

## Notes
- Home page stays a server component inside `DocsLayout`, so the mobile drawer + header are unchanged.
- Animations use transform/opacity/filter only; reduced-motion respected.
- Reuses existing components: `MCPInstall`, `MagicButton`, `CopyButton`, `GoduiLogo`, `HeroGrid`.

## Verification
- `tsc --noEmit` clean
- `pnpm check` (Biome) clean
- Dev server: all sections render, no runtime errors; all footer/CTA links resolve (200)