### PR TITLE
feat(docs): redesign Learn pages as a stage-first carousel

### DIFF
--- a/apps/docs/content/docs/components/ai/agent-flow/learn.mdx
+++ b/apps/docs/content/docs/components/ai/agent-flow/learn.mdx
@@ -1,14 +1,27 @@
 ---
 title: Anatomy of Agent Flow
 description: How a node graph becomes one continuous light — length-driven speed, a border-to-beam handoff, and a sequencer that walks the graph on its own.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="The graph"
+  scene={<AgentFlowAnatomy />}
+  code={`const startX = from.x + fs.w / 2;
+const startY = from.y;
+const endX = to.x - ts.w / 2;
+const endY = to.y;
+const controlX = (startX + endX) / 2;
+const controlY = (startY + endY) / 2 - (edge.curvature ?? 0);
+const d = \`M \${startX},\${startY} Q \${controlX},\${controlY} \${endX},\${endY}\`;`}
+>
 
 `AgentFlow` looks like a diagram tool, but the interesting part isn't the
 layout — it's the light. Every node card and every edge derives its motion
 from the same handful of numbers, so a graph of any shape reads as one
 unbroken current instead of a pile of independent animations.
-
-## The graph
 
 A node is a card at an absolute `(x, y)` centre. An edge is an SVG quadratic
 curve from its source's **right-edge centre** to its target's **left-edge
@@ -16,23 +29,22 @@ centre** — the anchors are computed from each card's live measured size, not
 a fixed offset, so relabelling a node (a longer sublabel, a taller card) never
 misaligns the line it's plugged into.
 
-<AgentFlowAnatomy />
-
-```tsx
-const startX = from.x + fs.w / 2;
-const startY = from.y;
-const endX = to.x - ts.w / 2;
-const endY = to.y;
-const controlX = (startX + endX) / 2;
-const controlY = (startY + endY) / 2 - (edge.curvature ?? 0);
-const d = `M ${startX},${startY} Q ${controlX},${controlY} ${endX},${endY}`;
-```
-
 Card sizes come from a `ResizeObserver` over every rendered node, not from
 props — so `fitView` and every edge anchor stay correct even after the DOM
 reflows text.
 
-## One pace for every length
+</LearnChapter>
+
+<LearnChapter
+  label="One pace for every length"
+  scene={<AgentFlowBorderTrace />}
+  code={`function borderOutlineLength(w: number, h: number): number {
+  const r = Math.min(CARD_RADIUS, w / 2, h / 2);
+  return w + h - (4 - Math.PI) * r;
+}
+
+const traceDuration = borderOutlineLength(size.w, size.h) / flowSpeed;`}
+>
 
 A bigger card's border has more perimeter to draw. A longer edge has more
 distance to cover. If each animated separately by *duration*, the light would
@@ -40,17 +52,6 @@ visibly slow down on big pieces and speed up on small ones. `AgentFlow` fixes
 the pace instead of the duration: everything shares one `flowSpeed`
 (px/second, default `280`), and each element's duration falls out of its own
 length.
-
-<AgentFlowBorderTrace />
-
-```tsx
-function borderOutlineLength(w: number, h: number): number {
-  const r = Math.min(CARD_RADIUS, w / 2, h / 2);
-  return w + h - (4 - Math.PI) * r;
-}
-
-const traceDuration = borderOutlineLength(size.w, size.h) / flowSpeed;
-```
 
 Edges do the same thing with their own geometry — chord length averaged with
 the two control-arm lengths, for a real (not straight-line) estimate of a
@@ -70,24 +71,24 @@ the component reaches for. An ease-out front decelerates right as it finishes
 — which would visibly stutter the exact moment the beam is supposed to pick
 up speed and continue. Constant velocity is what makes the seam invisible.
 
-## Border → beam, one continuous light
+</LearnChapter>
+
+<LearnChapter
+  label="Border → beam, one continuous light"
+  scene={<AgentFlowPacket />}
+  code={`function borderTracePaths(w: number, h: number): [string, string] {
+  const r = Math.min(CARD_RADIUS, w / 2, h / 2);
+  const top = \`M 0,\${h / 2} L 0,\${r} A \${r},\${r} 0 0 1 \${r},0 L \${w - r},0 A \${r},\${r} 0 0 1 \${w},\${r} L \${w},\${h / 2}\`;
+  const bottom = \`M 0,\${h / 2} L 0,\${h - r} A \${r},\${r} 0 0 0 \${r},\${h} L \${w - r},\${h} A \${r},\${r} 0 0 0 \${w},\${h - r} L \${w},\${h / 2}\`;
+  return [top, bottom];
+}`}
+>
 
 Each card's outline is really *two* paths — `borderTracePaths(w, h)` returns
 symmetric top and bottom outlines that both start at the **left-edge centre**
 and meet at the **right-edge centre**, so the trace grows outward in both
 directions from the same point an incoming beam would have landed on, and
 finishes at the exact point the outgoing beam starts from.
-
-<AgentFlowPacket />
-
-```tsx
-function borderTracePaths(w: number, h: number): [string, string] {
-  const r = Math.min(CARD_RADIUS, w / 2, h / 2);
-  const top = `M 0,${h / 2} L 0,${r} A ${r},${r} 0 0 1 ${r},0 L ${w - r},0 A ${r},${r} 0 0 1 ${w},${r} L ${w},${h / 2}`;
-  const bottom = `M 0,${h / 2} L 0,${h - r} A ${r},${r} 0 0 0 ${r},${h} L ${w - r},${h} A ${r},${r} 0 0 0 ${w},${h - r} L ${w},${h / 2}`;
-  return [top, bottom];
-}
-```
 
 The icon chip doesn't wait for the border to finish — it lights **at the
 halfway point** of the trace, off a plain timer, not an animation-complete
@@ -111,12 +112,10 @@ Timers derived from the same duration the animation itself uses fire exactly
 when the *visual* handoff needs them to, every time — including the graph's
 last hop, which has no next element waiting to double-check it.
 
-## The sequencer
-
-`autoPlay` walks the graph with three sets — `tracing`, `lit`, `flowing` —
-managed by a small reducer, not a timeline library. A node's status is
-derived from which set contains its id; an edge only shows its beam while its
-id is in `flowing`.
+**The sequencer.** `autoPlay` walks the graph with three sets — `tracing`,
+`lit`, `flowing` — managed by a small reducer, not a timeline library. A
+node's status is derived from which set contains its id; an edge only shows
+its beam while its id is in `flowing`.
 
 ```tsx
 type SeqState = { tracing: Set<string>; lit: Set<string>; flowing: Set<string> };
@@ -161,6 +160,18 @@ primary-coloured trail in sync with the packet and keeps it lit once
 `animated` drops back to `false`, so a graph that's finished a full pass shows
 its whole travelled route glowing rather than resetting to plain lines.
 
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<AgentFlowResult />} isResult>
+
+Same reducer, same length-driven pace, same 0.98-early arrival — running on a
+real graph instead of a two-node illustration. Watch the border meet the beam
+at every hop; that seam is the whole point of `flowSpeed`.
+
+</LearnChapter>
+
+</LearnPlayer>
+
 ## Reduced motion
 
 `useReducedMotion()` is read once at the top of the component and threaded
@@ -188,11 +199,3 @@ lit, every persisted edge drawn — it just gets there without the trip.
 ## Motion Score
 
 <MotionScorePanel name="agent-flow" />
-
-## The result
-
-<AgentFlowResult />
-
-Same reducer, same length-driven pace, same 0.98-early arrival — running on a
-real graph instead of a two-node illustration. Watch the border meet the beam
-at every hop; that seam is the whole point of `flowSpeed`.

--- a/apps/docs/content/docs/components/ai/agent-timeline/learn.mdx
+++ b/apps/docs/content/docs/components/ai/agent-timeline/learn.mdx
@@ -1,51 +1,46 @@
 ---
 title: Anatomy of the Agent Timeline
 description: How a live agent run is a spring-filled connector, three cross-faded ring states, and a collapsible body that morphs open on its own clock.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="The three pieces"
+  scene={<AgentTimelineAnatomy />}
+  code={`<li data-status={status} className="relative flex gap-3 pb-2">
+  <div className="relative flex flex-col items-center">
+    <span className={STATUS_RING[status]}>{/* icon */}</span>
+    {!last ? (
+      <span className="relative my-1 w-px flex-1 overflow-hidden rounded bg-border">
+        <motion.span className={\`absolute inset-0 origin-top \${CONNECTOR_FILL[status]}\`} />
+      </span>
+    ) : null}
+  </div>
+  <div className="min-w-0 flex-1 pb-2">{/* title, meta, chevron, body */}</div>
+</li>`}
+>
 
 An agent run isn't a progress bar — it's a rail of independent decisions, each
 one reporting its own status as it lands. `AgentTimeline` renders that rail as
 an `<ol>` of `AgentStep`s, and every piece of motion in it is keyed off one
 prop: `status`.
 
-## The three pieces
-
 Each `AgentStep` is a ring, a connector, and a body. The **ring** shows the
 step's current status. The **connector** below it fills as that status
 resolves, drawing the eye down to whatever's next. The **body** is optional —
 only steps with `children` get a chevron and something to expand.
 
-<AgentTimelineAnatomy />
-
-```tsx
-<li data-status={status} className="relative flex gap-3 pb-2">
-  <div className="relative flex flex-col items-center">
-    <span className={STATUS_RING[status]}>{/* icon */}</span>
-    {!last ? (
-      <span className="relative my-1 w-px flex-1 overflow-hidden rounded bg-border">
-        <motion.span className={`absolute inset-0 origin-top ${CONNECTOR_FILL[status]}`} />
-      </span>
-    ) : null}
-  </div>
-  <div className="min-w-0 flex-1 pb-2">{/* title, meta, chevron, body */}</div>
-</li>
-```
-
 `last` is the only structural prop — it just hides the connector on the final
 step, so the rail doesn't dangle a line into nothing.
 
-## The connector: one number, three destinations
+</LearnChapter>
 
-The connector is a `motion.span` inside an overflow-hidden track, scaled from
-an `origin-top`. `scaleY` maps directly off `status`: `0` while pending, `0.5`
-while running — a half-fill that reads as "in flight" — and `1` once the step
-lands on `success` or `error`. Every transition rides the same spring:
-`stiffness: 320, damping: 32, mass: 0.9`.
-
-<AgentTimelineRail />
-
-```tsx
-animate={{
+<LearnChapter
+  label="The connector: one number, three destinations"
+  scene={<AgentTimelineRail />}
+  code={`animate={{
   scaleY:
     status === "success" || status === "error"
       ? 1
@@ -53,10 +48,14 @@ animate={{
         ? 0.5
         : 0,
 }}
-transition={{ type: "spring", stiffness: 320, damping: 32, mass: 0.9 }}
-```
+transition={{ type: "spring", stiffness: 320, damping: 32, mass: 0.9 }}`}
+>
 
-## Why `scaleY`, not a growing `height`
+The connector is a `motion.span` inside an overflow-hidden track, scaled from
+an `origin-top`. `scaleY` maps directly off `status`: `0` while pending, `0.5`
+while running — a half-fill that reads as "in flight" — and `1` once the step
+lands on `success` or `error`. Every transition rides the same spring:
+`stiffness: 320, damping: 32, mass: 0.9`.
 
 A connector that grows by animating `height` has to re-run layout on every
 tick — the browser recalculates where every element below it sits, every
@@ -77,17 +76,12 @@ the spring treatment. The running ring also grows a `motion-reduce`-gated
 `animate-ping` halo, layered absolutely over the same box so it never
 disturbs the ring's own layout.
 
-## The collapsible body
+</LearnChapter>
 
-Steps with `children` get a chevron and an `AnimatePresence`-wrapped panel.
-Opening one is the same spring as the connector — `height: "auto"` and
-`opacity` animating together, so the panel never overshoots into visible
-overflow the way a plain `duration` tween would.
-
-<AgentTimelineExpand />
-
-```tsx
-<AnimatePresence initial={false}>
+<LearnChapter
+  label="The collapsible body"
+  scene={<AgentTimelineExpand />}
+  code={`<AnimatePresence initial={false}>
   {hasBody && open ? (
     <motion.div
       initial={{ height: 0, opacity: 0 }}
@@ -99,8 +93,13 @@ overflow the way a plain `duration` tween would.
       {children}
     </motion.div>
   ) : null}
-</AnimatePresence>
-```
+</AnimatePresence>`}
+>
+
+Steps with `children` get a chevron and an `AnimatePresence`-wrapped panel.
+Opening one is the same spring as the connector — `height: "auto"` and
+`opacity` animating together, so the panel never overshoots into visible
+overflow the way a plain `duration` tween would.
 
 `height: "auto"` is the one place this component reaches for a layout
 animation instead of a transform — Motion measures the panel's natural height
@@ -120,8 +119,6 @@ it never has to wait on the spring to know which way it's pointing.
 />
 ```
 
-## Cheap when idle, honest when running
-
 The title pulses only while `status === "running"` —
 `motion-safe:animate-pulse` scoped to that one class, so a step that's
 already resolved sits perfectly still. Nothing here polls or ticks on an
@@ -131,6 +128,21 @@ so the whole timeline is exactly as busy as the run actually is.
 ```tsx
 className={`... ${status === "running" ? "text-muted-foreground motion-safe:animate-pulse" : ""}`}
 ```
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<AgentTimelineResult />} isResult>
+
+A full run, advancing on its own — watch the connectors spring-fill as each
+step lands and the running step's body morph open.
+
+One prop drives all of it: `status` in, a filled connector and a settled ring
+out. That's the whole timeline — a rail that never has to be told how to
+move, only what happened.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility
 
@@ -159,14 +171,3 @@ transition={reduce ? { duration: 0 } : { type: "spring", stiffness: 320, damping
 ## Motion Score
 
 <MotionScorePanel name="agent-timeline" />
-
-## The result
-
-A full run, advancing on its own — watch the connectors spring-fill as each
-step lands and the running step's body morph open.
-
-<AgentTimelineResult />
-
-One prop drives all of it: `status` in, a filled connector and a settled ring
-out. That's the whole timeline — a rail that never has to be told how to
-move, only what happened.

--- a/apps/docs/content/docs/components/ai/conversation-thread/learn.mdx
+++ b/apps/docs/content/docs/components/ai/conversation-thread/learn.mdx
@@ -1,7 +1,30 @@
 ---
 title: Anatomy of the Conversation Thread
 description: How a chat surface stays pinned to the bottom with one arithmetic check, springs each message in, and reveals tokens on a plain interval.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="The three pieces"
+  scene={<ConversationThreadAnatomy />}
+  code={`const BUBBLE_BY_ROLE: Record<MessageRole, string> = {
+  user: "bg-primary text-primary-foreground",
+  assistant: "bg-muted text-foreground",
+  system: "bg-transparent text-muted-foreground italic",
+};
+
+<div className={\`flex gap-3 \${isUser && !isDocument ? "flex-row-reverse" : ""}\`}>
+  {avatar}
+  <div className={isUser ? "items-end" : "items-start"}>
+    <div className={\`rounded-2xl px-3.5 py-2 \${BUBBLE_BY_ROLE[role]} \${isUser ? "rounded-br-md" : "rounded-bl-md"}\`}>
+      {children}
+    </div>
+    {actions ? <div className="opacity-0 group-hover/msg:opacity-100">{/* … */}</div> : null}
+  </div>
+</div>`}
+>
 
 A chat thread lives or dies on one question: does it stay where the reader
 expects while new messages keep landing? `ConversationThread` answers that
@@ -9,32 +32,10 @@ with a single boolean derived from scroll math, and hands every message's
 entrance to one repeated spring. Nothing here is a physics engine — it's a
 threshold check, a transform, and a `setInterval`.
 
-## The three pieces
-
 `ConversationThread` owns the scroll container and the pinned/jump-to-latest
 state. `ConversationMessage` renders one turn — role, bubble tint, alignment,
 hover actions. `StreamingText` is unrelated to either: a standalone string
 that reveals itself over time and reports back through `onDone`.
-
-<ConversationThreadAnatomy />
-
-```tsx
-const BUBBLE_BY_ROLE: Record<MessageRole, string> = {
-  user: "bg-primary text-primary-foreground",
-  assistant: "bg-muted text-foreground",
-  system: "bg-transparent text-muted-foreground italic",
-};
-
-<div className={`flex gap-3 ${isUser && !isDocument ? "flex-row-reverse" : ""}`}>
-  {avatar}
-  <div className={isUser ? "items-end" : "items-start"}>
-    <div className={`rounded-2xl px-3.5 py-2 ${BUBBLE_BY_ROLE[role]} ${isUser ? "rounded-br-md" : "rounded-bl-md"}`}>
-      {children}
-    </div>
-    {actions ? <div className="opacity-0 group-hover/msg:opacity-100">{/* … */}</div> : null}
-  </div>
-</div>
-```
 
 `role` decides two independent things at once — which bubble tint from
 `BUBBLE_BY_ROLE`, and whether the row reverses to sit on the right. A
@@ -44,23 +45,23 @@ input, `variant`, down to every message without prop-drilling it through
 width, `compact` drops the name/timestamp row and tightens the gap. Same
 component, three readings of the same `role`.
 
-## Staying pinned to the bottom
+</LearnChapter>
+
+<LearnChapter
+  label="Staying pinned to the bottom"
+  scene={<ConversationThreadScroll />}
+  code={`onScroll={(e) => {
+  const el = e.currentTarget;
+  const atBottom =
+    el.scrollHeight - el.scrollTop - el.clientHeight < 48;
+  setPinnedBoth(atBottom);
+}}`}
+>
 
 `ConversationThread` recomputes "am I at the bottom" on every `onScroll` and
 stores the answer as `pinned` (mirrored into a ref so observers never read a
 stale value). New messages and streaming growth both re-stick while pinned;
 if the reader scrolls up past the threshold, it lets go and shows a pill.
-
-<ConversationThreadScroll />
-
-```tsx
-onScroll={(e) => {
-  const el = e.currentTarget;
-  const atBottom =
-    el.scrollHeight - el.scrollTop - el.clientHeight < 48;
-  setPinnedBoth(atBottom);
-}}
-```
 
 ```tsx
 // New message mounts → instant stick (smooth is reserved for Jump).
@@ -85,8 +86,6 @@ React.useEffect(() => {
 tick that grows a bubble. The ResizeObserver on the inner content wrapper
 closes that gap without a `MutationObserver` or a rAF loop.
 
-## Why 48px, not 0
-
 A `0`px threshold would un-pin the instant a subpixel scroll event fires —
 trackpads and momentum scrolling report fractional deltas constantly, so an
 exact-bottom check flickers the pill in and out on scroll noise alone. `48`
@@ -94,18 +93,14 @@ is generous enough to absorb that jitter while still being smaller than a
 single message row, so the thread only actually lets go once the reader has
 deliberately scrolled — never on rounding error.
 
-## Why instant scroll (and no `layout`)
-
 Streaming text changes height every few milliseconds. Smooth scrolling
 and Framer Motion `layout` both tween those changes — and they fight each
 other: the viewport eases toward the bottom while every sibling message
 re-measures and slides. Result: jump up, settle down, jump again.
 
 So the thread keeps stickiness **instant** while pinned, and messages enter
-with opacity + a short `y` spring only — no `layout` prop. `scrollToBottom
-("smooth")` is reserved for the intentional Jump-to-latest click.
-
-## The jump-to-latest pill
+with opacity + a short `y` spring only — no `layout` prop. `scrollToBottom("smooth")`
+is reserved for the intentional Jump-to-latest click.
 
 When `pinned` flips to `false`, `AnimatePresence` mounts a button —
 `sticky bottom-2`, so it rides the current scroll position instead of a fixed
@@ -137,16 +132,12 @@ calls `scrollToBottom` directly. Setting `pinned` alone would only affect the
 next content change — the click needs the thread to catch up immediately,
 so the imperative scroll and the state flip happen in the same handler.
 
-## The showpiece detail: streaming tokens
+</LearnChapter>
 
-`StreamingText` has no dependency on the thread or the message it lives in —
-it owns one `count` of how many characters to slice off `text`, and a
-`setInterval` that raises it by `chunk` every `speed` milliseconds:
-
-<ConversationThreadStream />
-
-```tsx
-React.useEffect(() => {
+<LearnChapter
+  label="The showpiece detail: streaming tokens"
+  scene={<ConversationThreadStream />}
+  code={`React.useEffect(() => {
   if (reduce) {
     setCount(text.length);
     onDone?.();
@@ -165,8 +156,12 @@ React.useEffect(() => {
   return () => clearInterval(id);
 }, [text, chunk, speed, reduce, onDone]);
 
-return <>{text.slice(0, count)}</>;
-```
+return <>{text.slice(0, count)}</>;`}
+>
+
+`StreamingText` has no dependency on the thread or the message it lives in —
+it owns one `count` of how many characters to slice off `text`, and a
+`setInterval` that raises it by `chunk` every `speed` milliseconds:
 
 `Math.min(current + chunk, text.length)` is the only bounds check in the
 whole component — without it the last tick could slice past the string's
@@ -186,14 +181,26 @@ That split matters: a consumer can drive `streaming` off their own state
 (say, "is the socket still open") independently of whether `StreamingText`
 has finished revealing the current chunk of text it already has.
 
-## Cheap when idle
-
 Every piece here is either event-driven or cleans up after itself.
 `onScroll` only runs while the user is actually scrolling. The
 `ResizeObserver` only fires when the message stack's box changes, and it
 disconnects on unmount. `StreamingText`'s `setInterval` is cleared both on
 completion and on unmount — there's no polling loop left running once a
 message has finished streaming or the component has left the tree.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<ConversationThreadResult />} isResult>
+
+One threshold check keeps the thread pinned, a ResizeObserver sticks through
+streaming growth, one spring brings every message in and pops the jump
+pill, and one `setInterval` — with nothing smarter than `Math.min` guarding
+it — turns a finished string into something that reads like it's still being
+written.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility
 
@@ -217,13 +224,3 @@ group-hover/msg:opacity-100` styling that reveals them visually.
 ## Motion Score
 
 <MotionScorePanel name="conversation-thread" />
-
-## The result
-
-<ConversationThreadResult />
-
-One threshold check keeps the thread pinned, a ResizeObserver sticks through
-streaming growth, one spring brings every message in and pops the jump
-pill, and one `setInterval` — with nothing smarter than `Math.min` guarding
-it — turns a finished string into something that reads like it's still being
-written.

--- a/apps/docs/content/docs/components/ai/prompt-composer/learn.mdx
+++ b/apps/docs/content/docs/components/ai/prompt-composer/learn.mdx
@@ -1,7 +1,17 @@
 ---
 title: Anatomy of the Prompt Composer
 description: How one form stays one form across chips, an auto-growing textarea, a model picker, and a send button that morphs into stop — no remounts, no separate layouts.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="One form, three stacked rows"
+  scene={<PromptComposerAnatomy />}
+  code={`const PANEL_BASE =
+  "group/composer relative flex w-full flex-col gap-2 rounded-2xl border border-border bg-card/80 p-2.5 shadow-sm backdrop-blur-md transition-[box-shadow,border-color] focus-within:border-ring focus-within:shadow-md";`}
+>
 
 Every "chat input" ends up needing the same five things: attachments, a
 field that grows with what you type, a model switcher, a drag target, and a
@@ -9,20 +19,11 @@ send button that has to become a stop button mid-stream. `PromptComposer`
 builds all five as states of one `<form>`, not five components stitched
 together. Here's how each state moves.
 
-## One form, three stacked rows
-
 The panel is a single `<form data-slot="prompt-composer">` with three rows
 that are always present in the DOM in the same order — an attachment row
 that collapses to nothing when empty, the textarea, and a toolbar. Nothing
 here remounts when attachments, streaming, or the model list change; only
 which children exist inside each row changes.
-
-<PromptComposerAnatomy />
-
-```tsx
-const PANEL_BASE =
-  "group/composer relative flex w-full flex-col gap-2 rounded-2xl border border-border bg-card/80 p-2.5 shadow-sm backdrop-blur-md transition-[box-shadow,border-color] focus-within:border-ring focus-within:shadow-md";
-```
 
 `focus-within` is doing the work a `focus` ring normally would — since the
 element that's actually focused is the `<textarea>` two levels down, not the
@@ -30,17 +31,12 @@ element that's actually focused is the `<textarea>` two levels down, not the
 anywhere inside it, which is why clicking the attach button or the model
 picker doesn't dim the "focused" look the way blurring the textarea would.
 
-## Chips spring in, spring out
+</LearnChapter>
 
-Attachments aren't rendered directly inside the panel — they're wrapped in
-two nested `AnimatePresence` regions. The outer one owns the row's own
-mount/unmount (`height: 0 → "auto"`, so the panel never jumps when the first
-file lands); the inner one owns each chip's own spring.
-
-<PromptComposerChips />
-
-```tsx
-<AnimatePresence initial={false}>
+<LearnChapter
+  label="Chips spring in, spring out"
+  scene={<PromptComposerChips />}
+  code={`<AnimatePresence initial={false}>
   {chips.length > 0 ? (
     <motion.div
       initial={{ opacity: 0, height: 0 }}
@@ -64,8 +60,13 @@ file lands); the inner one owns each chip's own spring.
       </AnimatePresence>
     </motion.div>
   ) : null}
-</AnimatePresence>
-```
+</AnimatePresence>`}
+>
+
+Attachments aren't rendered directly inside the panel — they're wrapped in
+two nested `AnimatePresence` regions. The outer one owns the row's own
+mount/unmount (`height: 0 → "auto"`, so the panel never jumps when the first
+file lands); the inner one owns each chip's own spring.
 
 `layout` on each chip is what makes removing one feel physical instead of
 abrupt — Framer measures the chip row before and after a chip leaves and
@@ -100,16 +101,12 @@ synchronously before the browser paints, so there's never a frame where the
 field is the wrong height. Past `maxRows`, `overflowY` flips to `auto` and
 growth stops — the field scrolls instead of pushing the toolbar off-panel.
 
-## Send becomes stop, not a different button
+</LearnChapter>
 
-Streaming doesn't swap in a different `<button>` — the same element stays
-mounted (same size, same position, same `type` toggling under the hood) and
-only its icon cross-fades via `AnimatePresence mode="wait"`:
-
-<PromptComposerSendMorph />
-
-```tsx
-<AnimatePresence mode="wait" initial={false}>
+<LearnChapter
+  label="Send becomes stop, not a different button"
+  scene={<PromptComposerSendMorph />}
+  code={`<AnimatePresence mode="wait" initial={false}>
   {isStreaming ? (
     <motion.span
       key="stop"
@@ -131,8 +128,12 @@ only its icon cross-fades via `AnimatePresence mode="wait"`:
       <ArrowUpIcon />
     </motion.span>
   )}
-</AnimatePresence>
-```
+</AnimatePresence>`}
+>
+
+Streaming doesn't swap in a different `<button>` — the same element stays
+mounted (same size, same position, same `type` toggling under the hood) and
+only its icon cross-fades via `AnimatePresence mode="wait"`:
 
 `mode="wait"` is the detail that makes this read as one icon morphing
 instead of two icons crossing paths: Framer waits for the exiting `key` to
@@ -217,14 +218,18 @@ streaming, the button's `type` is `"button"` and its `onClick` calls
 tracks the same branch (`"Send message"` / `"Stop generating"`), so a
 screen reader announces the swap the icon morph is showing sighted users.
 
-## Motion Score
+</LearnChapter>
 
-<MotionScorePanel name="prompt-composer" />
-
-## The result
-
-<PromptComposerResult />
+<LearnChapter label="The result" scene={<PromptComposerResult />} isResult>
 
 One `<form>`, three rows that never remount, and every "different state" —
 chips present, streaming, a model open, a file mid-drag — expressed as
 props on the same tree instead of a different component underneath it.
+
+</LearnChapter>
+
+</LearnPlayer>
+
+## Motion Score
+
+<MotionScorePanel name="prompt-composer" />

--- a/apps/docs/content/docs/components/ai/prompt-suggestions/learn.mdx
+++ b/apps/docs/content/docs/components/ai/prompt-suggestions/learn.mdx
@@ -1,24 +1,15 @@
 ---
 title: Anatomy of Prompt Suggestions
 description: Three container layouts sharing one item, a spring stagger with a single per-item variable, and a hover lift that never touches layout.
+learnPlayer: true
 ---
 
-An empty composer is the worst state an AI product can ship — a blinking
-cursor and no idea what to type. `PromptSuggestions` fills it with a handful
-of clickable starters that stagger in, lift under the pointer, and hand
-their text straight to `onSelect`. The whole component is one array, one
-`variant` switch, and two small motion systems layered on top.
+<LearnPlayer>
 
-## One item, three wrappers
-
-`PromptSuggestions` doesn't have three separate layouts — it has one
-`motion.button` per suggestion and a lookup table that decides how the
-_wrapper_ arranges them:
-
-<PromptSuggestionsAnatomy />
-
-```tsx
-const CONTAINER_BY_VARIANT: Record<PromptSuggestionsVariant, string> = {
+<LearnChapter
+  label="One item, three wrappers"
+  scene={<PromptSuggestionsAnatomy />}
+  code={`const CONTAINER_BY_VARIANT: Record<PromptSuggestionsVariant, string> = {
   grid: "grid grid-cols-1 gap-2 sm:grid-cols-2",
   chips: "flex flex-wrap gap-2",
   list: "flex flex-col gap-1.5",
@@ -28,8 +19,12 @@ const CONTAINER_BY_VARIANT: Record<PromptSuggestionsVariant, string> = {
   {suggestions.map((suggestion, index) => (
     <motion.button key={suggestion.id ?? suggestion.label} /* … */ />
   ))}
-</div>
-```
+</div>`}
+>
+
+`PromptSuggestions` doesn't have three separate layouts — it has one
+`motion.button` per suggestion and a lookup table that decides how the
+_wrapper_ arranges them:
 
 The button itself branches once, on `isChip`, to pick between a pill
 className and a card className — not a different component per variant:
@@ -47,15 +42,12 @@ That's why `hint` only ever renders outside chips — `{suggestion.hint &&
 second. Swapping `variant` never remounts a different tree; it just changes
 which layout classes and which of these two branches apply.
 
-## A spring stagger with one moving part
+</LearnChapter>
 
-Every suggestion animates in with the same spring. The only thing that
-changes per item is `delay`:
-
-<PromptSuggestionsStagger />
-
-```tsx
-<motion.button
+<LearnChapter
+  label="A spring stagger with one moving part"
+  scene={<PromptSuggestionsStagger />}
+  code={`<motion.button
   initial={reduce ? false : { opacity: 0, y: 8 }}
   animate={{ opacity: 1, y: 0 }}
   transition={{
@@ -65,8 +57,11 @@ changes per item is `delay`:
     damping: 32,
     mass: 0.9,
   }}
-/>
-```
+/>`}
+>
+
+Every suggestion animates in with the same spring. The only thing that
+changes per item is `delay`:
 
 `320/32/0.9` is a slightly underdamped spring — the same feel used across
 GodUI's other enter animations (badges, command palette rows) — so each
@@ -77,23 +72,23 @@ button computing its own 50ms offset from its position in the array.
 Reduced motion collapses `delay` to `0` and swaps `initial` to `false` in
 the same expression — the spring is gone, the layout isn't.
 
-## Hover moves the box, never the layout
+</LearnChapter>
 
-Hover is a second, independent motion system — plain Tailwind, not Framer —
-and it only ever touches `transform` and `opacity`:
-
-<PromptSuggestionsHover />
-
-```tsx
-// chip
+<LearnChapter
+  label="Hover moves the box, never the layout"
+  scene={<PromptSuggestionsHover />}
+  code={`// chip
 "hover:-translate-y-px hover:border-ring hover:bg-accent"
 
 // card
 "hover:-translate-y-0.5 hover:border-ring hover:shadow-md"
 
 // arrow (card only)
-"ml-auto size-4 -translate-x-1 opacity-0 transition-[transform,opacity] group-hover:translate-x-0 group-hover:opacity-100"
-```
+"ml-auto size-4 -translate-x-1 opacity-0 transition-[transform,opacity] group-hover:translate-x-0 group-hover:opacity-100"`}
+>
+
+Hover is a second, independent motion system — plain Tailwind, not Framer —
+and it only ever touches `transform` and `opacity`:
 
 `-translate-y-px` and `-translate-y-0.5` lift the item on the compositor —
 no `top`, no `margin`, nothing the browser has to re-lay-out. The arrow
@@ -104,6 +99,41 @@ size, which is why neighboring text never reflows when the arrow shows up.
 Cards additionally swap `shadow-2xs` for `shadow-md` on hover — the one
 concession to a paint property, and safe here because it's gated behind a
 single hovered element rather than something looping on scroll.
+
+Setting `loading` doesn't hide the component behind a spinner — it renders
+the same container with skeleton placeholders sized per variant:
+
+```tsx
+<div className={CONTAINER_BY_VARIANT[variant]}>
+  {Array.from({ length: skeletonCount }).map((_, i) => (
+    <div
+      key={i}
+      className={`rounded-xl border border-border bg-muted/40 motion-safe:animate-pulse ${
+        variant === "chips" ? "h-9 w-32" : "h-16"
+      }`}
+    />
+  ))}
+</div>
+```
+
+Because it's the exact same `CONTAINER_BY_VARIANT[variant]` wrapper, the
+skeleton grid occupies the same footprint the real suggestions will once
+they arrive — swapping `loading` off never causes a layout jump.
+`motion-safe:animate-pulse` keeps the shimmer itself opt-out under reduced
+motion, same as the entrance spring above.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<PromptSuggestionsResult />} isResult>
+
+One array of suggestions, one `variant` string picking a wrapper class, one
+spring staggered by index, and a hover system that only ever moves
+`transform`/`opacity`. Four small decisions, and an empty composer stops
+feeling empty.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Reduced motion and the keyboard
 
@@ -141,39 +171,6 @@ and `list`, because it walks `itemsRef` (population order), not the DOM's
 `ArrowUp`/`ArrowLeft` both move back, so the same two key pairs make sense
 whether the items are stacked in a column or wrapped in a row.
 
-## Loading is the same grid, no items
-
-Setting `loading` doesn't hide the component behind a spinner — it renders
-the same container with skeleton placeholders sized per variant:
-
-```tsx
-<div className={CONTAINER_BY_VARIANT[variant]}>
-  {Array.from({ length: skeletonCount }).map((_, i) => (
-    <div
-      key={i}
-      className={`rounded-xl border border-border bg-muted/40 motion-safe:animate-pulse ${
-        variant === "chips" ? "h-9 w-32" : "h-16"
-      }`}
-    />
-  ))}
-</div>
-```
-
-Because it's the exact same `CONTAINER_BY_VARIANT[variant]` wrapper, the
-skeleton grid occupies the same footprint the real suggestions will once
-they arrive — swapping `loading` off never causes a layout jump.
-`motion-safe:animate-pulse` keeps the shimmer itself opt-out under reduced
-motion, same as the entrance spring above.
-
 ## Motion Score
 
 <MotionScorePanel name="prompt-suggestions" />
-
-## The result
-
-<PromptSuggestionsResult />
-
-One array of suggestions, one `variant` string picking a wrapper class, one
-spring staggered by index, and a hover system that only ever moves
-`transform`/`opacity`. Four small decisions, and an empty composer stops
-feeling empty.

--- a/apps/docs/content/docs/components/ai/source-citations/learn.mdx
+++ b/apps/docs/content/docs/components/ai/source-citations/learn.mdx
@@ -1,15 +1,32 @@
 ---
 title: Anatomy of Source Citations
 description: How a numbered pill and a floating preview card share one wrapper, bridge a hover gap with two timers, and settle in with a near-critically-damped spring.
+learnPlayer: true
 ---
 
-An AI answer is only as trustworthy as its sources, and a citation only earns
-its keep if reading it costs nothing. `SourceCitation` answers that with a
-pill small enough to sit inside a sentence and a preview card that only
-exists while you're looking at it. `SourceList` answers the same brief for
-the footer: every source, collapsed by default, staggered in when it isn't.
+<LearnPlayer>
 
-## Anatomy of a citation
+<LearnChapter
+  label="Anatomy of a citation"
+  scene={<SourceCitationsAnatomy />}
+  code={`{/* one wrapper — card is a child of this, not of the paragraph */}
+<span className="relative inline-block align-baseline" onMouseEnter={show} onMouseLeave={hide}>
+  <a href={source.url} aria-label={\`Source \${index}: \${source.title}\`}>
+    {index}
+  </a>
+  <AnimatePresence>
+    {open ? (
+      <motion.span
+        role="tooltip"
+        className="absolute bottom-full left-1/2 z-popover mb-2 -translate-x-1/2 ..."
+      >
+        {/* favicon · hostname · title · snippet */}
+        <span className="absolute left-1/2 top-full size-2 -translate-x-1/2 -translate-y-1 rotate-45 ..." />
+      </motion.span>
+    ) : null}
+  </AnimatePresence>
+</span>`}
+>
 
 Think of it as a footnote mark that grows a preview on hover — not a
 standalone tooltip widget floating somewhere else on the page.
@@ -24,30 +41,8 @@ whole trick:
 3. **Caret** — a rotated square at the card's bottom edge; because the card
    is centered on the wrapper, the caret points at the number.
 
-<SourceCitationsAnatomy />
-
-```tsx
-{/* one wrapper — card is a child of this, not of the paragraph */}
-<span className="relative inline-block align-baseline" onMouseEnter={show} onMouseLeave={hide}>
-  <a href={source.url} aria-label={`Source ${index}: ${source.title}`}>
-    {index}
-  </a>
-  <AnimatePresence>
-    {open ? (
-      <motion.span
-        role="tooltip"
-        className="absolute bottom-full left-1/2 z-popover mb-2 -translate-x-1/2 ..."
-      >
-        {/* favicon · hostname · title · snippet */}
-        <span className="absolute left-1/2 top-full size-2 -translate-x-1/2 -translate-y-1 rotate-45 ..." />
-      </motion.span>
-    ) : null}
-  </AnimatePresence>
-</span>
-```
-
 Closed = pill alone. Open = the **same** wrapper with the card mounted
-above the pill. If the caret misses the number, the card is parented wrong.## Bridging the hover gap
+above the pill. If the caret misses the number, the card is parented wrong.
 
 The pill and the card don't touch — there's a couple of pixels of dead air
 between them, plus the `mb-2` gap the card sits in. Close on `mouseleave`
@@ -73,7 +68,18 @@ Keyboard users skip the timers entirely — `onFocus`/`onBlur` on the anchor
 flip `open` immediately, so tabbing to a pill opens the card exactly like a
 deliberate hover would, with no delay to wait out.
 
-## The spring pop
+</LearnChapter>
+
+<LearnChapter
+  label="The spring pop"
+  scene={<SourceCitationsTooltip />}
+  code={`<motion.span
+  initial={{ opacity: 0, y: 6, scale: 0.96 }}
+  animate={{ opacity: 1, y: 0, scale: 1 }}
+  exit={{ opacity: 0, y: 6, scale: 0.96 }}
+  transition={{ type: "spring", stiffness: 320, damping: 32, mass: 0.9 }}
+/>`}
+>
 
 Once `open` flips, `AnimatePresence` mounts the card off
 `initial={{ opacity: 0, y: 6, scale: 0.96 }}` into a spring —
@@ -82,19 +88,6 @@ damped: fast, with barely a flicker of overshoot past `scale: 1`, nothing
 like a springy button's bounce. Exit runs the same shape in reverse, so
 closing doesn't feel like a different animation.
 
-<SourceCitationsTooltip />
-
-```tsx
-<motion.span
-  initial={{ opacity: 0, y: 6, scale: 0.96 }}
-  animate={{ opacity: 1, y: 0, scale: 1 }}
-  exit={{ opacity: 0, y: 6, scale: 0.96 }}
-  transition={{ type: "spring", stiffness: 320, damping: 32, mass: 0.9 }}
-/>
-```
-
-## Why a spring, not a toggle
-
 `y` and `scale` are the only two properties animating, and both are
 transforms — the browser composites the card on the GPU without touching
 layout or paint. A spring over a fixed-duration ease also means the exit
@@ -102,7 +95,18 @@ feels continuous with whatever point the enter had reached: if you close the
 card mid-pop, the spring reverses from there instead of snapping or
 restarting a separate timeline.
 
-## The source list
+</LearnChapter>
+
+<LearnChapter
+  label="The source list"
+  scene={<SourceCitationsList />}
+  code={`<motion.a
+  initial={{ opacity: 0, y: reduce ? 0 : 8 }}
+  animate={{ opacity: 1, y: 0 }}
+  exit={{ opacity: 0, y: reduce ? 0 : -4, transition: { duration: reduce ? 0 : 0.15, ease } }}
+  transition={{ duration: reduce ? 0 : 0.3, ease, delay: reduce ? 0 : Math.min(i, previewCount) * 0.05 }}
+/>`}
+>
 
 `SourceList` is a flatter problem: no hover, no positioning math, just an
 ordered stack that needs to feel alive without dragging every row in one at
@@ -112,19 +116,24 @@ inside a quarter second. Collapsed, only the first `previewCount` rows exist;
 the "+N more" toggle mounts the rest, and they run the identical fade-up on
 their own delay.
 
-<SourceCitationsList />
-
-```tsx
-<motion.a
-  initial={{ opacity: 0, y: reduce ? 0 : 8 }}
-  animate={{ opacity: 1, y: 0 }}
-  exit={{ opacity: 0, y: reduce ? 0 : -4, transition: { duration: reduce ? 0 : 0.15, ease } }}
-  transition={{ duration: reduce ? 0 : 0.3, ease, delay: reduce ? 0 : Math.min(i, previewCount) * 0.05 }}
-/>
-```
-
 The exit is deliberately shorter than the enter (`0.15s` vs `0.3s`) — rows
 leaving on collapse shouldn't linger as long as rows arriving.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<SourceCitationsResult />} isResult>
+
+Both pieces together — the real components. Hover a pill or tab to one to
+feel the spring; open the collapsed rows below to feel the stagger.
+
+Two small mechanisms doing all the work: a wrapper that opens a card exactly
+where you're looking, bridged by two timers so the gap between them never
+trips you up, and a list that arrives one row at a time without ever making
+you wait for it.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility
 
@@ -145,15 +154,3 @@ const reduce = useReducedMotion();
 ## Motion Score
 
 <MotionScorePanel name="source-citations" />
-
-## The result
-
-Both pieces together — the real components. Hover a pill or tab to one to
-feel the spring; open the collapsed rows below to feel the stagger.
-
-<SourceCitationsResult />
-
-Two small mechanisms doing all the work: a wrapper that opens a card exactly
-where you're looking, bridged by two timers so the gap between them never
-trips you up, and a list that arrives one row at a time without ever making
-you wait for it.

--- a/apps/docs/content/docs/components/ai/voice-orb/learn.mdx
+++ b/apps/docs/content/docs/components/ai/voice-orb/learn.mdx
@@ -1,55 +1,54 @@
 ---
 title: Anatomy of the Voice Orb
 description: How a Siri-style orb is three absolute layers, an amp-shaped curve, and a wrapper/child split so scale never fights spin.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="Three layers, one box"
+  scene={<VoiceOrbAnatomy />}
+  code={`<div data-state={state} style={{ "--amp": level } as CSSProperties}>
+  <div style={{ transform: \`scale(\${0.92 + level * 0.35})\` }}>
+    <div className="… animate-voice-orb-spin …" />   {/* corona */}
+  </div>
+  <div className="… animate-voice-orb-breathe …">
+    <div style={{ transform: \`scale(\${1 + level * 0.22})\` }} />  {/* core */}
+  </div>
+  <div data-on={state === "listening"} className="… animate-voice-orb-ring" />
+</div>`}
+>
 
 An orb that "hears" you isn't a shader — it's a corona, a core, and a ring,
 all reading the same `--amp` CSS variable. Here's every piece.
-
-## Three layers, one box
 
 `VoiceOrb` is a square grid with three absolutely positioned children. The
 **corona** is a blurred conic gradient that spins forever. The **core** is a
 radial sphere with a specular highlight. The **listening ring** is a border
 that only exists while `state="listening"`.
 
-<VoiceOrbAnatomy />
-
-```tsx
-<div data-state={state} style={{ "--amp": level } as CSSProperties}>
-  <div style={{ transform: `scale(${0.92 + level * 0.35})` }}>
-    <div className="… animate-voice-orb-spin …" />   {/* corona */}
-  </div>
-  <div className="… animate-voice-orb-breathe …">
-    <div style={{ transform: `scale(${1 + level * 0.22})` }} />  {/* core */}
-  </div>
-  <div data-on={state === "listening"} className="… animate-voice-orb-ring" />
-</div>
-```
-
 Everything shares the same box. Only which layer is visible — and how hard
 `--amp` pushes it — changes with state.
 
-## Why scale and spin live on separate nodes
+</LearnChapter>
+
+<LearnChapter
+  label="Why scale and spin live on separate nodes"
+  scene={<VoiceOrbAmpSplit />}
+  code={`{/* Corona — amplitude swells the wrapper; the inner layer spins. */}
+<div style={{ transform: \`scale(\${0.92 + level * 0.35})\` }}>
+  <div className="animate-voice-orb-spin …" />
+</div>`}
+>
 
 A CSS keyframe that sets `transform: rotate(…)` will overwrite any inline
 `transform: scale(…)`. The fix is structural: put amplitude scale on a
 **wrapper**, put the spin keyframe on the **child**. They compose instead of
 clobbering each other.
 
-<VoiceOrbAmpSplit />
-
-```tsx
-{/* Corona — amplitude swells the wrapper; the inner layer spins. */}
-<div style={{ transform: `scale(${0.92 + level * 0.35})` }}>
-  <div className="animate-voice-orb-spin …" />
-</div>
-```
-
 The core uses the same pattern: `animate-voice-orb-breathe` on the outer
 shell, inline amplitude scale on the painted sphere inside.
-
-## Shaping noisy amplitude
 
 Raw analyser levels jitter. Before they touch CSS, they're clamped and
 eased through `c ** 0.6` — quiet speech gets visible life without loud peaks
@@ -67,9 +66,9 @@ Idle hard-zeros the level so the breathe keyframe is the only motion. The
 listening ring also shortens its duration as level rises
 (`1.6 - level * 0.7`s), so louder input pulses faster.
 
-## The three states
+</LearnChapter>
 
-<VoiceOrbStates />
+<LearnChapter label="The three states" scene={<VoiceOrbStates />}>
 
 | State | What moves |
 | --- | --- |
@@ -80,6 +79,20 @@ listening ring also shortens its duration as level rises
 `useAudioAmplitude` turns a `MediaStream` into that `0`–`1` level via RMS of
 the time-domain waveform, cleaned up with `cancelAnimationFrame` +
 `ctx.close()` when the stream drops.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<VoiceOrbResult />} isResult>
+
+Toggle states and watch the same three layers reconfigure around a live
+`--amp`.
+
+Three layers, one shaped number, and a wrapper/child split so transforms
+compose — that's the whole orb.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility
 
@@ -96,13 +109,3 @@ sphere, just not breathing or spinning.
 ## Motion Score
 
 <MotionScorePanel name="voice-orb" />
-
-## The result
-
-Toggle states and watch the same three layers reconfigure around a live
-`--amp`.
-
-<VoiceOrbResult />
-
-Three layers, one shaped number, and a wrapper/child split so transforms
-compose — that's the whole orb.

--- a/apps/docs/content/docs/components/backgrounds/blueprint-grid/learn.mdx
+++ b/apps/docs/content/docs/components/backgrounds/blueprint-grid/learn.mdx
@@ -1,55 +1,54 @@
 ---
 title: Anatomy of Blueprint Grid
 description: How CSS lattices, a perspective floor, an 8s light sweep, and a parent-owned spotlight build a technical backdrop without canvas.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="Lines and dots"
+  scene={<BlueprintGridAnatomy />}
+  code={`const buildGrid = (c: string) =>
+  variant === "dots"
+    ? \`radial-gradient(\${c} 1px, transparent 1.5px)\`
+    : \`linear-gradient(to right, \${c} 1px, transparent 1px), linear-gradient(to bottom, \${c} 1px, transparent 1px)\`;
+
+backgroundSize:
+  variant === "dots"
+    ? \`\${cellSize}px \${cellSize}px\`
+    : \`\${cellSize}px \${cellSize}px, \${cellSize}px \${cellSize}px\`;`}
+>
 
 `BlueprintGrid` is pure CSS: layered backgrounds, one keyframed sweep, and
 CSS variables for a cursor spotlight. No canvas, no rAF. Drop it first in a
 `relative overflow-hidden` container; your content sits above at `z-raised`.
 
-## Lines and dots
-
 Two recipes share the same `cellSize` (default `32`):
-
-```tsx
-const buildGrid = (c: string) =>
-  variant === "dots"
-    ? `radial-gradient(${c} 1px, transparent 1.5px)`
-    : `linear-gradient(to right, ${c} 1px, transparent 1px), linear-gradient(to bottom, ${c} 1px, transparent 1px)`;
-
-backgroundSize:
-  variant === "dots"
-    ? `${cellSize}px ${cellSize}px`
-    : `${cellSize}px ${cellSize}px, ${cellSize}px ${cellSize}px`;
-```
 
 Color defaults to `var(--border)` so the lattice tracks the theme. The base
 layer sits at `opacity-50` so content above stays readable.
 
-<BlueprintGridAnatomy />
+</LearnChapter>
 
-## Perspective floor
-
-`variant="perspective"` wraps the grid in a 3D stage:
-
-```tsx
-<div className="absolute inset-0 [perspective:600px] [perspective-origin:50%_0%]">
+<LearnChapter
+  label="Perspective floor"
+  scene={<BlueprintGridPerspective />}
+  code={`<div className="absolute inset-0 [perspective:600px] [perspective-origin:50%_0%]">
   <div
     className="absolute right-[-50%] bottom-0 left-[-50%] h-[160%] origin-bottom
       opacity-50 [transform:rotateX(72deg)]
       [mask-image:linear-gradient(to_top,#000,transparent)]"
     style={baseGrid}
   />
-</div>
-```
+</div>`}
+>
+
+`variant="perspective"` wraps the grid in a 3D stage:
 
 The floor is oversized horizontally, tilted `72deg`, and faded toward the
 horizon. **Spotlight is skipped** on this variant — the foreshortening is
 the whole trick, and a radial mask would fight the perspective mask.
-
-<BlueprintGridPerspective />
-
-## Sweep band
 
 When `sweep` is on (default), a blurred diagonal band runs
 `animate-blueprint-sweep`:
@@ -67,19 +66,21 @@ The layer is `w-[55%] h-[140%]` with `blur(14px)` and
 `motion-reduce:hidden` — reduced-motion users keep the lattice, lose the
 traveling light.
 
-## Parent-owned spotlight
+</LearnChapter>
+
+<LearnChapter
+  label="Parent-owned spotlight"
+  scene={<BlueprintGridSweep />}
+  code={`const target = root.offsetParent ?? root;
+root.style.setProperty("--bx", \`\${ev.clientX - rect.left}px\`);
+root.style.setProperty("--by", \`\${ev.clientY - rect.top}px\`);
+root.style.setProperty("--bo", "0.55");
+// leave → --bo = 0`}
+>
 
 Spotlight listeners attach to `offsetParent` (the nearest positioned
 ancestor), not the grid root — so moving over content stacked above still
 drives the disc:
-
-```tsx
-const target = root.offsetParent ?? root;
-root.style.setProperty("--bx", `${ev.clientX - rect.left}px`);
-root.style.setProperty("--by", `${ev.clientY - rect.top}px`);
-root.style.setProperty("--bo", "0.55");
-// leave → --bo = 0
-```
 
 The accent layer is an accent-colored copy of the grid plus a soft glow,
 both clipped with:
@@ -89,17 +90,19 @@ maskImage: `radial-gradient(circle ${spotlightRadius}px at var(--bx) var(--by), 
 opacity: "var(--bo)" // transition 300ms ease-out
 ```
 
-<BlueprintGridSweep />
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<BlueprintGridResult />} isResult>
+
+Move across the stage — the spotlight follows through the content layer.
+
+Lattice, optional floor, one keyframe, one parent pointer — technical
+atmosphere without a canvas.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Motion Score
 
 <MotionScorePanel name="blueprint-grid" />
-
-## The result
-
-Move across the stage — the spotlight follows through the content layer.
-
-<BlueprintGridResult />
-
-Lattice, optional floor, one keyframe, one parent pointer — technical
-atmosphere without a canvas.

--- a/apps/docs/content/docs/components/backgrounds/flow-field/learn.mdx
+++ b/apps/docs/content/docs/components/backgrounds/flow-field/learn.mdx
@@ -1,29 +1,30 @@
 ---
 title: Anatomy of Flow Field
 description: How value noise becomes a vector field, how a translucent wipe leaves silk trails, and how observers keep the rAF loop cheap when idle.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="Noise → angle → step"
+  scene={<FlowFieldAnatomy />}
+  code={`const angle =
+  valueNoise(p.x * noiseScale, p.y * noiseScale + z) * Math.PI * 4;
+p.x += Math.cos(angle) * 1.6 * speed;
+p.y += Math.sin(angle) * 1.6 * speed;
+z += 0.0008 * speed; // field evolves slowly`}
+>
 
 `FlowField` paints particles on a canvas that stream along an evolving noise
 field. There is no SVG path and no retained trail geometry — each frame
 samples noise for an angle, steps the particle, then fades the whole buffer
 a hair so yesterday's stroke lingers as silk.
 
-## Noise → angle → step
-
 Per particle, every frame:
-
-```tsx
-const angle =
-  valueNoise(p.x * noiseScale, p.y * noiseScale + z) * Math.PI * 4;
-p.x += Math.cos(angle) * 1.6 * speed;
-p.y += Math.sin(angle) * 1.6 * speed;
-z += 0.0008 * speed; // field evolves slowly
-```
 
 `noiseScale` defaults to `0.0016` — smaller means broader, smoother
 currents. `speed` scales both the step and the z drift.
-
-<FlowFieldAnatomy />
 
 Particle count defaults to `900`, then clamps so dense viewports don't melt
 the main thread:
@@ -32,24 +33,26 @@ the main thread:
 Math.max(120, Math.min(particleCount, Math.round((w * h) / 1400)))
 ```
 
-## Fade wipe trails
+</LearnChapter>
+
+<LearnChapter
+  label="Fade wipe trails"
+  scene={<FlowFieldTrails />}
+  code={`ctx.fillStyle = \`rgba(\${br}, \${bg}, \${bb}, \${fade})\`; // default fade = 0.06
+ctx.fillRect(0, 0, w, h);
+// then stroke each particle's latest segment in --primary`}
+>
 
 Instead of storing polylines, every frame fills the canvas with a translucent
 rect in the background color:
-
-```tsx
-ctx.fillStyle = `rgba(${br}, ${bg}, ${bb}, ${fade})`; // default fade = 0.06
-ctx.fillRect(0, 0, w, h);
-// then stroke each particle's latest segment in --primary
-```
 
 Lower `fade` → longer, silkier wakes. Higher → crisp, short ticks. Theme
 colors re-resolve via a `MutationObserver` on `<html>` (`class` /
 `data-theme` / `style`) so light and dark both stay correct.
 
-<FlowFieldTrails />
+</LearnChapter>
 
-## Cheap when offscreen
+<LearnChapter label="Cheap when offscreen" scene={<FlowFieldLifecycle />}>
 
 Three gates stop the loop when work would be wasted:
 
@@ -61,15 +64,17 @@ Three gates stop the loop when work would be wasted:
 
 `ResizeObserver` rebuilds the buffer when the container changes size.
 
-<FlowFieldLifecycle />
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<FlowFieldResult />} isResult>
+
+Sample → step → wipe. A living field that refuses to burn frames when nobody
+is looking.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Motion Score
 
 <MotionScorePanel name="flow-field" />
-
-## The result
-
-<FlowFieldResult />
-
-Sample → step → wipe. A living field that refuses to burn frames when nobody
-is looking.

--- a/apps/docs/content/docs/components/backgrounds/light-rays/learn.mdx
+++ b/apps/docs/content/docs/components/backgrounds/light-rays/learn.mdx
@@ -1,13 +1,28 @@
 ---
 title: Anatomy of Light Rays
 description: How a top glow, a repeating-conic fan, a ±6° breathe, and optional film grain stack into volumetric god-rays — all pure CSS.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="Three plates, one pivot"
+  scene={<LightRaysAnatomy />}
+  code={`const step = 360 / rayCount;
+const rayColor = \`color-mix(in oklab, \${color}, transparent 55%)\`;
+
+repeating-conic-gradient(
+  from \${angle}deg at 50% 0%,
+  transparent 0deg,
+  \${rayColor} \${step * 0.16}deg,
+  transparent \${step}deg,
+)`}
+>
 
 `LightRays` is three stacked layers and one keyframe. No canvas, no rAF —
 just paint, an oversized transform, and an optional SVG noise overlay. Drop
 it first in a `relative overflow-hidden` container.
-
-## Three plates, one pivot
 
 Read left → right. Every plate shares the same top-center origin:
 
@@ -17,36 +32,24 @@ Read left → right. Every plate shares the same top-center origin:
 3. **Soft fan** — those wedges at `inset-[-50%]`, `blur(8px)`, faded with a
    bottom mask. Oversizing is why a ±6° rotate never flashes an empty edge.
 
-```tsx
-const step = 360 / rayCount;
-const rayColor = `color-mix(in oklab, ${color}, transparent 55%)`;
-
-repeating-conic-gradient(
-  from ${angle}deg at 50% 0%,
-  transparent 0deg,
-  ${rayColor} ${step * 0.16}deg,
-  transparent ${step}deg,
-)
-```
-
 Color defaults to `var(--primary)`. Intensity (`0.6` default) sets the fan
 opacity.
 
-<LightRaysAnatomy />
+</LearnChapter>
 
-## The sweep is tiny on purpose
-
-Rest vs live. The live plate runs `animate-light-rays-sweep`:
-
-```css
-@keyframes light-rays-sweep {
+<LearnChapter
+  label="The sweep is tiny on purpose"
+  scene={<LightRaysSweep />}
+  code={`@keyframes light-rays-sweep {
   0%   { transform: rotate(calc(var(--rays-angle) - 6deg)) scale(1);
          opacity: calc(var(--rays-intensity) * 0.7); }
   100% { transform: rotate(calc(var(--rays-angle) + 6deg)) scale(1.08);
          opacity: var(--rays-intensity); }
 }
-/* duration: var(--rays-speed, 14s) = 14 / speed · ease-in-out alternate */
-```
+/* duration: var(--rays-speed, 14s) = 14 / speed · ease-in-out alternate */`}
+>
+
+Rest vs live. The live plate runs `animate-light-rays-sweep`:
 
 ```tsx
 style={{ "--rays-speed": `${14 / speed}s`, "--rays-angle": `${angle}deg`, … }}
@@ -56,31 +59,33 @@ The needle in the diagram tracks that same arc so the motion is not lost in
 the blur. `motion-reduce:animate-none` freezes the fan — glow and wedges
 stay.
 
-<LightRaysSweep />
+</LearnChapter>
 
-## Grain is an overlay, not a texture bake
-
-Clean fan → `feTurbulence` field → both with `mix-blend-overlay`. Default
-`grain={0.05}` is almost subliminal; set `0` to omit the SVG entirely.
-
-```tsx
-<feTurbulence
+<LearnChapter
+  label="Grain is an overlay, not a texture bake"
+  scene={<LightRaysGrain />}
+  code={`<feTurbulence
   type="fractalNoise"
   baseFrequency="0.9"
   numOctaves={2}
   stitchTiles="stitch"
 />
-// rect opacity = grain, mix-blend-overlay
-```
+// rect opacity = grain, mix-blend-overlay`}
+>
 
-<LightRaysGrain />
+Clean fan → `feTurbulence` field → both with `mix-blend-overlay`. Default
+`grain={0.05}` is almost subliminal; set `0` to omit the SVG entirely.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<LightRaysResult />} isResult>
+
+Three layers, one keyframe, optional grit — compositor-only the whole way.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Motion Score
 
 <MotionScorePanel name="light-rays" />
-
-## The result
-
-<LightRaysResult />
-
-Three layers, one keyframe, optional grit — compositor-only the whole way.

--- a/apps/docs/content/docs/components/backgrounds/liquid-metaballs/learn.mdx
+++ b/apps/docs/content/docs/components/backgrounds/liquid-metaballs/learn.mdx
@@ -1,30 +1,29 @@
 ---
 title: Anatomy of Liquid Metaballs
 description: How SVG circles, a classic goo filter, toroidal drift, and a cursor blob merge without React re-renders per frame.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="Circles, not meshes"
+  scene={<LiquidMetaballsAnatomy />}
+  code={`b.r = min * (0.08 + Math.random() * 0.08);
+b.vx = (Math.random() - 0.5) * 0.6 * speed;
+b.vy = (Math.random() - 0.5) * 0.6 * speed;`}
+>
 
 `LiquidMetaballs` is physics on SVG circles under a blur + contrast filter.
 Positions update with `setAttribute` so React stays out of the hot path —
 the rAF loop never calls `setState`.
 
-## Circles, not meshes
-
 Defaults: `blobCount={7}`, colors cycling
 `#6366f1 / #a855f7 / #ec4899 / #06b6d4`, radii roughly `8–16%` of the short
 side, velocity `(rand - 0.5) * 0.6 * speed`.
 
-```tsx
-b.r = min * (0.08 + Math.random() * 0.08);
-b.vx = (Math.random() - 0.5) * 0.6 * speed;
-b.vy = (Math.random() - 0.5) * 0.6 * speed;
-```
-
 Edges wrap toroidally — leave left, enter right — so the field never piles
 up in a corner.
-
-<LiquidMetaballsAnatomy />
-
-## Why `setAttribute`, not React
 
 ```tsx
 const paint = () => {
@@ -38,36 +37,48 @@ const paint = () => {
 Writing attributes skips reconciliation. The circles are created once; the
 loop only mutates geometry.
 
-## The goo chain
+</LearnChapter>
+
+<LearnChapter
+  label="The goo chain"
+  scene={<LiquidMetaballsGoo />}
+  code={`<feGaussianBlur stdDeviation={gooeyness} />  {/* default 16 */}
+<feColorMatrix values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 20 -9" />`}
+>
 
 Classic metaball filter — blur, then punch alpha back up with a contrast
 matrix:
 
-```tsx
-<feGaussianBlur stdDeviation={gooeyness} />  {/* default 16 */}
-<feColorMatrix values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 20 -9" />
-```
-
 Overlapping discs fuse into one liquid silhouette. Higher `gooeyness` =
 softer merge.
 
-<LiquidMetaballsGoo />
+</LearnChapter>
 
-## Cursor merge
+<LearnChapter
+  label="Cursor merge"
+  scene={<LiquidMetaballsCursor />}
+  code={`cursorRef.current?.setAttribute("r", active ? \`\${min * 0.1}\` : "0");
+cursorRef.current?.setAttribute("cx", \`\${cursor.x}\`);
+cursorRef.current?.setAttribute("cy", \`\${cursor.y}\`);`}
+>
 
 With `interactive` (default), an extra circle follows the pointer. While
 active its radius is `min(w,h) * 0.1`; on leave it collapses to `0` so no
 orphan disc remains:
 
-```tsx
-cursorRef.current?.setAttribute("r", active ? `${min * 0.1}` : "0");
-cursorRef.current?.setAttribute("cx", `${cursor.x}`);
-cursorRef.current?.setAttribute("cy", `${cursor.y}`);
-```
-
 It shares the same goo filter, so it melts into neighbors on contact.
 
-<LiquidMetaballsCursor />
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<LiquidMetaballsResult />} isResult>
+
+Move to merge. Leave and the cursor blob vanishes.
+
+Physics on attributes, fusion in a filter, zero React re-renders per frame.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Lifecycle + a11y
 
@@ -79,11 +90,3 @@ positions simply freeze). Root is `aria-hidden`; the SVG is
 ## Motion Score
 
 <MotionScorePanel name="liquid-metaballs" />
-
-## The result
-
-Move to merge. Leave and the cursor blob vanishes.
-
-<LiquidMetaballsResult />
-
-Physics on attributes, fusion in a filter, zero React re-renders per frame.

--- a/apps/docs/content/docs/components/backgrounds/pixel-grid/learn.mdx
+++ b/apps/docs/content/docs/components/backgrounds/pixel-grid/learn.mdx
@@ -1,57 +1,60 @@
 ---
 title: Anatomy of Pixel Grid
 description: How stochastic flicker, a smoothstep cursor reveal, and intensity lerping turn a canvas of squares into an automatic field or a spotlight.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="The lattice"
+  scene={<PixelGridAnatomy />}
+  code={`squareSize = 4
+gridGap = 6
+maxOpacity = 0.3
+// color defaults to --foreground, re-probed on theme change`}
+>
 
 `PixelGrid` is a canvas lattice of tiny squares. In auto mode they flicker
 on a probability clock; in interactive mode a soft spotlight reveals them
 under the cursor. Defaults favor the spotlight (`interactive={true}`,
 `cursorReveal="hidden"`).
 
-## The lattice
-
-```tsx
-squareSize = 4
-gridGap = 6
-maxOpacity = 0.3
-// color defaults to --foreground, re-probed on theme change
-```
-
 Each cell is a filled rect. Opacity is the only animated channel — no
 transforms, no layout.
 
-<PixelGridAnatomy />
+</LearnChapter>
 
-## Flicker probability
+<LearnChapter
+  label="Flicker probability"
+  scene={<PixelGridFlicker />}
+  code={`// P(re-roll) ≈ flickerChance * dt   (default flickerChance = 0.3 / s)
+if (Math.random() < flickerChance * dt) {
+  opacity = Math.random() * maxOpacity;
+}`}
+>
 
 In auto mode (or inside the spotlight), each second a square re-rolls with
 probability scaled by frame delta:
 
-```tsx
-// P(re-roll) ≈ flickerChance * dt   (default flickerChance = 0.3 / s)
-if (Math.random() < flickerChance * dt) {
-  opacity = Math.random() * maxOpacity;
-}
-```
-
 That keeps the field alive without a fixed phase on every cell.
 
-<PixelGridFlicker />
+</LearnChapter>
 
-## Smoothstep reveal
-
-Interactive mode tracks the pointer and eases an `intensity` toward a
-target (1 while over the surface, 0 on leave):
-
-```tsx
-pointer.intensity +=
+<LearnChapter
+  label="Smoothstep reveal"
+  scene={<PixelGridReveal />}
+  code={`pointer.intensity +=
   (pointer.target - pointer.intensity) * Math.min(dt * 8, 1);
 
 const t = /* 0..1 distance falloff inside interactionRadius */;
 const reveal =
   t * t * (3 - 2 * t) * interactionStrength * pointer.intensity;
-// smoothstep — soft edge, not a hard disc
-```
+// smoothstep — soft edge, not a hard disc`}
+>
+
+Interactive mode tracks the pointer and eases an `intensity` toward a
+target (1 while over the surface, 0 on leave):
 
 `cursorReveal` picks the baseline outside the disc:
 
@@ -63,23 +66,23 @@ const reveal =
 Default radius is `120`. Reduced motion stops the rAF and paints one still
 frame.
 
-<PixelGridReveal />
-
-## Lifecycle
-
 `ResizeObserver` (when width/height are unset) and `IntersectionObserver`
 gate the loop. There is no `visibilitychange` listener here — unlike Flow
 Field — so keep that in mind if you leave a tab open on a huge grid.
 
-## Motion Score
+</LearnChapter>
 
-<MotionScorePanel name="pixel-grid" />
-
-## The result
+<LearnChapter label="The result" scene={<PixelGridResult />} isResult>
 
 Move across the stage — squares bloom under the pointer.
 
-<PixelGridResult />
-
 Probability flicker, smoothstep falloff, intensity lerp. A spotlight that
 costs almost nothing when it is off screen.
+
+</LearnChapter>
+
+</LearnPlayer>
+
+## Motion Score
+
+<MotionScorePanel name="pixel-grid" />

--- a/apps/docs/content/docs/components/backgrounds/topographic-drift/learn.mdx
+++ b/apps/docs/content/docs/components/backgrounds/topographic-drift/learn.mdx
@@ -1,41 +1,39 @@
 ---
 title: Anatomy of Topographic Drift
 description: How an 18px noise grid, a 16-case marching-squares switch, and a creeping z-offset redraw living contour lines every frame — then freeze under reduced motion.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="Sample the field"
+  scene={<TopographicDriftAnatomy />}
+  code={`field[j * stride + i] = valueNoise(
+  i * cell * noiseScale,       // default noiseScale = 0.004
+  j * cell * noiseScale + z,
+);`}
+>
 
 `TopographicDrift` is not an SVG map you morph. Every frame it **samples** a
 value-noise field onto a coarse grid, **connects** isolines with marching
 squares, and **nudges** the noise's z-offset so the terrain slowly drifts.
 The canvas clears and redraws — there is no retained path geometry.
 
-## Sample the field
-
 Corners sit on an ~`18px` lattice. Each corner stores one noise value:
-
-```tsx
-field[j * stride + i] = valueNoise(
-  i * cell * noiseScale,       // default noiseScale = 0.004
-  j * cell * noiseScale + z,
-);
-```
 
 `lineCount` (default `9`) is how many elevation levels you stroke afterward —
 not how many grid cells you have.
 
-<TopographicDriftAnatomy />
-
 The dots in the diagram are those sample corners. Darker / lighter is just
 noise amplitude so you can see the field before any lines are drawn.
 
-## Marching squares → isolines
+</LearnChapter>
 
-For every cell and every level `l / (lineCount + 1)`, the four corners
-become a 4-bit mask (`tl|tr|br|bl`). Mask `0` and `15` skip (all below /
-all above). Everything else picks edge midpoints by linear interpolation and
-strokes one or two segments — the classic 16-case table.
-
-```tsx
-let id = 0;
+<LearnChapter
+  label="Marching squares → isolines"
+  scene={<TopographicDriftMarch />}
+  code={`let id = 0;
 if (tl > level) id |= 8;
 if (tr > level) id |= 4;
 if (br > level) id |= 2;
@@ -43,8 +41,13 @@ if (bl > level) id |= 1;
 if (id === 0 || id === 15) continue;
 
 const top = x + cell * ((level - tl) / (tr - tl || 1e-6));
-// …right, bottom, left — then switch (id) { case 1: seg(…); … }
-```
+// …right, bottom, left — then switch (id) { case 1: seg(…); … }`}
+>
+
+For every cell and every level `l / (lineCount + 1)`, the four corners
+become a 4-bit mask (`tl|tr|br|bl`). Mask `0` and `15` skip (all below /
+all above). Everything else picks edge midpoints by linear interpolation and
+strokes one or two segments — the classic 16-case table.
 
 Stroke alpha peaks on mid-levels and falls off toward the extremes:
 
@@ -52,37 +55,39 @@ Stroke alpha peaks on mid-levels and falls off toward the extremes:
 0.1 + 0.25 * (1 - Math.abs(0.5 - level) * 2)
 ```
 
-<TopographicDriftMarch />
+</LearnChapter>
 
-## Drift is just `z`
-
-The "living map" feeling is one line in the tick:
-
-```tsx
-const tick = () => {
+<LearnChapter
+  label="Drift is just z"
+  scene={<TopographicDriftDrift />}
+  code={`const tick = () => {
   z += 0.0015 * speed;
   draw(); // sampleField() + marching squares again
   rafId = requestAnimationFrame(tick);
-};
-```
+};`}
+>
+
+The "living map" feeling is one line in the tick:
 
 Same lifecycle as the other canvas backgrounds: `ResizeObserver` rebuilds the
 grid, `IntersectionObserver` and `visibilitychange` pause offscreen / when the
 tab hides, and `prefers-reduced-motion` stops the loop on a still frame.
 
-<TopographicDriftDrift />
-
 Color comes from `--foreground` (or a `color` prop), re-probed when the
 document theme mutates — so light and dark both stay legible without a baked
 palette.
 
-## Motion Score
+</LearnChapter>
 
-<MotionScorePanel name="topographic-drift" />
-
-## The result
-
-<TopographicDriftResult />
+<LearnChapter label="The result" scene={<TopographicDriftResult />} isResult>
 
 Sample → march → nudge `z`. Contours without a mesh, motion without morphing
 paths.
+
+</LearnChapter>
+
+</LearnPlayer>
+
+## Motion Score
+
+<MotionScorePanel name="topographic-drift" />

--- a/apps/docs/content/docs/components/backgrounds/warp-starfield/learn.mdx
+++ b/apps/docs/content/docs/components/backgrounds/warp-starfield/learn.mdx
@@ -1,43 +1,42 @@
 ---
 title: Anatomy of Warp Starfield
 description: How perspective projection (focal / z), optional warp streaks, and a 0.06 parallax lerp fly a canvas starfield that pauses when you look away.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="Perspective: focal / z"
+  scene={<WarpStarfieldAnatomy />}
+  code={`focal = Math.max(w, h) * 0.6;
+const k = focal / s.z;
+const sx = cx + s.x * k;
+const sy = cy + s.y * k;
+const t = 1 - s.z / maxZ;
+const size = Math.max(0.4, t * 2.2);
+const alpha = Math.min(1, t * 1.2);`}
+>
 
 `WarpStarfield` keeps a cloud of stars in normalized 3D (`x, y ∈ [-1, 1]`,
 `z ∈ (0, depth]`). Each frame it projects them onto the canvas, optionally
 strokes a hyperspace trail, and eases the projection center toward the
 pointer. No textures — points (or lines) and a `requestAnimationFrame` loop.
 
-## Perspective: `focal / z`
-
 Stars closer to the camera (small `z`) project farther from center and draw
 larger / more opaque. The focal length is derived from the surface:
-
-```tsx
-focal = Math.max(w, h) * 0.6;
-const k = focal / s.z;
-const sx = cx + s.x * k;
-const sy = cy + s.y * k;
-const t = 1 - s.z / maxZ;
-const size = Math.max(0.4, t * 2.2);
-const alpha = Math.min(1, t * 1.2);
-```
 
 Every frame `s.z` decreases by `dz`. When it dips to `≤ 0.02`, the star
 respawns at the far plane (`spawn(maxZ)`). Count is clamped with
 `max(80, min(starCount, area / 2200))` so phone-sized heroes don't spawn
 hundreds of dots.
 
-<WarpStarfieldAnatomy />
+</LearnChapter>
 
-## Cruise vs warp
-
-Default cruise fills a disc. Flip `warp` and the brush strokes from the
-**previous** projected point to the current one — a streak — while `dz`
-doubles:
-
-```tsx
-const dz = 0.004 * speed * (warp ? 2 : 1);
+<LearnChapter
+  label="Cruise vs warp"
+  scene={<WarpStarfieldWarp />}
+  code={`const dz = 0.004 * speed * (warp ? 2 : 1);
 
 if (warp) {
   const k2 = focal / pz; // z before this frame's step
@@ -47,42 +46,48 @@ if (warp) {
 } else {
   ctx.arc(sx, sy, size, 0, Math.PI * 2);
   ctx.fill();
-}
-```
+}`}
+>
 
-<WarpStarfieldWarp />
+Default cruise fills a disc. Flip `warp` and the brush strokes from the
+**previous** projected point to the current one — a streak — while `dz`
+doubles:
 
-## Parallax is a lazy center
+</LearnChapter>
+
+<LearnChapter
+  label="Parallax is a lazy center"
+  scene={<WarpStarfieldParallax />}
+  code={`pointer.x += (pointer.tx - pointer.x) * 0.06;
+pointer.y += (pointer.ty - pointer.y) * 0.06;
+const cx = w / 2 + pointer.x * parallax; // default parallax = 30
+const cy = h / 2 + pointer.y * parallax;`}
+>
 
 Pointer position is normalized to `[-0.5, 0.5]` on the container. The draw
 loop never snaps — it lerps:
-
-```tsx
-pointer.x += (pointer.tx - pointer.x) * 0.06;
-pointer.y += (pointer.ty - pointer.y) * 0.06;
-const cx = w / 2 + pointer.x * parallax; // default parallax = 30
-const cy = h / 2 + pointer.y * parallax;
-```
 
 Leave the surface and targets ease back to `0`. Same offscreen / hidden-tab /
 reduced-motion gates as Flow Field: stop the rAF when nothing can see it;
 under reduced motion, paint one still frame.
 
-<WarpStarfieldParallax />
-
 Star color tracks `--foreground` (or a `color` prop) via a theme
 `MutationObserver`, so the field stays high-contrast in light and dark.
 
-## Motion Score
+</LearnChapter>
 
-<MotionScorePanel name="warp-starfield" />
-
-## The result
+<LearnChapter label="The result" scene={<WarpStarfieldResult />} isResult>
 
 Move across the stage — the vanishing point drifts. The live demo stays in
 cruise (`warp={false}`); set `warp` when you want streaks.
 
-<WarpStarfieldResult />
-
 Project, recycle, optionally streak, ease the center. A starfield that costs
 nothing when it is off screen.
+
+</LearnChapter>
+
+</LearnPlayer>
+
+## Motion Score
+
+<MotionScorePanel name="warp-starfield" />

--- a/apps/docs/content/docs/components/buttons/gooey-fab/learn.mdx
+++ b/apps/docs/content/docs/components/buttons/gooey-fab/learn.mdx
@@ -1,143 +1,151 @@
 ---
 title: Anatomy of the Gooey FAB
 description: How a floating action button fuses satellite blobs with an SVG metaball filter, then springs them apart on a staggered timeline.
+learnPlayer: true
 ---
 
-A FAB that splits like mercury isn't a canvas trick — it's two layers of
-circles, one SVG filter, and a spring. Here's every piece, pulled apart.
+<LearnPlayer>
 
-## The two-layer stack
+<LearnChapter
+  label="The two-layer stack"
+  scene={<GooeyLayers />}
+  code={`{/* Blob layer — native SVG so the filter survives Safari compositing. */}
+<svg aria-hidden style={{ overflow: "visible" }}>
+  <g className="fill-primary" filter={reduce ? undefined : \`url(#\${filterId})\`}>
+    <circle cx={0} cy={0} r={trigger / 2} />
+    {actions.map((action) => (
+      <motion.circle key={action.label} cx={0} cy={0} r={sat / 2} />
+    ))}
+  </g>
+</svg>
 
-The goo only works on soft, solid shapes. Icons need sharp edges and real hit
-targets. So every open satellite is drawn twice in the same place: a **blob**
-(filled circle under the SVG filter) and a **control** (transparent button with
-the icon). The trigger is the same idea at the base — soft paint underneath, a
-sharp face on top.
-
-<GooeyLayers />
-
-Same open FAB three ways: blobs alone, controls alone, then both. The third
-column is what you get in the Result — liquid shape with readable icons.
-
-```tsx
-{/* Blob layer: solid circles that merge under the goo filter. */}
-<div aria-hidden style={reduce ? undefined : { filter: `url(#${filterId})` }}>
-  <div className="rounded-full bg-primary" style={{ width: trigger, height: trigger }} />
-  {actions.map(/* motion.div satellites */)}
-</div>
-
-{/* Control layer: sharp, clickable icon buttons over the blobs. */}
+{/* Control layer — sharp, clickable icon buttons over the blobs. */}
 <div className="absolute inset-0 grid place-items-center">
-  {actions.map(/* motion.button satellites */)}
-</div>
-```
+  {actions.map((action) => (
+    <motion.button key={action.label} aria-label={action.label}>
+      {action.icon}
+    </motion.button>
+  ))}
+</div>`}
+>
 
-## The goo filter
+The goo only works on soft, solid shapes; icons need sharp edges and real hit
+targets. So every open satellite is drawn twice in the same place — a **blob** (a
+filled circle under the SVG filter) and a **control** (a transparent button with
+the icon). Apply the filter to the icons and they smear into illegible mush; skip
+it on the paint and you get hard circles with no mercury bridge. Splitting the
+job keeps both the illusion and the usability: the control layer owns
+`pointer-events`, `tabIndex`, and `aria-label`; the blob layer is `aria-hidden`.
 
-The liquid look is two SVG filter primitives. `feGaussianBlur` softens every
-edge so nearby shapes bleed into each other. `feColorMatrix` then punches the
-alpha channel back up — multiply by 20, subtract 10 — so the soft overlap
-collapses into a hard metaball bridge while the rest of the shape stays
-crisp.
+The blob layer is **native SVG** — circles inside the filtered `<g>` — not
+filtered HTML. Safari promotes a transform-animated HTML child onto its own
+compositing layer, which escapes an HTML `filter: url()` and breaks the merge;
+SVG shapes stay inside the filter and fuse on every engine.
 
-<GooeyFilter />
+</LearnChapter>
 
-```tsx
-<filter id={filterId}>
+<LearnChapter
+  label="The goo filter"
+  scene={<GooeyFilter />}
+  code={`<filter id={filterId} colorInterpolationFilters="sRGB">
   <feGaussianBlur in="SourceGraphic" stdDeviation="6" result="blur" />
   <feColorMatrix
     in="blur"
     mode="matrix"
     values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 20 -10"
-    result="goo"
   />
-</filter>
-```
+</filter>`}
+>
 
-That matrix only touches alpha (`0 0 0 20 -10` in the last row). Color channels
-pass through untouched — the goo is a shape effect, not a tint.
+The liquid look is two SVG filter primitives. `feGaussianBlur` softens every edge
+so nearby shapes bleed into each other; `feColorMatrix` then punches the alpha
+channel back up — multiply by 20, subtract 10 — so the soft overlap collapses
+into a hard metaball bridge while the rest of the shape stays crisp.
 
-## Why separate layers
+That matrix only touches alpha (`0 0 0 20 -10` in the last row). The color
+channels pass through untouched, so the goo is a shape effect, not a tint.
 
-Apply the filter to the icons and they smear into illegible blobs. Skip it on
-the paint layer and you get a stack of hard circles with no mercury bridge.
-Splitting the job — soft paint underneath, sharp controls on top — keeps the
-illusion and the usability. The control layer also owns `pointer-events`,
-`tabIndex`, and `aria-label`; the blob layer is `aria-hidden` and
-`pointer-events-none`.
+</LearnChapter>
 
-## Spring extrusion
+<LearnChapter
+  label="Spring extrusion"
+  scene={<GooeySpring />}
+  code={`const target = offsetFor(direction, step * (i + 1));
+
+<motion.circle
+  animate={
+    open
+      ? { x: target.x, y: target.y, scale: 1, opacity: 1 }
+      : { x: 0, y: 0, scale: 0.2, opacity: 0 }
+  }
+  transition={
+    reduce
+      ? { duration: 0.15 }
+      : {
+          type: "spring",
+          stiffness: 170,
+          damping: 12,
+          mass: 0.1,
+          delay: open ? i * 0.04 : (actions.length - i) * 0.02,
+        }
+  }
+/>`}
+>
 
 Depth is the filter; _motion_ is a spring. Each satellite animates `x` / `y` /
-`scale` / `opacity` with Framer Motion: `stiffness: 170`, `damping: 12`,
-`mass: 0.1`. On open they stagger out (`i × 40ms`); on close they reverse
-(`(n − i) × 20ms`) so the farthest blob snaps home first. The trigger's plus
-rotates `135°` on the same spring into a cross.
+`scale` / `opacity` with `stiffness: 170`, `damping: 12`, `mass: 0.1`. On open
+they stagger out (`i × 40ms`); on close they reverse (`(n − i) × 20ms`) so the
+farthest blob snaps home first. Icons lag the blobs by an extra `30ms` on open —
+the goo bridge forms a beat before the sharp glyph lands, which sells the
+"extrude then solidify" read.
 
-<GooeySpring />
+Offsets never touch `top` / `left` or resize the parent — they come from
+`offsetFor()` and land in Framer's `x` / `y`, GPU-composited transforms. The
+wrapper stays a fixed `trigger × trigger` box, so opening the menu never reflows
+the page. Same house rule as the rest of GodUI: compositor props only.
 
-```tsx
-transition={
-  reduce
-    ? { duration: 0.15 }
-    : {
-        type: "spring",
-        stiffness: 170,
-        damping: 12,
-        mass: 0.1,
-        delay: open ? i * 0.04 : (actions.length - i) * 0.02,
-      }
-}
-```
+</LearnChapter>
 
-Icons lag the blobs by an extra `30ms` on open — the goo bridge forms a beat
-before the sharp glyph lands, which sells the "extrude then solidify" read.
+<LearnChapter label="The result" scene={<GooeyFabResult />} isResult>
 
-## Why transform, not layout
+Every piece, assembled — the real component. Open it, pick an action, watch the
+blobs fuse and split. Each motion is one of the mechanisms above doing its job:
+soft circles under a blur matrix, sharp buttons on top, one spring timeline, and
+the discipline to keep the filter off anything you still need to read.
 
-Satellites never animate `top` / `left` or resize the parent. Offsets come from
-`offsetFor(direction, step * (i + 1))` and land in Framer's `x` / `y` — GPU
-composited transforms. The wrapper stays a fixed `trigger × trigger` box, so
-opening the menu doesn't reflow the page. Same house rule as the rest of
-GodUI: compositor props only.
+</LearnChapter>
 
-```tsx
-const target = offsetFor(direction, step * (i + 1));
-animate={
-  open
-    ? { x: target.x, y: target.y, scale: 1, opacity: 1 }
-    : { x: 0, y: 0, scale: 0.2, opacity: 0 }
-}
-```
+</LearnPlayer>
 
 ## Accessibility
 
-`useReducedMotion()` swaps the spring for a `150ms` fade and drops the goo
-filter entirely — no smear for anyone who's asked the OS to cut motion. Closed
+`useReducedMotion()` swaps the spring for a `150ms` fade and drops the goo filter
+entirely — no smear for anyone who's asked the OS to cut motion. Closed
 satellites get `tabIndex={-1}` and `pointerEvents: "none"` so they can't steal
 focus; open ones take `0` and become real buttons. The trigger exposes
-`aria-expanded` and a label; every satellite carries its own `aria-label`.
+`aria-expanded` and a label; every satellite carries its own `aria-label`, and
 `focus-visible` rings land on both layers with a `2px` offset.
 
 ```tsx
 const reduce = useReducedMotion() ?? false;
-// …
+
+// Blob layer drops the filter entirely under reduced motion:
+filter={reduce ? undefined : `url(#${filterId})`}
+
+// Closed satellites can't steal focus or clicks; open ones become buttons:
 tabIndex={open ? 0 : -1}
-pointerEvents: open ? "auto" : "none"
+style={{ pointerEvents: open ? "auto" : "none" }}
+
+// Trigger announces state; every satellite carries its own label:
 aria-expanded={open}
+aria-label={action.label}
 ```
 
 ## Motion Score
 
 <MotionScorePanel name="gooey-fab" />
 
-## The result
-
-Every piece, assembled — the real component. Open it, pick an action, watch the
-blobs fuse and split. Each motion is one of the mechanisms above doing its job.
-
-<GooeyFabResult />
-
-That's the whole illusion: soft circles under a blur matrix, sharp buttons on
-top, one spring timeline, and the discipline to keep the filter off anything
-you still need to read.
+The SVG goo filter is the one paint-tier cost — that's the C on the score.
+Everything else that moves is a transform or an opacity, and the filter drops
+out entirely under reduced motion, so the mercury illusion stays cheap enough to
+run the moment you open it.

--- a/apps/docs/content/docs/components/buttons/hold-confirm-button/learn.mdx
+++ b/apps/docs/content/docs/components/buttons/hold-confirm-button/learn.mdx
@@ -1,29 +1,25 @@
 ---
 title: Anatomy of the Hold Confirm Button
 description: How a press-and-hold gesture replaces a confirmation dialog — one motion value, a linear fill, a spring cancel, and a label stack that never resizes the button.
+learnPlayer: true
 ---
 
-A confirmation dialog asks you to move your eyes and click again. A hold
-asks you to commit with the same gesture for a little longer — and it can
-change its mind mid-motion. That's the whole design brief, and it comes down
-to one `motion value` and two very different easings.
+<LearnPlayer>
 
-## The fill
+<LearnChapter
+  label="The fill"
+  scene={<HoldFill />}
+  code={`<motion.span
+  aria-hidden="true"
+  style={{ scaleX: progress }}
+  className="absolute inset-0 origin-left bg-black/20"
+/>`}
+>
 
 Everything rides on a single `useMotionValue(0)` called `progress`. It never
 touches layout — it drives the `scaleX` of an absolutely-positioned span
 pinned to the button's own bounds, `transform-origin: left`. The button
 never resizes; only the fill's transform changes.
-
-<HoldFill />
-
-```tsx
-<motion.span
-  aria-hidden="true"
-  style={{ scaleX: progress }}
-  className="absolute inset-0 origin-left bg-black/20"
-/>
-```
 
 On pointer/key down, `progress` animates `0 → 1` over `duration` (default
 `900`ms) with `ease: "linear"` — no acceleration, no easing curve. A hold is
@@ -38,18 +34,12 @@ playback.current = animate(progress, 1, {
 });
 ```
 
-## Cancel vs confirm
+</LearnChapter>
 
-Release before the fill completes and `progress` doesn't just jump back —
-it springs, with enough damping to feel decisive rather than bouncy:
-`stiffness: 320`, `damping: 32`, `mass: 0.9`. Hold all the way through and
-the fill locks at `1`, a checkmark draws itself in over the label, and
-`onConfirm` fires.
-
-<HoldCancel />
-
-```tsx
-const cancel = () => {
+<LearnChapter
+  label="Cancel vs confirm"
+  scene={<HoldCancel />}
+  code={`const cancel = () => {
   if (statusRef.current !== "holding") return;
   playback.current?.stop();
   setStatus("idle");
@@ -59,8 +49,14 @@ const cancel = () => {
     damping: 32,
     mass: 0.9,
   });
-};
-```
+};`}
+>
+
+Release before the fill completes and `progress` doesn't just jump back —
+it springs, with enough damping to feel decisive rather than bouncy:
+`stiffness: 320`, `damping: 32`, `mass: 0.9`. Hold all the way through and
+the fill locks at `1`, a checkmark draws itself in over the label, and
+`onConfirm` fires.
 
 The check draws with the same restraint as the fill: an SVG path animates
 `pathLength` from `0` to `1` over a flat `0.3`s, no spring, no overshoot. The
@@ -75,8 +71,6 @@ stays quiet.
   transition={{ duration: 0.3 }}
 />
 ```
-
-## A label stack that never resizes
 
 `idle`, `holding`, and `confirmed` each have their own label, and all three
 occupy the **same grid cell**:
@@ -107,8 +101,6 @@ twitch when the hold starts; it was already sized for it. The inactive
 labels also carry `aria-hidden`, so screen readers only ever see the one
 that's showing.
 
-## The confirmed beat
-
 Confirming doesn't reset immediately — the filled bar holds for `1100`ms so
 the "done" state actually registers, then eases back to `0` over a quick
 `0.2`s (no spring here; the moment has passed, this is just tidying up):
@@ -130,8 +122,6 @@ Both the pending `animate()` playback and this timeout are torn down on
 unmount, so a hold that outlives its button never calls `setState` into the
 void.
 
-## Keyboard holds like pointer
-
 `onPointerDown` / `onPointerUp` / `onPointerLeave` / `onPointerCancel` all
 map to the same `start()` / `cancel()` pair that Enter and Space use — a
 keyboard hold is not a lesser affordance, it's the identical state machine:
@@ -152,6 +142,19 @@ const handleKeyUp = (event) => {
 the OS repeat rate, and without that guard every one of them would call
 `start()` again and re-stomp the running animation.
 
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<HoldConfirmResult />} isResult>
+
+One motion value, two easings, and a grid trick — that's the entire
+mechanism. The fill tells you how much longer, the spring tells you it heard
+you let go, and the label stack means none of it ever costs you a layout
+shift.
+
+</LearnChapter>
+
+</LearnPlayer>
+
 ## No reduced-motion branch — and that's fine here
 
 Unlike most GodUI motion, this component doesn't check
@@ -164,12 +167,3 @@ someone how much longer to keep holding.
 ## Motion Score
 
 <MotionScorePanel name="hold-confirm-button" />
-
-## The result
-
-<HoldConfirmResult />
-
-One motion value, two easings, and a grid trick — that's the entire
-mechanism. The fill tells you how much longer, the spring tells you it heard
-you let go, and the label stack means none of it ever costs you a layout
-shift.

--- a/apps/docs/content/docs/components/buttons/jelly-button/learn.mdx
+++ b/apps/docs/content/docs/components/buttons/jelly-button/learn.mdx
@@ -1,51 +1,46 @@
 ---
 title: Anatomy of the Jelly Button
 description: How a squishy, physical-feeling button is built from a single surface, one animated property, and a bezier that overshoots.
+learnPlayer: true
 ---
 
-A button that feels _squishy_ isn't a texture or a spring library — it's one
-surface, one animated property, and a curve that springs past its target. Here's
-every trick, pulled apart.
+<LearnPlayer>
 
-## One surface, one origin
+<LearnChapter
+  label="One surface, one origin"
+  scene={<JellyAnatomy />}
+  code={`<button className="group origin-bottom ...">{children}</button>`}
+>
 
 There are no layers here. Unlike a 3D push button, the Jelly Button is a single
 element that _deforms in place_. The whole trick is `transform-origin: bottom` —
 the surface is pinned to its baseline, so when it squashes it flattens _down_
 into that edge, the way a real object settles under your finger.
 
-<JellyAnatomy />
-
 The dashed frame is the envelope the surface deforms into on press: wider on X,
 shorter on Y, but anchored to the same bottom edge.
 
-```tsx
-<button className="group origin-bottom ...">{children}</button>
-```
+</LearnChapter>
 
-## The squash & stretch
+<LearnChapter
+  label="The squash & stretch"
+  scene={<JellySquash />}
+  code={`"[transition:scale_300ms_cubic-bezier(0.3,0.7,0.4,1.5)]
+ active:[scale:var(--jelly-press)]
+ active:[transition:scale_120ms_cubic-bezier(0.3,0.7,0.4,1)]"`}
+>
 
 Depth is faked by deform. On press the surface snaps to `scale(1.13, 0.87)` —
 fatter and shorter — then _releases past_ its rest size before settling. That
 overshoot is the entire "jelly" read: a rigid button would just return to `1`,
 but this one springs to `scale(0.97, 1.06)` and back.
 
-<JellySquash />
-
 Two timings do the work: a near-instant `120ms` squash while held, and a slower
 `300ms` release on a bezier that overshoots.
-
-```tsx
-"[transition:scale_300ms_cubic-bezier(0.3,0.7,0.4,1.5)]
- active:[scale:var(--jelly-press)]
- active:[transition:scale_120ms_cubic-bezier(0.3,0.7,0.4,1)]"
-```
 
 The overshoot lives in that `1.5` — the fourth control point of
 `cubic-bezier(0.3, 0.7, 0.4, 1.5)` pushes the value past its target and lets it
 spring back, no keyframes and no JS spring required.
-
-## Why `scale`, nothing else
 
 The deform animates `scale` and _only_ `scale`. No `width`/`height` (that would
 re-flow the page every frame), no `box-shadow` (that would re-paint it). `scale`
@@ -59,8 +54,6 @@ MotionScore **S**.
 "origin-bottom [will-change:transform]
  [transition:scale_300ms_cubic-bezier(0.3,0.7,0.4,1.5)]"
 ```
-
-## The squash knob
 
 How hard the button deforms is one prop, `squash` (`0`–`1`), mapped to the
 `scale` value the button snaps to and handed in as a CSS variable so the class
@@ -78,6 +71,22 @@ style={{ "--jelly-press": pressScale(squash) }}
 
 Driving it through `--jelly-press` means the same handful of Tailwind classes
 serve every intensity — the scanner never sees an interpolated class name.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<JellyButtonResult />} isResult>
+
+Every piece, assembled — the real component. Hover it, tab to it, press and
+hold. The squash, the overshoot, the settle: each is `scale` on a bezier, and
+nothing else.
+
+That's the whole illusion: one surface pinned to its baseline, a single
+composited property, and a curve with the discipline to overshoot and spring
+back.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility
 
@@ -98,15 +107,3 @@ const handleKeyDown = (e) => {
 ## Motion Score
 
 <MotionScorePanel name="jelly-button" />
-
-## The result
-
-Every piece, assembled — the real component. Hover it, tab to it, press and
-hold. The squash, the overshoot, the settle: each is `scale` on a bezier, and
-nothing else.
-
-<JellyButtonResult />
-
-That's the whole illusion: one surface pinned to its baseline, a single
-composited property, and a curve with the discipline to overshoot and spring
-back.

--- a/apps/docs/content/docs/components/buttons/magic-button/learn.mdx
+++ b/apps/docs/content/docs/components/buttons/magic-button/learn.mdx
@@ -1,52 +1,48 @@
 ---
 title: Anatomy of the Magic Button
 description: How a pushable 3D button is built from three flat layers, a springy bezier, and a rainbow that costs nothing when idle.
+learnPlayer: true
 ---
 
-A button that feels _pushable_ isn't a texture — it's a lie told by three flat
-layers and a spring. Here's every trick, pulled apart.
+<LearnPlayer>
 
-## The three-layer stack
+<LearnChapter
+  label="The three-layer stack"
+  scene={<LayerReveal />}
+  code={`<button className="group relative ...">
+  <span className="absolute inset-0 rounded-xl ..." aria-hidden />   {/* shadow */}
+  <span className="absolute inset-0 rounded-xl ..." aria-hidden />   {/* edge   */}
+  <span className="relative block rounded-xl ...">{children}</span>  {/* face   */}
+</button>`}
+>
 
 There is no 3D geometry here. The depth is three stacked `<span>`s: a blurred
 **shadow** on the surface, a colored **edge** that fakes the side wall, and the
 **front face** you actually read. Lift the face a few pixels above the edge and
 your eye fills in a solid object.
 
-<LayerReveal />
-
 Each layer is absolutely positioned in the same box, so they overlap perfectly
 at rest. Only their vertical offsets differ.
 
-```tsx
-<button className="group relative ...">
-  <span className="absolute inset-0 rounded-xl ..." aria-hidden />   {/* shadow */}
-  <span className="absolute inset-0 rounded-xl ..." aria-hidden />   {/* edge   */}
-  <span className="relative block rounded-xl ...">{children}</span>  {/* face   */}
-</button>
-```
+</LearnChapter>
 
-## The push physics
+<LearnChapter
+  label="The push physics"
+  scene={<PushPhysics />}
+  code={`// front face
+"-translate-y-[4px] [transition:translate_600ms_cubic-bezier(0.3,0.7,0.4,1)]
+ group-hover:-translate-y-[6px]
+ group-hover:[transition:translate_250ms_cubic-bezier(0.3,0.7,0.4,1.5)]
+ group-active:-translate-y-[2px] group-active:[transition:translate_34ms]"`}
+>
 
 Depth is static; _push_ is motion. The face sits at `-4px`, lifts to `-6px` on
 hover, and dips to `-2px` on press — while the shadow deepens underneath. What
 sells it is the timing: a slow, springy settle at rest, a snappy overshoot on
 hover, and a near-instant `34ms` dip on press.
 
-<PushPhysics />
-
 The overshoot lives in the bezier: `cubic-bezier(0.3, 0.7, 0.4, 1.5)` — that
 final `1.5` control point pushes past the target and springs back.
-
-```tsx
-// front face
-"-translate-y-[4px] [transition:translate_600ms_cubic-bezier(0.3,0.7,0.4,1)]
- group-hover:-translate-y-[6px]
- group-hover:[transition:translate_250ms_cubic-bezier(0.3,0.7,0.4,1.5)]
- group-active:-translate-y-[2px] group-active:[transition:translate_34ms]"
-```
-
-## Why `translate`, not `top` or `box-shadow`
 
 Every offset animates `translate`, never `top`/`margin` or an animated
 `box-shadow`. Transforms are composited — the browser moves an already-painted
@@ -58,23 +54,21 @@ the house rule across GodUI's motion, enforced in CI.
 "[will-change:translate] [transition:translate_600ms_cubic-bezier(0.3,0.7,0.4,1)]"
 ```
 
-## The rainbow edge
+</LearnChapter>
+
+<LearnChapter
+  label="The rainbow edge"
+  scene={<RainbowSweep />}
+  code={`"[background-image:linear-gradient(90deg,var(--rainbow-1),var(--rainbow-5),...)]
+ [background-size:200%_100%] animate-magic-rainbow motion-reduce:animate-none"`}
+>
 
 The optional rainbow isn't a video or a canvas — it's one gradient twice as wide
 as the button, slid sideways forever. `background-size: 200% 100%` gives the
 slack; a keyframe animates `background-position` across it.
 
-<RainbowSweep />
-
-```tsx
-"[background-image:linear-gradient(90deg,var(--rainbow-1),var(--rainbow-5),...)]
- [background-size:200%_100%] animate-magic-rainbow motion-reduce:animate-none"
-```
-
 `motion-reduce:animate-none` freezes the sweep for anyone who's asked the OS to
 cut motion.
-
-## Cheap when idle
 
 An infinite `background-position` keyframe is main-thread paint — cheap, but not
 free, and pointless when the button is off screen. An `IntersectionObserver`
@@ -93,6 +87,20 @@ const io = new IntersectionObserver(
 
 The `128px` margin resumes it just before it re-enters, so you never catch it
 mid-restart.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<ResultPreview />} isResult>
+
+Every piece, assembled — the real component. Hover it, tab to it, press and
+hold. Each motion is one of the mechanisms above doing its job.
+
+That's the whole illusion: three flat layers, one springy curve, a gradient on a
+timer, and the discipline to animate only what the GPU can move for free.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility
 
@@ -113,13 +121,3 @@ const handleKeyDown = (e) => {
 ## Motion Score
 
 <MotionScorePanel name="magic-button" />
-
-## The result
-
-Every piece, assembled — the real component. Hover it, tab to it, press and
-hold. Each motion is one of the mechanisms above doing its job.
-
-<ResultPreview />
-
-That's the whole illusion: three flat layers, one springy curve, a gradient on a
-timer, and the discipline to animate only what the GPU can move for free.

--- a/apps/docs/content/docs/components/buttons/magnetic-button/learn.mdx
+++ b/apps/docs/content/docs/components/buttons/magnetic-button/learn.mdx
@@ -1,13 +1,24 @@
 ---
 title: Anatomy of the Magnetic Button
 description: How a button's content leans toward the cursor — a sensor, a scaled delta, and one underdamped spring driving two elements at different weights.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="The pull"
+  scene={<MagneticPull />}
+  code={`const rect = el.getBoundingClientRect();
+const cx = rect.left + rect.width / 2;
+const cy = rect.top + rect.height / 2;
+x.set((e.clientX - cx) * strength);
+y.set((e.clientY - cy) * strength);`}
+>
 
 The button doesn't track the cursor directly. A sensor computes a scaled
 offset, hands it to a spring, and the spring drives both the shell and its
 label — at different weights. Here's every piece.
-
-## The sensor
 
 `MagneticButton` wraps its `<button>` in an invisible div. Pointer events are
 bound there, not on the button itself, so `range` can extend the pull past
@@ -26,18 +37,8 @@ the visible edges without changing hit-testing on the button's own box:
 `range` defaults to `0` — the sensor is exactly the button's box until you
 opt into a wider catchment.
 
-## The pull
-
 On every `pointermove`, the handler reads the button's center and turns the
 cursor's distance from it into a target, scaled by `strength`:
-
-```tsx
-const rect = el.getBoundingClientRect();
-const cx = rect.left + rect.width / 2;
-const cy = rect.top + rect.height / 2;
-x.set((e.clientX - cx) * strength);
-y.set((e.clientY - cy) * strength);
-```
 
 That target is a raw motion value — it jumps instantly, no easing. What
 actually renders is `useSpring(x, SPRING)`, an underdamped spring
@@ -46,37 +47,33 @@ doesn't ease flatly into place: it laps past the target and settles with a
 touch of elasticity, which is what makes the pull feel alive instead of
 merely delayed.
 
-<MagneticPull />
-
 Three tracks, same timeline: the cursor moves, the dashed target follows it
 instantly at `× strength`, and the solid shell lags a beat behind before
 overshooting into place. On `pointerleave`, both motion values reset to `0`
 and the same spring pulls the shell back home.
 
-## The parallax layer
+</LearnChapter>
+
+<LearnChapter
+  label="The parallax layer"
+  scene={<MagneticParallax />}
+  code={`const labelFactor = staticLabel ? 0 : 0.4;
+const labelX = useTransform(springX, (v) => v * labelFactor);
+const labelY = useTransform(springY, (v) => v * labelFactor);`}
+>
 
 The label isn't just centered text — it's its own `motion.span`, nested
 inside the `motion.button`, riding a second `useTransform` off the same
 spring value:
-
-```tsx
-const labelFactor = staticLabel ? 0 : 0.4;
-const labelX = useTransform(springX, (v) => v * labelFactor);
-const labelY = useTransform(springY, (v) => v * labelFactor);
-```
 
 Because the label is a DOM child of the button, its own `× 0.4` transform
 stacks on top of whatever the shell is already doing — the button moves by
 the full spring value, and the label inside it drifts an extra 40% in the
 same direction. Two elements, one spring, two different weights.
 
-<MagneticParallax />
-
 Set `staticLabel` and `labelFactor` becomes `0` — the label gets no transform
 of its own and just rides the shell, staying dead-center no matter how far
 the button leans.
-
-## Why one spring, not two tweens
 
 A single `useSpring` per axis drives everything downstream through
 `useTransform`. There's no separate animation to keep in sync when the
@@ -86,13 +83,26 @@ motion values applied via `style={{ x: springX, y: springY }}`, Framer writes
 directly to `transform` on the compositor thread — no React re-render per
 pointer move, no layout, no paint.
 
-## Cheap when idle
-
 The sensor has exactly two handlers: `onPointerMove` and `onPointerLeave`.
 There's no `RequestAnimationFrame` loop, no `ResizeObserver`, nothing running
 while the cursor is elsewhere. The spring itself only does work while it's
 displaced from its target — once it settles at `0`, it's inert until the
 next `pointermove`.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<MagneticResult />} isResult>
+
+Every mechanism, assembled. Move the cursor near each button and feel the
+sensor, the spring, and the parallax working together.
+
+One spring value, read twice at different weights, is the whole trick — the
+shell chases the cursor, the label chases it a little harder, and
+`pointerleave` lets the same spring pull everything back to zero.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility
 
@@ -119,14 +129,3 @@ regardless of motion preference. Focus gets the standard ring:
 ## Motion Score
 
 <MotionScorePanel name="magnetic-button" />
-
-## The result
-
-Every mechanism, assembled. Move the cursor near each button and feel the
-sensor, the spring, and the parallax working together.
-
-<MagneticResult />
-
-One spring value, read twice at different weights, is the whole trick — the
-shell chases the cursor, the label chases it a little harder, and
-`pointerleave` lets the same spring pull everything back to zero.

--- a/apps/docs/content/docs/components/buttons/mask-button/learn.mdx
+++ b/apps/docs/content/docs/components/buttons/mask-button/learn.mdx
@@ -1,42 +1,49 @@
 ---
 title: Anatomy of the Mask Button
 description: How a button's face wipes away on hover — two stacked labels, a sprite-sheet mask, and a steps() flipbook instead of an eased transition.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="Two labels, one visible through a mask"
+  scene={<MaskTwinLabels />}
+  code={`<span className="relative z-0">{children}</span>
+<span
+  className={\`\${FILL_BASE} \${fillVariant[variant]} \${cfg.sizeClass} \${cfg.rest} \${cfg.hover}\`}
+  style={{ "--mask-img": \`url("\${MASK_ASSETS[mask]}")\` } as React.CSSProperties}
+  aria-hidden="true"
+>
+  {children}
+</span>`}
+>
 
 The wipe isn't a gradient or a clip-path animating smoothly — it's two copies
 of the same label and a sprite sheet scrubbed frame by frame. Here's every
 piece, pulled apart.
-
-## Two labels, one visible through a mask
 
 Every `MaskButton` renders its children twice. The first span is plain and
 always there. The second is an `aria-hidden` twin, absolutely positioned on
 top, filled with the variant color, and only visible where a mask image lets
 it through:
 
-```tsx
-<span className="relative z-0">{children}</span>
-<span
-  className={`${FILL_BASE} ${fillVariant[variant]} ${cfg.sizeClass} ${cfg.rest} ${cfg.hover}`}
-  style={{ "--mask-img": `url("${MASK_ASSETS[mask]}")` } as React.CSSProperties}
-  aria-hidden="true"
->
-  {children}
-</span>
-```
-
 `FILL_BASE` sets `mask-image: var(--mask-img)` on that second span. At rest
 the mask hides it almost entirely, so you see the plain base label
 underneath; the hover animation slides the mask across, and wherever it's
 opaque, the colored twin shows through instead.
 
-<MaskTwinLabels />
-
 Same label, twice — a plain span underneath, a colored one clipped by the
 mask on top. The third panel loops the boundary sweeping across, which is
 exactly what a hover-then-leave cycle looks like on the real button.
 
-## The flipbook
+</LearnChapter>
+
+<LearnChapter
+  label="The flipbook"
+  scene={<MaskFlipbook />}
+  code={`hover: "group-hover:animate-mask-nature-in group-focus-visible:animate-mask-nature-in",`}
+>
 
 The mask asset is a horizontal sprite sheet, not a single image, and the
 reveal is a `mask-position` animation with a `steps()` timing function — not
@@ -62,25 +69,15 @@ own width — `2300%` for nature's 22-ish frames, `3000%` for urban, `7100%`
 for forest — so each `steps()` tick lands exactly on the next frame instead
 of somewhere between two.
 
-<MaskFlipbook />
-
 The playhead jumps across illustrative frames in discrete steps, and the
 reveal underneath jumps with it — `steps(n)` on a `mask-position` animation
 never interpolates between frames, it holds each one and cuts to the next.
-
-## Why hover and focus-visible share one animation
-
-```tsx
-hover: "group-hover:animate-mask-nature-in group-focus-visible:animate-mask-nature-in",
-```
 
 Keyboard focus gets the identical `*-in` class as a mouse hover — same
 sprite, same duration, same steps. A keyboard user sees precisely the
 transition a mouse user would, instead of a cheaper fallback. Mouse-leave (or
 losing focus) plays `*-out`, the same keyframes run backward, so the wipe
 always resolves in the direction it started.
-
-## The press detail
 
 Press feedback works whether the button was clicked or activated from the
 keyboard. A CSS class handles the pointer case; `data-pressed` covers
@@ -98,6 +95,21 @@ enabled:active:scale-[0.96] enabled:data-[pressed=true]:scale-[0.96]
 ```
 
 Both paths land on the same `scale-[0.96]` — one state, two triggers.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<MaskResult />} isResult>
+
+Every piece, assembled — three real buttons, three sprites. Hover, tab to,
+or press each one.
+
+That's the whole illusion: a plain label always in the DOM, a colored twin
+clipped by a sprite mask, and a `steps()` timing function doing the one thing
+an eased transition can't — holding each frame instead of blending it.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility
 
@@ -119,14 +131,3 @@ assistive tech only ever sees the one real label.
 ## Motion Score
 
 <MotionScorePanel name="mask-button" />
-
-## The result
-
-Every piece, assembled — three real buttons, three sprites. Hover, tab to,
-or press each one.
-
-<MaskResult />
-
-That's the whole illusion: a plain label always in the DOM, a colored twin
-clipped by a sprite mask, and a `steps()` timing function doing the one thing
-an eased transition can't — holding each frame instead of blending it.

--- a/apps/docs/content/docs/components/buttons/progress-fold-button/learn.mdx
+++ b/apps/docs/content/docs/components/buttons/progress-fold-button/learn.mdx
@@ -1,54 +1,57 @@
 ---
 title: Anatomy of the Progress Fold Button
 description: How a 3D hinge, three triggers, and a rAF-armed transition turn one button into a folding progress indicator.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="The hinge"
+  scene={<FoldStages />}
+  code={`const FRONT_BASE =
+  "relative grid w-full place-items-center rounded-[inherit] " +
+  "[transform:rotateX(0deg)] [transform-origin:top_center] " +
+  "[transition:transform_0.2s] " +
+  "group-hover:[transform:rotateX(35deg)] " +
+  "group-focus-visible:[transform:rotateX(35deg)] " +
+  "group-data-[status=loading]:[transform:rotateX(35deg)]";`}
+>
 
 The fold isn't a separate open/closed component swapped in on hover — it's
 one button whose front face is a hinged plate in 3D space. Tilt it back and
 whatever's underneath becomes visible. Here's the hinge, the three things
 that tilt it, and the bar that lives behind it.
 
-## The hinge
-
 The button sits in a `perspective(800px)` space. Its front face is a single
 element with `transform-origin: top center`, so rotating it on the X axis
 tips the *bottom* edge away from the viewer while the top stays pinned —
 like a flap hinged at the top:
 
-```tsx
-const FRONT_BASE =
-  "relative grid w-full place-items-center rounded-[inherit] " +
-  "[transform:rotateX(0deg)] [transform-origin:top_center] " +
-  "[transition:transform_0.2s] " +
-  "group-hover:[transform:rotateX(35deg)] " +
-  "group-focus-visible:[transform:rotateX(35deg)] " +
-  "group-data-[status=loading]:[transform:rotateX(35deg)]";
-```
-
 Behind that face, at `-z-[1]`, sits a back layer: a tint that's always
 there, plus a progress bar that's `scaleX(0)` until loading starts.
-
-<FoldStages />
 
 Three completely different triggers — a mouse hovering, a keyboard user
 tabbing in, a `status` prop flipping to `"loading"` — all resolve to the
 same `rotateX(35deg)`. None of them know or care which of the other two is
 also true; they're just three selectors pointed at one transform.
 
-## The bar behind the fold
+</LearnChapter>
+
+<LearnChapter
+  label="The bar behind the fold"
+  scene={<FoldProgress />}
+  code={`const BAR_BASE =
+  "absolute top-0 left-0 h-full w-full origin-left [transform:scaleX(0)] " +
+  "group-data-[determinate=true]:[transform:scaleX(var(--progress-fold-fill,0))] " +
+  "group-[&[data-status=loading]:not([data-determinate=true])]:w-[40%] " +
+  "group-[&[data-status=loading]:not([data-determinate=true])]:animate-progress-fold-indeterminate";`}
+>
 
 Once the face is tilted, the back layer is doing one of two things. If you
 pass a `progress` number, the bar is **determinate** — it `scaleX`s from
 the left to that fraction. If you don't, it's **indeterminate** — a fixed
 `40%`-wide segment sweeps across on a loop:
-
-```tsx
-const BAR_BASE =
-  "absolute top-0 left-0 h-full w-full origin-left [transform:scaleX(0)] " +
-  "group-data-[determinate=true]:[transform:scaleX(var(--progress-fold-fill,0))] " +
-  "group-[&[data-status=loading]:not([data-determinate=true])]:w-[40%] " +
-  "group-[&[data-status=loading]:not([data-determinate=true])]:animate-progress-fold-indeterminate";
-```
 
 ```css
 @keyframes progress-fold-indeterminate {
@@ -57,13 +60,9 @@ const BAR_BASE =
 }
 ```
 
-<FoldProgress />
-
 Both modes stay on the compositor: determinate is `scaleX` against a
 unitless CSS variable (`progress / 100`), indeterminate is a fixed-width
 segment translating left→right. No layout property moves.
-
-## Snap, then arm
 
 Determinate progress can't just start transitioning `scaleX` the instant
 `status` becomes `"loading"` — the CSS variable would already be set to the
@@ -94,6 +93,17 @@ full. With it, the first frame paints at `scaleX(0)` untransitioned, and
 only the second frame turns the transition on, so there's always a "from"
 state to fill away from.
 
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<ProgressFoldResult />} isResult>
+
+One hinge, three triggers, a bar that's either counting up or just letting
+you know it's still working. Click it.
+
+</LearnChapter>
+
+</LearnPlayer>
+
 ## Accessibility
 
 The button carries `aria-busy` while loading, plus a visually hidden
@@ -121,10 +131,3 @@ the tween or the endless sweep.
 ## Motion Score
 
 <MotionScorePanel name="progress-fold-button" />
-
-## The result
-
-One hinge, three triggers, a bar that's either counting up or just letting
-you know it's still working. Click it.
-
-<ProgressFoldResult />

--- a/apps/docs/content/docs/components/buttons/shimmer-button/learn.mdx
+++ b/apps/docs/content/docs/components/buttons/shimmer-button/learn.mdx
@@ -1,25 +1,15 @@
 ---
 title: Anatomy of the Shimmer Button
 description: How a single rotating conic gradient becomes a border-only light sweep, and why it speeds up under your cursor without restarting.
+learnPlayer: true
 ---
 
-The shimmer isn't a border animation — there's no border being drawn. It's a
-spinning gradient blob, mostly hidden behind a solid cutout, so only a sliver
-of it ever reaches the edge. Here's the whole stack, then the trick that
-makes it feel alive under your cursor.
+<LearnPlayer>
 
-## The three-layer stack
-
-Every button renders three things in the same box: a **spark** (a blurred
-conic gradient that spins and slides), a **cut** (a solid inset the exact
-color of the background), and the **label**. The spark fills the entire
-button. The cut sits on top of it and covers everything except a thin ring
-at the edge — that ring is the only part of the spark you ever see.
-
-<ShimmerLayers />
-
-```tsx
-<div ref={sparkRef} className="absolute inset-0 -z-30 overflow-visible blur-[2px] [container-type:size]">
+<LearnChapter
+  label="The three-layer stack"
+  scene={<ShimmerLayers />}
+  code={`<div ref={sparkRef} className="absolute inset-0 -z-30 overflow-visible blur-[2px] [container-type:size]">
   <div className="animate-shimmer-slide absolute inset-0 aspect-square h-[100cqh] [mask:none]">
     <div className="animate-spin-around absolute -inset-full w-auto [background:conic-gradient(from_calc(270deg-(var(--spread)*0.5)),transparent_0,var(--shimmer-color)_var(--spread),transparent_var(--spread))]" />
   </div>
@@ -27,14 +17,21 @@ at the edge — that ring is the only part of the spark you ever see.
 
 <span className="relative z-10">{children}</span>
 
-<div className="absolute -z-20 [inset:var(--cut)] [border-radius:var(--radius)] [background:var(--bg)]" />
-```
+<div className="absolute -z-20 [inset:var(--cut)] [border-radius:var(--radius)] [background:var(--bg)]" />`}
+>
+
+The shimmer isn't a border animation — there's no border being drawn. It's a
+spinning gradient blob, mostly hidden behind a solid cutout, so only a sliver
+of it ever reaches the edge. Every button renders three things in the same
+box: a **spark** (a blurred conic gradient that spins and slides), a **cut** (a
+solid inset the exact color of the background), and the **label**. The spark
+fills the entire button. The cut sits on top of it and covers everything
+except a thin ring at the edge — that ring is the only part of the spark you
+ever see.
 
 The stacking context does the work: spark at `-z-30`, cut at `-z-20`, label
 at `z-10`. Nothing here is a `border` — it's paint you can only partially
 see.
-
-## Two animations, one gradient
 
 The spark layer is two nested elements, each running its own keyframe. The
 outer one, `shimmer-slide`, translates the whole gradient sideways across
@@ -53,24 +50,24 @@ just bouncing.
 `--speed` defaults to `3s` and is just a CSS variable — `shimmerDuration`
 sets it directly, no re-render required.
 
-## Speeding up without restarting
+</LearnChapter>
 
-Hovering doesn't swap in a faster animation. The same Web Animations API
-timeline keeps running; the button just asks the browser to play it back
-three times as fast:
-
-```tsx
-const setSparkRate = (rate: number) => {
+<LearnChapter
+  label="Speeding up without restarting"
+  scene={<ShimmerSpeed />}
+  code={`const setSparkRate = (rate: number) => {
   sparkRef.current?.getAnimations({ subtree: true }).forEach((a) => {
     a.playbackRate = rate;
   });
 };
 
 const handleMouseEnter = () => setSparkRate(3);
-const handleMouseLeave = () => setSparkRate(1);
-```
+const handleMouseLeave = () => setSparkRate(1);`}
+>
 
-<ShimmerSpeed />
+Hovering doesn't swap in a faster animation. The same Web Animations API
+timeline keeps running; the button just asks the browser to play it back
+three times as fast.
 
 Because `playbackRate` scrubs the existing timeline rather than restarting
 it, the gradient never jumps or resets position when you hover — it just
@@ -83,8 +80,6 @@ const handleFocus = (e: React.FocusEvent<HTMLButtonElement>) => {
   if (e.target.matches(":focus-visible")) setSparkRate(3);
 };
 ```
-
-## The press dip
 
 Enter and Space fire a native click but never toggle CSS `:active`, so the
 component tracks it manually with `data-pressed`, matching the same
@@ -102,6 +97,18 @@ className="... active:translate-y-px data-[pressed=true]:translate-y-px ..."
 
 One rule, two triggers — pointer `:active` and the synthetic `data-pressed`
 land on the exact same transform.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<ShimmerResult />} isResult>
+
+Spinning gradient, solid cutout, a label riding on top, and one line that
+scrubs a Web Animations timeline instead of swapping animations. That's the
+whole light show.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility
 
@@ -124,11 +131,3 @@ removing the light show never removes the focus indicator.
 ## Motion Score
 
 <MotionScorePanel name="shimmer-button" />
-
-## The result
-
-Spinning gradient, solid cutout, a label riding on top, and one line that
-scrubs a Web Animations timeline instead of swapping animations. That's the
-whole light show.
-
-<ShimmerResult />

--- a/apps/docs/content/docs/components/buttons/slide-confirm-button/learn.mdx
+++ b/apps/docs/content/docs/components/buttons/slide-confirm-button/learn.mdx
@@ -1,21 +1,15 @@
 ---
 title: Anatomy of the Slide Confirm Button
 description: How a drag-to-confirm thumb measures its own track, trails a fill behind an x motion value, and commits past a 90% line.
+learnPlayer: true
 ---
 
-Dragging is the most deliberate confirmation gesture there is — you can't
-mash it, and you can feel exactly how far you've committed before you let
-go. The whole thing is one motion value, `x`, and a track that measures
-itself.
+<LearnPlayer>
 
-## The track measures itself
-
-`maxX` — how far the thumb can travel — isn't a fixed number. It's
-`trackWidth - thumb - pad × 2`, recomputed by a `ResizeObserver` so the
-button stays correct if its container resizes:
-
-```tsx
-React.useLayoutEffect(() => {
+<LearnChapter
+  label="The track measures itself"
+  scene={<SlideAnatomy />}
+  code={`React.useLayoutEffect(() => {
   const el = trackRef.current;
   if (!el) return;
   const measure = () => {
@@ -26,14 +20,21 @@ React.useLayoutEffect(() => {
   const ro = new ResizeObserver(measure);
   ro.observe(el);
   return () => ro.disconnect();
-}, [dims.thumb, dims.pad]);
-```
+}, [dims.thumb, dims.pad]);`}
+>
+
+Dragging is the most deliberate confirmation gesture there is — you can't
+mash it, and you can feel exactly how far you've committed before you let
+go. The whole thing is one motion value, `x`, and a track that measures
+itself.
+
+`maxX` — how far the thumb can travel — isn't a fixed number. It's
+`trackWidth - thumb - pad × 2`, recomputed by a `ResizeObserver` so the
+button stays correct if its container resizes.
 
 At the `md` size that's a real `288`px track, a `40`px thumb, `4`px of pad
 on each side — so `maxX` comes out to `240`. Everything below uses those
 exact numbers.
-
-<SlideAnatomy />
 
 The fill is a second absolutely-positioned pill, pinned at `top`/`bottom`/
 `left: pad`, whose `width` is derived straight from `x`:
@@ -53,21 +54,21 @@ instruction has already gotten out of the way:
 const labelOpacity = useTransform(x, [0, Math.max(1, maxX * 0.6)], [1, 0]);
 ```
 
-## The threshold
+</LearnChapter>
 
-`threshold` defaults to `0.9` — the thumb has to clear 90% of `maxX` before
-release counts as a confirm. Everything before that line springs back;
-everything past it springs the rest of the way home:
-
-<SlideThreshold />
-
-```tsx
-const handleDragEnd = () => {
+<LearnChapter
+  label="The threshold"
+  scene={<SlideThreshold />}
+  code={`const handleDragEnd = () => {
   if (statusRef.current === "confirmed") return;
   if (maxX > 0 && x.get() >= maxX * threshold) confirm();
   else settleBack();
-};
-```
+};`}
+>
+
+`threshold` defaults to `0.9` — the thumb has to clear 90% of `maxX` before
+release counts as a confirm. Everything before that line springs back;
+everything past it springs the rest of the way home.
 
 Both outcomes use the same spring — `stiffness: 500`, `damping: 40` — just
 aimed at different targets. A failed drag springs `x` back to `0`; a
@@ -95,8 +96,6 @@ same spring for a flat `0.2`s tween on the settle-back path, so a
 reduced-motion user still gets an instant, legible snap instead of a
 bounce.
 
-## Drag feel: elastic, not momentum-driven
-
 Two Framer Motion drag props shape how the thumb feels under a real finger:
 
 ```tsx
@@ -114,6 +113,18 @@ without it, a fast flick could carry `x` past the threshold on momentum
 alone, which would make "past the line" mean something different depending
 on drag speed instead of drag distance. Distance is the only thing that
 should decide a confirm.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<SlideConfirmResult />} isResult>
+
+A measured track, a fill derived from one motion value, a threshold that
+picks the target for the same spring, and a drag config tuned so distance —
+not speed — is what commits. Drag it, or just press the arrow key.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Keyboard confirms instantly
 
@@ -138,11 +149,3 @@ gesture-appropriate shortcut instead of only the generic activation keys.
 ## Motion Score
 
 <MotionScorePanel name="slide-confirm-button" />
-
-## The result
-
-<SlideConfirmResult />
-
-A measured track, a fill derived from one motion value, a threshold that
-picks the target for the same spring, and a drag config tuned so distance —
-not speed — is what commits. Drag it, or just press the arrow key.

--- a/apps/docs/content/docs/components/collaboration/comment-pin/learn.mdx
+++ b/apps/docs/content/docs/components/collaboration/comment-pin/learn.mdx
@@ -1,30 +1,31 @@
 ---
 title: Anatomy of the Comment Pin
 description: A pin that springs onto a surface and a thread panel that hangs off its corner — two independent springs, one anchor, no coordinate math for the popover.
+learnPlayer: true
 ---
 
-Figma-style annotation pins look like they need real positioning logic for
-the popover — where does the thread go so it doesn't run off the pin? The
-answer `CommentPin` picks is to not solve that problem: the panel isn't
-positioned against the viewport or the pin's measured box, it's `absolute`
-inside the *same* relatively-positioned wrapper the pin already lives in.
+<LearnPlayer>
 
-## One anchor, one panel hanging off it
-
-<CommentPinAnatomy />
-
-```tsx
-<div
+<LearnChapter
+  label="One anchor, one panel hanging off it"
+  scene={<CommentPinAnatomy />}
+  code={`<div
   className="absolute z-raised"
-  style={{ left: `${x}%`, top: `${y}%` }}
+  style={{ left: \`\${x}%\`, top: \`\${y}%\` }}
 >
   <motion.button className="rounded-full rounded-bl-sm ..." />
 
   <motion.div className="absolute left-0 top-9 z-popover w-72 origin-top-left ...">
     {/* comment list + reply form */}
   </motion.div>
-</div>
-```
+</div>`}
+>
+
+Figma-style annotation pins look like they need real positioning logic for
+the popover — where does the thread go so it doesn't run off the pin? The
+answer `CommentPin` picks is to not solve that problem: the panel isn't
+positioned against the viewport or the pin's measured box, it's `absolute`
+inside the *same* relatively-positioned wrapper the pin already lives in.
 
 The outer `div` is the only element that knows about `x`/`y` — it's placed
 with a `left`/`top` percentage inside whatever container the caller renders
@@ -36,12 +37,12 @@ to keep in sync. `rounded-full rounded-bl-sm` on the button is the one
 detail that sells "pin" over "avatar" — leaving a single square corner reads
 as a speech-bubble tail pointing at the exact spot being annotated.
 
-## Two springs, one anchored to the other
+</LearnChapter>
 
-<CommentPinSpring />
-
-```tsx
-<motion.button
+<LearnChapter
+  label="Two springs, one anchored to the other"
+  scene={<CommentPinSpring />}
+  code={`<motion.button
   layout
   initial={{ scale: 0 }}
   animate={{ scale: resolved ? 0.85 : 1 }}
@@ -58,8 +59,8 @@ as a speech-bubble tail pointing at the exact spot being annotated.
       className="... origin-top-left"
     />
   ) : null}
-</AnimatePresence>
-```
+</AnimatePresence>`}
+>
 
 The pin's own spring (`520/32`) is tuned tighter than the panel's (`320/32`,
 plus `mass: 0.9` to add a beat of inertia) — it should feel like the more
@@ -70,8 +71,6 @@ on entry. Anchoring the transform origin to the same corner the panel is
 positioned from makes it read as growing *out of* the pin, not popping up
 independently beside it.
 
-## `layout` on the pin, not the panel
-
 The pin button carries a `layout` prop; the panel doesn't. That's because
 `resolved` can flip while the pin's own size only ever changes by a spring
 `scale` (a transform, cheap for Framer to interpolate with `layout`
@@ -80,14 +79,14 @@ shrinking — real height changes — and it's already animating in and out via
 `AnimatePresence`'s own `initial`/`animate`/`exit`, so adding `layout` there
 would fight the mount/unmount transition instead of helping it.
 
-## Active vs resolved: two systems, same element
+</LearnChapter>
 
-<CommentPinResolved />
-
-```tsx
-className={`... transition-[filter,opacity] ${resolved ? "opacity-60 grayscale" : ""}`}
-style={{ backgroundColor: pinColor }}
-```
+<LearnChapter
+  label="Active vs resolved: two systems, same element"
+  scene={<CommentPinResolved />}
+  code={`className={\`... transition-[filter,opacity] \${resolved ? "opacity-60 grayscale" : ""}\`}
+style={{ backgroundColor: pinColor }}`}
+>
 
 `resolved` doesn't get its own spring — the `scale: 0.85` above already
 covers the size change. Desaturating the pin is a second, entirely separate
@@ -97,6 +96,18 @@ Splitting it this way means the grayscale fade rides the browser's own
 compositor timeline independently of whatever Framer's spring is doing to
 `scale` in the same frame — two cheap, unrelated transitions landing on one
 element instead of one animation system trying to own both.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<CommentPinResult />} isResult>
+
+One relatively-positioned wrapper carrying `x`/`y`, a tighter spring on the
+pin than on the panel it anchors, and a resolved state that never touches
+the spring at all — it just lets a CSS transition run alongside it.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility
 
@@ -121,11 +132,3 @@ a submit button disabled until there's text to send:
 ## Motion Score
 
 <MotionScorePanel name="comment-pin" />
-
-## The result
-
-<CommentPinResult />
-
-One relatively-positioned wrapper carrying `x`/`y`, a tighter spring on the
-pin than on the panel it anchors, and a resolved state that never touches
-the spring at all — it just lets a CSS transition run alongside it.

--- a/apps/docs/content/docs/components/collaboration/live-cursors/learn.mdx
+++ b/apps/docs/content/docs/components/collaboration/live-cursors/learn.mdx
@@ -1,7 +1,21 @@
 ---
 title: Anatomy of Live Cursors
 description: Why multiplayer cursors chase a spring instead of teleporting to every network update, and how each one enters and leaves without a manual timer.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="One motion.div, two shapes"
+  scene={<LiveCursorsAnatomy />}
+  code={`<motion.div style={{ x, y }} className="absolute left-0 top-0 z-popover flex items-start">
+  <svg viewBox="0 0 24 24" width="20" height="20" style={{ color }}>
+    <path d="M5 3l5.5 16 2.2-6.8L19.5 10z" fill="currentColor" stroke="white" strokeWidth={1.5} />
+  </svg>
+  <span className="mt-3 -ml-1 rounded-[10px] rounded-tl-sm ...">{cursor.message ?? cursor.name}</span>
+</motion.div>`}
+>
 
 A cursor position arriving over a websocket is noisy by nature — batched,
 occasionally late, never perfectly smooth. Write it straight to `style.left`
@@ -9,31 +23,18 @@ and the cursor teleports every time a message lands. `LiveCursors` never
 does that: every incoming coordinate is a *target* for a spring, not a value
 it paints directly.
 
-## One `motion.div`, two shapes
-
-<LiveCursorsAnatomy />
-
-```tsx
-<motion.div style={{ x, y }} className="absolute left-0 top-0 z-popover flex items-start">
-  <svg viewBox="0 0 24 24" width="20" height="20" style={{ color }}>
-    <path d="M5 3l5.5 16 2.2-6.8L19.5 10z" fill="currentColor" stroke="white" strokeWidth={1.5} />
-  </svg>
-  <span className="mt-3 -ml-1 rounded-[10px] rounded-tl-sm ...">{cursor.message ?? cursor.name}</span>
-</motion.div>
-```
-
 The pointer and the name flag are siblings inside one animated `motion.div`
 — only the outer element's `x`/`y` ever moves; the pointer and flag stay in
 a fixed relationship to each other. `rounded-tl-sm` on the flag is the same
 idea as the comment pin's `rounded-bl-sm`: leaving one corner square gives
 it a tail, here pointing back up at the cursor tip it's attached to.
 
-## Raw updates vs a spring
+</LearnChapter>
 
-<LiveCursorsSpring />
-
-```tsx
-const config = { stiffness: 700, damping: 40, mass: 0.6 };
+<LearnChapter
+  label="Raw updates vs a spring"
+  scene={<LiveCursorsSpring />}
+  code={`const config = { stiffness: 700, damping: 40, mass: 0.6 };
 const x = useSpring(cursor.x, config);
 const y = useSpring(cursor.y, config);
 
@@ -45,8 +46,8 @@ React.useEffect(() => {
     x.set(cursor.x);
     y.set(cursor.y);
   }
-}, [cursor.x, cursor.y, x, y, reduce]);
-```
+}, [cursor.x, cursor.y, x, y, reduce]);`}
+>
 
 `useSpring` holds a motion value that *chases* whatever you `.set()` it to
 — it doesn't jump there. Every new `{ x, y }` prop just retargets the same
@@ -57,8 +58,6 @@ high — tuned for something that should feel almost immediate — but never
 zero, so there's always a hint of catch-up motion that reads as "this is a
 person moving," not a value snapping between fixed points.
 
-## Why `.jump()`, not a shorter spring
-
 Reduced motion doesn't lower the stiffness or shorten the spring — it swaps
 to `.jump()`, the same instant repositioning a raw update would have done.
 That's a deliberate branch, not the spring config's edge case: someone who
@@ -67,35 +66,22 @@ Keeping the two paths as an explicit `if` rather than tuning one spring
 down to "fast enough" means reduced motion is guaranteed to be exactly as
 still as it claims, not just less animated.
 
-## Enter and exit are the array, not a toggle
+</LearnChapter>
 
-<LiveCursorsPresence />
-
-```tsx
-<AnimatePresence>
+<LearnChapter
+  label="Enter and exit are the array, not a toggle"
+  scene={<LiveCursorsPresence />}
+  code={`<AnimatePresence>
   {cursors.map((cursor) => (
     <CursorFlag key={cursor.id} cursor={cursor} hideName={hideNames} />
   ))}
 </AnimatePresence>
-```
 
-```tsx
 initial={{ opacity: 0, scale: 0.5 }}
 animate={{ opacity: 1, scale: 1 }}
 exit={{ opacity: 0, scale: 0.5 }}
 transition={{ duration: 0.15 }}
-```
 
-There's no `visible` prop and no manual show/hide state anywhere in this
-component. `AnimatePresence` wraps a `.map()` over `cursors`, keyed by
-`cursor.id` — when the array a caller passes in gains or loses an entry
-(a peer joins, a peer's connection drops), React's own reconciliation is
-what triggers the `initial` or `exit` transition. The component doesn't
-know or care *why* the array changed; it only reacts to the diff.
-
-## Self-driving peers for demos
-
-```tsx
 const tick = () => {
   for (const peer of peers) {
     peer.x += (peer.tx - peer.x) * 0.02;
@@ -104,8 +90,15 @@ const tick = () => {
   }
   setCursors(peers.map((p) => ({ id: p.id, name: p.name, x: p.x * w, y: p.y * h })));
   raf = requestAnimationFrame(tick);
-};
-```
+};`}
+>
+
+There's no `visible` prop and no manual show/hide state anywhere in this
+component. `AnimatePresence` wraps a `.map()` over `cursors`, keyed by
+`cursor.id` — when the array a caller passes in gains or loses an entry
+(a peer joins, a peer's connection drops), React's own reconciliation is
+what triggers the `initial` or `exit` transition. The component doesn't
+know or care *why* the array changed; it only reacts to the diff.
 
 `SimulatedCursors` doesn't animate anything itself — it runs a plain random
 walk in a `requestAnimationFrame` loop (each peer eases 2% of the way
@@ -115,8 +108,6 @@ The spring above still does all the actual smoothing; the simulation only
 ever supplies noisy target coordinates, exactly like a real network feed
 would.
 
-## Cheap when idle
-
 The rAF loop checks `reduce` once and returns immediately if motion is
 disabled — no peers ever move, so there's nothing to interpolate and no
 frames burned animating nobody. The loop itself is cleaned up with
@@ -124,15 +115,19 @@ frames burned animating nobody. The loop itself is cleaned up with
 owned by Framer's own lifecycle: no cursor keeps a timer running after
 `AnimatePresence` finishes its exit and removes it from the tree.
 
-## Motion Score
+</LearnChapter>
 
-<MotionScorePanel name="live-cursors" />
-
-## The result
-
-<LiveCursorsResult />
+<LearnChapter label="The result" scene={<LiveCursorsResult />} isResult>
 
 A spring retargeted on every update instead of a value painted straight to
 `style`, a reduced-motion path that swaps to instant positioning rather
 than a faster tween, and enter/exit driven entirely by the shape of the
 `cursors` array — no cursor-specific show/hide logic anywhere.
+
+</LearnChapter>
+
+</LearnPlayer>
+
+## Motion Score
+
+<MotionScorePanel name="live-cursors" />

--- a/apps/docs/content/docs/components/collaboration/notification-inbox/learn.mdx
+++ b/apps/docs/content/docs/components/collaboration/notification-inbox/learn.mdx
@@ -1,7 +1,18 @@
 ---
 title: Anatomy of the Notification Inbox
 description: How a Linear-style inbox groups notifications into sticky buckets, archives a row with an elastic drag, and clears its unread badge in one motion.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="Header, sticky groups, rows"
+  scene={<NotificationInboxAnatomy />}
+  code={`<div className="sticky top-0 z-base bg-card/90 px-4 py-1.5 backdrop-blur-sm">
+  {label}
+</div>`}
+>
 
 A notification inbox lives or dies on triage speed: can you tell what's new,
 clear it, and get rid of what you don't need without ever reaching for a
@@ -9,14 +20,10 @@ menu? Notification Inbox answers with three mechanisms — sticky grouping, a
 draggable archive, and a badge that clears in lockstep with the rows it
 represents.
 
-## Header, sticky groups, rows
-
 The whole thing is one card: a header with the title and an unread count,
 then notifications bucketed by `group` (defaulting to `"Earlier"` when a
 notification doesn't specify one) under a label that sticks to the top of
 the scroll container while its bucket is in view:
-
-<NotificationInboxAnatomy />
 
 ```tsx
 function groupNotifications(items: Notification[]) {
@@ -34,12 +41,6 @@ function groupNotifications(items: Notification[]) {
 }
 ```
 
-```tsx
-<div className="sticky top-0 z-base bg-card/90 px-4 py-1.5 backdrop-blur-sm">
-  {label}
-</div>
-```
-
 `sticky top-0` inside the scroll container is what lets "Today" pin to the
 top while its rows scroll underneath it — no scroll listener, no manual
 offset math. `z-base` keeps it above the rows without reaching for an
@@ -50,25 +51,25 @@ Each row's `<motion.li layout>` is what makes the group actually respond to
 changes: read a notification, remove one, and every remaining row
 re-measures and springs to its new position instead of snapping.
 
-## Swipe to archive, with a real threshold
+</LearnChapter>
 
-Archiving isn't a button — it's a drag. Each row is `drag="x"`, constrained
-to only move left, with elastic resistance built in so a small nudge feels
-soft and a big pull still can't be dragged off past a limit that doesn't
-exist:
-
-<NotificationInboxSwipe />
-
-```tsx
-<motion.div
+<LearnChapter
+  label="Swipe to archive, with a real threshold"
+  scene={<NotificationInboxSwipe />}
+  code={`<motion.div
   drag="x"
   dragConstraints={{ left: 0, right: 0 }}
   dragElastic={{ left: 0.7, right: 0 }}
   onDragEnd={(_, info) => {
     if (info.offset.x < -80) onArchive?.(notification.id);
   }}
-/>
-```
+/>`}
+>
+
+Archiving isn't a button — it's a drag. Each row is `drag="x"`, constrained
+to only move left, with elastic resistance built in so a small nudge feels
+soft and a big pull still can't be dragged off past a limit that doesn't
+exist:
 
 `dragConstraints: { left: 0, right: 0 }` sounds like it should lock the row
 in place — and it would, if not for `dragElastic`. Elastic drag lets the row
@@ -90,12 +91,12 @@ On archive, the row's `exit` animation is `{ opacity: 0, height: 0, x: -80 }`
 than snapping back to center first, so the dismissal reads as a
 continuation of the gesture instead of a separate animation taking over.
 
-## The badge and the dots clear together
+</LearnChapter>
 
-<NotificationInboxBadge />
-
-```tsx
-<AnimatePresence>
+<LearnChapter
+  label="The badge and the dots clear together"
+  scene={<NotificationInboxBadge />}
+  code={`<AnimatePresence>
   {unread > 0 ? (
     <motion.span
       initial={{ opacity: 0, scale: 0.6 }}
@@ -105,8 +106,8 @@ continuation of the gesture instead of a separate animation taking over.
       {unread}
     </motion.span>
   ) : null}
-</AnimatePresence>
-```
+</AnimatePresence>`}
+>
 
 The badge isn't hidden with `display: none` when the count hits zero — it's
 conditionally rendered inside `AnimatePresence`, so removing it triggers the
@@ -117,8 +118,6 @@ row's unread-dot disappearance happen on the same tick, not staggered one
 notification at a time. Nothing individually "clears" — the count that
 drives the badge and the flags that drive the dots are the same source of
 truth, updated once.
-
-## Cheap when empty
 
 An empty inbox isn't a static "no notifications" line — the bell icon
 bobs on a slow, infinite `y: [0, -4, 0]` loop:
@@ -136,6 +135,18 @@ It's a single `transform`-only keyframe on one small icon, so there's no
 per-frame cost worth pausing for — unlike a full row list, an empty state
 has nothing else on screen competing for main-thread time.
 
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<NotificationInboxResult />} isResult>
+
+One card, one grouping function, one drag threshold, and a badge that's
+just another `AnimatePresence` child reacting to the same state as the rows
+underneath it.
+
+</LearnChapter>
+
+</LearnPlayer>
+
 ## Accessibility
 
 The unread dot carries a visually-hidden `<span className="sr-only">Unread
@@ -147,11 +158,3 @@ keyboard independent of the drag gesture layered on top of it.
 ## Motion Score
 
 <MotionScorePanel name="notification-inbox" />
-
-## The result
-
-<NotificationInboxResult />
-
-One card, one grouping function, one drag threshold, and a badge that's
-just another `AnimatePresence` child reacting to the same state as the rows
-underneath it.

--- a/apps/docs/content/docs/components/collaboration/presence-facepile/learn.mdx
+++ b/apps/docs/content/docs/components/collaboration/presence-facepile/learn.mdx
@@ -1,19 +1,15 @@
 ---
 title: Anatomy of the Presence Facepile
 description: How a live avatar stack overlaps with ordinary flex flow, springs people in and out with popLayout, and turns status into color instead of a label.
+learnPlayer: true
 ---
 
-A facepile has to answer "who's here, and what are they doing" in the width
-of a few avatars. Presence Facepile gets there with plain flex overlap, one
-shared spring for every avatar entering or leaving, and status encoded
-entirely as color and motion rather than text.
+<LearnPlayer>
 
-## Overlap is flex flow, not absolute position
-
-<PresenceFacepileAnatomy />
-
-```tsx
-<div className="flex items-center -space-x-2">
+<LearnChapter
+  label="Overlap is flex flow, not absolute position"
+  scene={<PresenceFacepileAnatomy />}
+  code={`<div className="flex items-center -space-x-2">
   {visible.map((user) => (
     <motion.div key={user.id} layout /* ... */>
       <Avatar user={user} sizeClass={sizeClass} showStatus={showStatus} />
@@ -22,8 +18,13 @@ entirely as color and motion rather than text.
   {overflow.length > 0 ? (
     <motion.button layout /* +N chip, same row */ />
   ) : null}
-</div>
-```
+</div>`}
+>
+
+A facepile has to answer "who's here, and what are they doing" in the width
+of a few avatars. Presence Facepile gets there with plain flex overlap, one
+shared spring for every avatar entering or leaving, and status encoded
+entirely as color and motion rather than text.
 
 `-space-x-2` is Tailwind's negative-margin utility applied to every child
 but the first — the row is still ordinary flex flow, so tab order and DOM
@@ -33,12 +34,12 @@ anywhere. The `+N` chip isn't a specially-positioned badge; it's the same
 flex row's last child, sharing the identical overlap and `ring-2
 ring-background` treatment that separates every avatar from its neighbor.
 
-## One spring for entering, leaving, and shifting
+</LearnChapter>
 
-<PresenceFacepileEnter />
-
-```tsx
-<AnimatePresence initial={false} mode="popLayout">
+<LearnChapter
+  label="One spring for entering, leaving, and shifting"
+  scene={<PresenceFacepileEnter />}
+  code={`<AnimatePresence initial={false} mode="popLayout">
   {visible.map((user) => (
     <motion.div
       key={user.id}
@@ -51,8 +52,8 @@ ring-background` treatment that separates every avatar from its neighbor.
       <Avatar user={user} sizeClass={sizeClass} showStatus={showStatus} />
     </motion.div>
   ))}
-</AnimatePresence>
-```
+</AnimatePresence>`}
+>
 
 `mode="popLayout"` is what makes a departure feel instant instead of
 laggy: the leaving avatar is pulled out of layout the moment it starts
@@ -72,7 +73,28 @@ plain CSS `transition` on `hover:-translate-y-0.5`, paired with
 `hover:z-raised` so the lifted avatar clears its neighbors' overlap instead
 of disappearing behind them.
 
-## Status is color, not a label
+</LearnChapter>
+
+<LearnChapter
+  label="Status is color, not a label"
+  scene={<PresenceFacepileStatus />}
+  code={`{status === "typing" ? (
+  <span className="absolute -bottom-0.5 -right-0.5 flex items-center gap-px rounded-full bg-background px-0.5 py-1 shadow-sm">
+    {[0, 1, 2].map((i) => (
+      <span
+        key={i}
+        className="size-1 rounded-full bg-primary motion-safe:animate-bounce"
+        style={{ animationDelay: \`\${i * 120}ms\` }}
+      />
+    ))}
+  </span>
+) : (
+  <span
+    className="absolute bottom-0 right-0 size-2.5 rounded-full ring-2 ring-background"
+    style={{ backgroundColor: STATUS_COLOR[status] }}
+  />
+)}`}
+>
 
 Every avatar can carry a status ring, resolved from one lookup table:
 
@@ -87,28 +109,7 @@ const STATUS_COLOR: Record<PresenceStatus, string> = {
 
 `typing` is the one status that isn't a static ring — it swaps in three
 1px dots instead, each bouncing on `motion-safe:animate-bounce` with a
-`120ms` stagger per dot:
-
-<PresenceFacepileStatus />
-
-```tsx
-{status === "typing" ? (
-  <span className="absolute -bottom-0.5 -right-0.5 flex items-center gap-px rounded-full bg-background px-0.5 py-1 shadow-sm">
-    {[0, 1, 2].map((i) => (
-      <span
-        key={i}
-        className="size-1 rounded-full bg-primary motion-safe:animate-bounce"
-        style={{ animationDelay: `${i * 120}ms` }}
-      />
-    ))}
-  </span>
-) : (
-  <span
-    className="absolute bottom-0 right-0 size-2.5 rounded-full ring-2 ring-background"
-    style={{ backgroundColor: STATUS_COLOR[status] }}
-  />
-)}
-```
+`120ms` stagger per dot.
 
 `motion-safe:` is what pauses the bounce for anyone who's asked for reduced
 motion — the dots still render (typing is still communicated by their
@@ -116,8 +117,6 @@ presence and position), they just stop moving. Every other status stays
 exactly what it looks like: a ring, in a fixed color, never fading or
 pulsing, because "idle" or "offline" isn't information that benefits from
 motion drawing your eye to it every few seconds.
-
-## The overflow chip opts out of the lift
 
 Beyond `max`, the rest collapse into a `+N` button that shares the row's
 `layout` animation (so it slides smoothly as the row's contents change) but
@@ -135,6 +134,19 @@ different statuses at once anyway.
 />
 ```
 
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<PresenceFacepileResult />} isResult>
+
+Flex overlap for the stack, one spring shared by every avatar that enters,
+leaves, or shifts to fill a gap, and a status system that's just a color
+lookup — except for the one status that earns its own motion because it's
+the one that's actually happening right now.
+
+</LearnChapter>
+
+</LearnPlayer>
+
 ## Accessibility
 
 Every avatar carries a `title` combining the user's name and status
@@ -148,12 +160,3 @@ correctly, it just does so without animating the transition.
 ## Motion Score
 
 <MotionScorePanel name="presence-facepile" />
-
-## The result
-
-<PresenceFacepileResult />
-
-Flex overlap for the stack, one spring shared by every avatar that enters,
-leaves, or shifts to fill a gap, and a status system that's just a color
-lookup — except for the one status that earns its own motion because it's
-the one that's actually happening right now.

--- a/apps/docs/content/docs/components/effects/beam-draw/learn.mdx
+++ b/apps/docs/content/docs/components/effects/beam-draw/learn.mdx
@@ -1,60 +1,71 @@
 ---
 title: Anatomy of Beam Draw
 description: How scroll progress becomes a spring-smoothed SVG pathLength, and why four fan paths share one motion value.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="Four paths, one origin"
+  scene={<BeamDrawAnatomy />}
+  code={`const DEFAULT_PATHS = [
+  "M0 200 C 250 200, 350 60, 600 60 S 900 40, 1000 40",
+  "M0 200 C 250 200, 350 140, 600 140 S 900 150, 1000 150",
+  "M0 200 C 250 200, 350 260, 600 260 S 900 250, 1000 250",
+  "M0 200 C 250 200, 350 340, 600 340 S 900 360, 1000 360",
+];`}
+>
 
 `BeamDraw` doesn't animate a stroke dash by hand each frame. It maps the SVG's
 own scroll progress through a spring, then hands the result to every path as
 `pathLength`. Geometry is static; only how much of each path is revealed
 changes.
 
-## Four paths, one origin
-
 The default set lives on a `1000×400` viewBox. All four cubics start at
 `(0, 200)` and fan to the right edge at `y = 40 / 150 / 250 / 360` — a left
 core feeding four destinations. Pass your own `paths` array to replace them;
 the motion plumbing stays identical.
 
-<BeamDrawAnatomy />
-
-```tsx
-const DEFAULT_PATHS = [
-  "M0 200 C 250 200, 350 60, 600 60 S 900 40, 1000 40",
-  "M0 200 C 250 200, 350 140, 600 140 S 900 150, 1000 150",
-  "M0 200 C 250 200, 350 260, 600 260 S 900 250, 1000 250",
-  "M0 200 C 250 200, 350 340, 600 340 S 900 360, 1000 360",
-];
-```
-
 Each `<motion.path>` gets the same `pathLength` MotionValue. There's no
 per-path stagger in the component — the fan reads as simultaneous draw
 because the curves diverge spatially, not temporally.
 
-## Scroll window → pathLength
+</LearnChapter>
 
-`useScroll` tracks the SVG with `offset: ["start end", "end start"]` — the
-full travel from entering the viewport bottom to leaving the top.
-`useTransform` then squeezes that into a narrower active band:
-
-<BeamDrawScroll />
-
-```tsx
-const { scrollYProgress } = useScroll({
+<LearnChapter
+  label="Scroll window → pathLength"
+  scene={<BeamDrawScroll />}
+  code={`const { scrollYProgress } = useScroll({
   target: containerRef as unknown as React.RefObject<HTMLElement>,
   offset: ["start end", "end start"],
 });
 const pathLength = useSpring(
   useTransform(scrollYProgress, [0.1, 0.8], [0, 1]),
   SPRING,
-);
-```
+);`}
+>
+
+`useScroll` tracks the SVG with `offset: ["start end", "end start"]` — the
+full travel from entering the viewport bottom to leaving the top.
+`useTransform` then squeezes that into a narrower active band:
 
 Below `0.1` the beams stay empty; above `0.8` they're fully drawn. The dead
 zones keep the stroke from flickering on the first/last pixels of scroll —
 you're past "just entered" before ink starts, and finished before the element
 exits.
 
-## Spring first, then glow
+</LearnChapter>
+
+<LearnChapter
+  label="Spring first, then glow"
+  scene={<BeamDrawSpring />}
+  code={`const SPRING = { stiffness: 320, damping: 32, mass: 0.9 } as const;
+
+// …
+className={\`w-full [filter:drop-shadow(0_0_8px_color-mix(in_oklch,var(--primary)_50%,transparent))] \${className ?? ""}\`}
+style={{ pathLength: reduce ? 1 : pathLength }}`}
+>
 
 Raw scroll progress is jerky. The mapped value feeds
 `useSpring({ stiffness: 320, damping: 32, mass: 0.9 })` — `SPRING.smooth` —
@@ -62,15 +73,16 @@ so pathLength eases instead of tracking the wheel 1:1. The SVG itself carries
 a primary-tinted drop-shadow; color-mix keeps the glow on-theme without a
 second paint layer.
 
-<BeamDrawSpring />
+</LearnChapter>
 
-```tsx
-const SPRING = { stiffness: 320, damping: 32, mass: 0.9 } as const;
+<LearnChapter label="The result" scene={<BeamDrawResult />} isResult>
 
-// …
-className={`w-full [filter:drop-shadow(0_0_8px_color-mix(in_oklch,var(--primary)_50%,transparent))] ${className ?? ""}`}
-style={{ pathLength: reduce ? 1 : pathLength }}
-```
+One MotionValue, four static paths, a spring between scroll and stroke —
+that's the whole machine.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Reduced motion
 
@@ -81,10 +93,3 @@ still see the fan — it just arrives complete.
 ## Motion Score
 
 <MotionScorePanel name="beam-draw" />
-
-## The result
-
-<BeamDrawResult />
-
-One MotionValue, four static paths, a spring between scroll and stroke —
-that's the whole machine.

--- a/apps/docs/content/docs/components/effects/border-beam/learn.mdx
+++ b/apps/docs/content/docs/components/effects/border-beam/learn.mdx
@@ -1,26 +1,27 @@
 ---
 title: Anatomy of Border Beam
 description: How a masked square rides an offset-path rectangle around a border ring, with rainbow or two-color paint and an optional glow echo.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="Mask ring + riding square"
+  scene={<BorderBeamAnatomy />}
+  code={`className="pointer-events-none absolute inset-0 rounded-[inherit] border-(length:--border-beam-width) border-transparent mask-[linear-gradient(transparent,transparent),linear-gradient(#000,#000)] mask-intersect [mask-clip:padding-box,border-box]"`}
+>
 
 `BorderBeam` never draws a travelling stroke. A square sits on
 `offsetPath: rect(...)`, `offsetDistance` loops forever, and a dual-layer
 mask reveals only the border ring — so the square looks like light skating
 the edge.
 
-## Mask ring + riding square
-
 The host is `absolute inset-0`, `pointer-events-none`,
 `rounded-[inherit]`. Its border is transparent but sized via
 `--border-beam-width`. The mask composite is the trick: one layer clips to
 `padding-box`, the other to `border-box`, intersected — everything inside the
 padding edge disappears, leaving a hollow ring where the beam can show.
-
-<BorderBeamAnatomy />
-
-```tsx
-className="pointer-events-none absolute inset-0 rounded-[inherit] border-(length:--border-beam-width) border-transparent mask-[linear-gradient(transparent,transparent),linear-gradient(#000,#000)] mask-intersect [mask-clip:padding-box,border-box]"
-```
 
 Inside that ring, an `aspect-square` `motion.div` gets:
 
@@ -31,7 +32,19 @@ offsetPath: `rect(0 auto auto 0 round ${size}px)`,
 Larger `size` → longer streak along the perimeter. The square isn't clipped
 to a thin line; the mask does that job for free.
 
-## Offset distance, not direction flags
+</LearnChapter>
+
+<LearnChapter
+  label="Offset distance, not direction flags"
+  scene={<BorderBeamPath />}
+  code={`const animate = reduceMotion
+  ? { offsetDistance: \`\${initialOffset}%\` }
+  : {
+      offsetDistance: reverse
+        ? [\`\${100 - initialOffset}%\`, \`\${-initialOffset}%\`]
+        : [\`\${initialOffset}%\`, \`\${100 + initialOffset}%\`],
+    };`}
+>
 
 Motion is a single property: `offsetDistance`. Default travel runs
 `[initialOffset%, 100 + initialOffset%]` on an infinite linear loop.
@@ -39,22 +52,17 @@ Motion is a single property: `offsetDistance`. Default travel runs
 `[100 − initialOffset%, −initialOffset%]` so the timeline still plays
 forward through opposite percentages.
 
-<BorderBeamPath />
-
-```tsx
-const animate = reduceMotion
-  ? { offsetDistance: `${initialOffset}%` }
-  : {
-      offsetDistance: reverse
-        ? [`${100 - initialOffset}%`, `${-initialOffset}%`]
-        : [`${initialOffset}%`, `${100 + initialOffset}%`],
-    };
-```
-
 `delay` is applied as `delay: -delay` so a late start still looks mid-loop
 instead of waiting from rest.
 
-## Rainbow, two-color, and the glow echo
+</LearnChapter>
+
+<LearnChapter
+  label="Rainbow, two-color, and the glow echo"
+  scene={<BorderBeamRainbow />}
+  code={`const RAINBOW_BEAM =
+  "linear-gradient(to left, var(--rainbow-1), var(--rainbow-5), var(--rainbow-3), var(--rainbow-4), transparent)";`}
+>
 
 With `rainbow` (the default), the square paints
 `RAINBOW_BEAM` — the same hue order as MagicButton
@@ -66,12 +74,16 @@ a comet. Flip `rainbow={false}` and the utilities
 same `animate` / `transition` — a soft neon echo without a second motion
 timeline to keep in sync.
 
-<BorderBeamRainbow />
+</LearnChapter>
 
-```tsx
-const RAINBOW_BEAM =
-  "linear-gradient(to left, var(--rainbow-1), var(--rainbow-5), var(--rainbow-3), var(--rainbow-4), transparent)";
-```
+<LearnChapter label="The result" scene={<BorderBeamResult />} isResult>
+
+Mask the ring, park a gradient square on `offsetPath`, loop
+`offsetDistance`. Everything else is paint.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Reduced motion
 
@@ -82,10 +94,3 @@ no orbit.
 ## Motion Score
 
 <MotionScorePanel name="border-beam" />
-
-## The result
-
-<BorderBeamResult />
-
-Mask the ring, park a gradient square on `offsetPath`, loop
-`offsetDistance`. Everything else is paint.

--- a/apps/docs/content/docs/components/effects/confetti/learn.mdx
+++ b/apps/docs/content/docs/components/effects/confetti/learn.mdx
@@ -1,68 +1,62 @@
 ---
 title: Anatomy of Confetti
 description: How a thin canvas-confetti wrapper shares one DEFAULTS object across a button trigger, an imperative ref, and a bare helper — and why origin is normalized to the viewport.
+learnPlayer: true
 ---
 
-`Confetti` is intentionally thin. GodUI doesn't reimplement particle physics —
-it wraps `canvas-confetti` with shared defaults, three call sites, and one
-accessibility flag that the library already understands.
+<LearnPlayer>
 
-## One DEFAULTS object
-
-Every fire path merges the same base options. Spread, velocity, count, and a
-default origin height are tuned once; call sites only override what they need.
-
-<ConfettiAnatomy />
-
-```tsx
-const DEFAULTS: ConfettiOptions = {
+<LearnChapter
+  label="One DEFAULTS object"
+  scene={<ConfettiAnatomy />}
+  code={`const DEFAULTS: ConfettiOptions = {
   spread: 70,
   startVelocity: 45,
   particleCount: 120,
   origin: { y: 0.7 },
   disableForReducedMotion: true,
-};
-```
+};`}
+>
+
+`Confetti` is intentionally thin. GodUI doesn't reimplement particle physics —
+it wraps `canvas-confetti` with shared defaults, three call sites, and one
+accessibility flag that the library already understands.
+
+Every fire path merges the same base options. Spread, velocity, count, and a
+default origin height are tuned once; call sites only override what they need.
 
 `origin.y: 0.7` parks bursts in the lower third of the viewport when no
 explicit origin is passed — celebration from "below," not raining from the
 top chrome.
 
-## ConfettiButton: rect → viewport fractions
+</LearnChapter>
+
+<LearnChapter
+  label="ConfettiButton: rect → viewport fractions"
+  scene={<ConfettiOrigin />}
+  code={`const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+  const rect = e.currentTarget.getBoundingClientRect();
+  const x = (rect.left + rect.width / 2) / window.innerWidth;
+  const y = (rect.top + rect.height / 2) / window.innerHeight;
+  canvasConfetti({ ...DEFAULTS, origin: { x, y }, ...options });
+  onClick?.(e);
+};`}
+>
 
 The button doesn't fire from a hard-coded point. On click it measures itself,
 normalizes the center into `0…1` viewport space, and passes that as
 `origin: { x, y }` — so the burst reads as coming from the control, wherever
 it sits after layout, scroll, or resize.
 
-<ConfettiOrigin />
-
-```tsx
-const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-  const rect = e.currentTarget.getBoundingClientRect();
-  const x = (rect.left + rect.width / 2) / window.innerWidth;
-  const y = (rect.top + rect.height / 2) / window.innerHeight;
-  canvasConfetti({ ...DEFAULTS, origin: { x, y }, ...options });
-  onClick?.(e);
-};
-```
-
 `options` still win last — you can widen the spread or bump the count without
 losing the positional origin unless you override it.
 
-## Three APIs, one core
+</LearnChapter>
 
-Same merge, three ergonomics:
-
-1. **`ConfettiButton`** — declarative trigger, origin from the click target.
-2. **`<Confetti ref />` + `fire()`** — imperative, toast-style; returns
-   `null` (no DOM).
-3. **`confetti(options?)`** — bare helper for non-React call sites.
-
-<ConfettiApi />
-
-```tsx
-React.useImperativeHandle(
+<LearnChapter
+  label="Three APIs, one core"
+  scene={<ConfettiApi />}
+  code={`React.useImperativeHandle(
   ref,
   () => ({
     fire: (override?: ConfettiOptions) => {
@@ -74,8 +68,26 @@ React.useImperativeHandle(
 
 function confetti(options?: ConfettiOptions) {
   canvasConfetti({ ...DEFAULTS, ...options });
-}
-```
+}`}
+>
+
+Same merge, three ergonomics:
+
+1. **`ConfettiButton`** — declarative trigger, origin from the click target.
+2. **`<Confetti ref />` + `fire()`** — imperative, toast-style; returns
+   `null` (no DOM).
+3. **`confetti(options?)`** — bare helper for non-React call sites.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<ConfettiResult />} isResult>
+
+Defaults once, origin from layout, three ways to pull the trigger — that's
+the whole wrapper.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Reduced motion
 
@@ -87,10 +99,3 @@ maintain.
 ## Motion Score
 
 <MotionScorePanel name="confetti" />
-
-## The result
-
-<ConfettiResult />
-
-Defaults once, origin from layout, three ways to pull the trigger — that's
-the whole wrapper.

--- a/apps/docs/content/docs/components/effects/encrypted-card/learn.mdx
+++ b/apps/docs/content/docs/components/effects/encrypted-card/learn.mdx
@@ -1,35 +1,46 @@
 ---
 title: Anatomy of Encrypted Card
 description: How a radial mask and a re-scrambling glyph stream turn a static card into a live ciphertext reveal that follows the pointer.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="Stream under, content over"
+  scene={<EncryptedCardAnatomy />}
+  code={`<div className="group relative overflow-hidden …">
+  <div aria-hidden className={STREAM_BASE} style={{ color: streamColor }}>
+    {stream}
+  </div>
+  <div className="relative z-raised">{children}</div>
+</div>`}
+>
 
 `EncryptedCard` doesn't animate ciphertext across the surface — it keeps a
 full glyph field painted underneath the content and reveals it through a soft
 radial mask centered on the pointer. Two layers, one CSS variable pair, and
 an interval that only runs while you hover.
 
-## Stream under, content over
-
 The root is a `group relative overflow-hidden` card. An absolute, `aria-hidden`
 glyph layer fills the inset with `STREAM_LEN` (1500) characters drawn from
 `DEFAULT_CHARS`. Children sit in a sibling at `z-raised`, so real content
 never fights the stream for stacking order.
 
-<EncryptedCardAnatomy />
-
-```tsx
-<div className="group relative overflow-hidden …">
-  <div aria-hidden className={STREAM_BASE} style={{ color: streamColor }}>
-    {stream}
-  </div>
-  <div className="relative z-raised">{children}</div>
-</div>
-```
-
 The stream is filled client-side on mount so SSR markup stays deterministic —
 `randomString` never runs during the first server render.
 
-## The reveal is a mask, not a clip of content
+</LearnChapter>
+
+<LearnChapter
+  label="The reveal is a mask, not a clip of content"
+  scene={<EncryptedCardMask />}
+  code={`el.style.setProperty("--x", \`\${e.clientX - rect.left}px\`);
+el.style.setProperty("--y", \`\${e.clientY - rect.top}px\`);
+
+// STREAM_BASE includes:
+// [mask-image:radial-gradient(var(--reveal) circle at var(--x,50%) var(--y,50%),#000_0%,transparent_100%)]`}
+>
 
 Pointer position never moves the glyphs. `onPointerMove` writes `--x` and
 `--y` as pixel offsets from the card's bounding rect; the stream's
@@ -37,21 +48,24 @@ Pointer position never moves the glyphs. `onPointerMove` writes `--x` and
 `--reveal` for radius). Defaults are `50%` / `50%`, so the first paint isn't
 a corner flash.
 
-<EncryptedCardMask />
-
-```tsx
-el.style.setProperty("--x", `${e.clientX - rect.left}px`);
-el.style.setProperty("--y", `${e.clientY - rect.top}px`);
-
-// STREAM_BASE includes:
-// [mask-image:radial-gradient(var(--reveal) circle at var(--x,50%) var(--y,50%),#000_0%,transparent_100%)]
-```
-
 Opacity is separate from the mask: the stream starts at `opacity-0` and fades
 to `--stream-opacity` on `group-hover` over 300ms. The mask only decides
 *where* the faded-in stream is visible.
 
-## Scramble only while hovered
+</LearnChapter>
+
+<LearnChapter
+  label="Scramble only while hovered"
+  scene={<EncryptedCardScramble />}
+  code={`React.useEffect(() => {
+  setStream(randomString(STREAM_LEN, characters));
+  if (reduced || !hovered) return;
+  const id = window.setInterval(() => {
+    setStream(randomString(STREAM_LEN, characters));
+  }, speed);
+  return () => window.clearInterval(id);
+}, [characters, speed, hovered, reduced]);`}
+>
 
 While `hovered` is true and reduced motion is off, a `setInterval` re-rolls
 the entire 1500-character string every `speed` ms (default 55). Leaving the
@@ -59,18 +73,19 @@ card clears the interval; entering starts it again. That's why the ciphertext
 looks alive under the spotlight without a forever-running timer in the
 background.
 
-<EncryptedCardScramble />
+</LearnChapter>
 
-```tsx
-React.useEffect(() => {
-  setStream(randomString(STREAM_LEN, characters));
-  if (reduced || !hovered) return;
-  const id = window.setInterval(() => {
-    setStream(randomString(STREAM_LEN, characters));
-  }, speed);
-  return () => window.clearInterval(id);
-}, [characters, speed, hovered, reduced]);
-```
+<LearnChapter label="The result" scene={<EncryptedCardResult />} isResult>
+
+Hover the card and move across it — the spotlight and the scramble are the
+same two mechanisms from above.
+
+One glyph field, one radial mask on `--x`/`--y`, and an interval that only
+lives for the length of the hover.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Reduced motion
 
@@ -88,13 +103,3 @@ const reduced = usePrefersReducedMotion();
 ## Motion Score
 
 <MotionScorePanel name="encrypted-card" />
-
-## The result
-
-Hover the card and move across it — the spotlight and the scramble are the
-same two mechanisms from above.
-
-<EncryptedCardResult />
-
-One glyph field, one radial mask on `--x`/`--y`, and an interval that only
-lives for the length of the hover.

--- a/apps/docs/content/docs/components/effects/fluid-cursor/learn.mdx
+++ b/apps/docs/content/docs/components/effects/fluid-cursor/learn.mdx
@@ -1,14 +1,30 @@
 ---
 title: Anatomy of Fluid Cursor
 description: How a portal-rendered dot and lagging trail chase the pointer with three lerps — and why the rAF loop stops the moment everything settles.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="Dot, trail, portal"
+  scene={<FluidCursorAnatomy />}
+  code={`return createPortal(
+  <div
+    aria-hidden
+    className={\`pointer-events-none \${scoped ? "absolute" : "fixed"} inset-0 z-toast … \${blend ? "mix-blend-difference" : ""}\`}
+  >
+    {trail ? <div ref={trailRef} className="… blur-md" style={{ width: size * 2.4, … }} /> : null}
+    <div ref={dotRef} style={{ width: size, height: size, background: color }} />
+  </div>,
+  target,
+);`}
+>
 
 `FluidCursor` isn't a CSS `cursor:` swap. It portals a custom stack into the
 page (or a scoped container), hides the system cursor in that region, and
 drives two circles with a `requestAnimationFrame` loop that only runs while
 there's catching-up left to do.
-
-## Dot, trail, portal
 
 When enabled, the component `createPortal`s a `pointer-events-none` overlay
 into `containerRef.current` (or `document.body`). Inside: an optional soft
@@ -16,22 +32,19 @@ trail (`size × 2.4`, `blur-md`) and a sharp leading dot. With `blend` on, the
 whole stack uses `mix-blend-mode: difference` so a white fill inverts whatever
 sits underneath.
 
-<FluidCursorAnatomy />
+</LearnChapter>
 
-```tsx
-return createPortal(
-  <div
-    aria-hidden
-    className={`pointer-events-none ${scoped ? "absolute" : "fixed"} inset-0 z-toast … ${blend ? "mix-blend-difference" : ""}`}
-  >
-    {trail ? <div ref={trailRef} className="… blur-md" style={{ width: size * 2.4, … }} /> : null}
-    <div ref={dotRef} style={{ width: size, height: size, background: color }} />
-  </div>,
-  target,
-);
-```
+<LearnChapter
+  label="Three lerps, one loop"
+  scene={<FluidCursorLerp />}
+  code={`s.x += (s.tx - s.x) * 0.25;
+s.y += (s.ty - s.y) * 0.25;
+s.sx += (s.tx - s.sx) * 0.12;
+s.sy += (s.ty - s.sy) * 0.12;
+s.hover += (s.thover - s.hover) * 0.15;
 
-## Three lerps, one loop
+dot.style.transform = \`translate3d(\${s.x}px, \${s.y}px, 0) translate(-50%, -50%) scale(\${1 + s.hover * 1.6})\`;`}
+>
 
 Every frame the loop nudges three values toward their targets: position for
 the dot (`0.25`), position for the trail (`0.12`), and a hover amount
@@ -39,32 +52,15 @@ the dot (`0.25`), position for the trail (`0.12`), and a hover amount
 `[data-cursor]` by default — set `thover` to `1`, which scales the dot to
 `1 + hover × 1.6` (trail to `1 + hover × 0.8`).
 
-<FluidCursorLerp />
-
-```tsx
-s.x += (s.tx - s.x) * 0.25;
-s.y += (s.ty - s.y) * 0.25;
-s.sx += (s.tx - s.sx) * 0.12;
-s.sy += (s.ty - s.sy) * 0.12;
-s.hover += (s.thover - s.hover) * 0.15;
-
-dot.style.transform = `translate3d(${s.x}px, ${s.y}px, 0) translate(-50%, -50%) scale(${1 + s.hover * 1.6})`;
-```
-
 Direct style writes — no React re-render per move. The first `pointermove`
 snaps all positions to the pointer so the cursor doesn't fly in from `(0,0)`.
 
-## Cheap when idle
+</LearnChapter>
 
-`SETTLE` is `0.01`. When every delta is under that threshold — or the tab is
-hidden — the loop sets `raf = 0` and returns. The next `pointermove` /
-`pointerover` / visibility restore calls `start()` again. A resting cursor
-costs zero frames.
-
-<FluidCursorLifecycle />
-
-```tsx
-const SETTLE = 0.01;
+<LearnChapter
+  label="Cheap when idle"
+  scene={<FluidCursorLifecycle />}
+  code={`const SETTLE = 0.01;
 const settled = () =>
   Math.abs(s.tx - s.x) < SETTLE &&
   Math.abs(s.ty - s.y) < SETTLE &&
@@ -73,8 +69,27 @@ const settled = () =>
 if (settled() || document.hidden) {
   raf = 0;
   return;
-}
-```
+}`}
+>
+
+`SETTLE` is `0.01`. When every delta is under that threshold — or the tab is
+hidden — the loop sets `raf = 0` and returns. The next `pointermove` /
+`pointerover` / visibility restore calls `start()` again. A resting cursor
+costs zero frames.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<FluidCursorResult />} isResult>
+
+Move inside the card — hover the button and the `[data-cursor]` chip to feel
+the scale lerp.
+
+Two circles, three lerps, and an rAF loop that refuses to spin when nothing
+is moving.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Who gets a custom cursor
 
@@ -93,13 +108,3 @@ setEnabled(fine && !reduce);
 ## Motion Score
 
 <MotionScorePanel name="fluid-cursor" />
-
-## The result
-
-Move inside the card — hover the button and the `[data-cursor]` chip to feel
-the scale lerp.
-
-<FluidCursorResult />
-
-Two circles, three lerps, and an rAF loop that refuses to spin when nothing
-is moving.

--- a/apps/docs/content/docs/components/effects/image-trail/learn.mdx
+++ b/apps/docs/content/docs/components/effects/image-trail/learn.mdx
@@ -1,14 +1,26 @@
 ---
 title: Anatomy of Image Trail
 description: How a recycled DOM pool, a travel threshold, and the Web Animations API leave a trail of images without a React re-render per move.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="A pool, not a stream of mounts"
+  scene={<ImageTrailAnatomy />}
+  code={`const slots = React.useRef<(HTMLImageElement | null)[]>([]);
+const slotIndex = React.useRef(0);
+
+const img = slots.current[slotIndex.current % max];
+slotIndex.current += 1;
+img.src = images[imageIndex.current % images.length];`}
+>
 
 `ImageTrail` doesn't mount a new `<img>` every time the pointer moves. It
 keeps a fixed pool of slots, skips spawns until you've travelled far enough,
 and drives each appearance with `element.animate()` — direct style writes,
 zero React updates on the hot path.
-
-## A pool, not a stream of mounts
 
 On render, `max` (default 12) invisible `<img>` nodes are created once and
 stored in `slots.current`. Each spawn takes `slots[slotIndex % max]`, bumps
@@ -16,18 +28,17 @@ the index, swaps `src` from the `images` array, and animates. When the pool
 wraps, the oldest slot is reused mid-flight — that's intentional: the
 previous animation is simply overwritten.
 
-<ImageTrailAnatomy />
+</LearnChapter>
 
-```tsx
-const slots = React.useRef<(HTMLImageElement | null)[]>([]);
-const slotIndex = React.useRef(0);
-
-const img = slots.current[slotIndex.current % max];
-slotIndex.current += 1;
-img.src = images[imageIndex.current % images.length];
-```
-
-## Distance gate before spawn
+<LearnChapter
+  label="Distance gate before spawn"
+  scene={<ImageTrailThreshold />}
+  code={`const dx = x - prev.x;
+const dy = y - prev.y;
+if (Math.hypot(dx, dy) < threshold) return;
+spawn(x, y, Math.atan2(dy, dx));
+last.current = { x, y };`}
+>
 
 `onPointerMove` converts the event to container-local coordinates and
 compares against `last`. If `Math.hypot(dx, dy)` is under `threshold`
@@ -35,17 +46,20 @@ compares against `last`. If `Math.hypot(dx, dy)` is under `threshold`
 threshold, `atan2(dy, dx)` becomes a clamped tilt (±12°) so each image leans
 slightly into the direction of travel.
 
-<ImageTrailThreshold />
+</LearnChapter>
 
-```tsx
-const dx = x - prev.x;
-const dy = y - prev.y;
-if (Math.hypot(dx, dy) < threshold) return;
-spawn(x, y, Math.atan2(dy, dx));
-last.current = { x, y };
-```
-
-## WAAPI keyframes, not React state
+<LearnChapter
+  label="WAAPI keyframes, not React state"
+  scene={<ImageTrailWaapi />}
+  code={`img.animate(
+  [
+    { opacity: 0, transform: \`translate(-50%, -50%) scale(0.4) rotate(\${tilt}deg)\` },
+    { opacity: 1, transform: \`translate(-50%, -50%) scale(1) rotate(\${tilt}deg)\`, offset: 0.18 },
+    { opacity: 0, transform: \`translate(-50%, -65%) scale(0.92) rotate(\${tilt}deg)\` },
+  ],
+  { duration, easing: "cubic-bezier(0.22,1,0.36,1)", fill: "forwards" },
+);`}
+>
 
 `spawn` sets `left`/`top`, then calls `img.animate` with three keyframes:
 fade/scale in to full size at 18%, then fade out while drifting slightly
@@ -53,18 +67,19 @@ upward (`translate(-50%, -65%)`) and settling at `scale(0.92)`. Easing is
 `cubic-bezier(0.22, 1, 0.36, 1)` with `fill: "forwards"`. Nothing in that
 path calls `setState`.
 
-<ImageTrailWaapi />
+</LearnChapter>
 
-```tsx
-img.animate(
-  [
-    { opacity: 0, transform: `translate(-50%, -50%) scale(0.4) rotate(${tilt}deg)` },
-    { opacity: 1, transform: `translate(-50%, -50%) scale(1) rotate(${tilt}deg)`, offset: 0.18 },
-    { opacity: 0, transform: `translate(-50%, -65%) scale(0.92) rotate(${tilt}deg)` },
-  ],
-  { duration, easing: "cubic-bezier(0.22,1,0.36,1)", fill: "forwards" },
-);
-```
+<LearnChapter label="The result" scene={<ImageTrailResult />} isResult>
+
+Move across the stage — images spawn only after you've travelled, then drift
+away on their own timeline.
+
+One recycled pool, one distance check, one `animate()` call — that's the
+whole trail.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Reduced motion
 
@@ -84,13 +99,3 @@ row of photos.
 ## Motion Score
 
 <MotionScorePanel name="image-trail" />
-
-## The result
-
-Move across the stage — images spawn only after you've travelled, then drift
-away on their own timeline.
-
-<ImageTrailResult />
-
-One recycled pool, one distance check, one `animate()` call — that's the
-whole trail.

--- a/apps/docs/content/docs/components/effects/lamp/learn.mdx
+++ b/apps/docs/content/docs/components/effects/lamp/learn.mdx
@@ -1,14 +1,27 @@
 ---
 title: Anatomy of Lamp
 description: How two mirrored conic cones, a glowing seam, and a delayed children rise compose a scroll-triggered lamp that ignites once and stays lit.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="Two cones, one seam"
+  scene={<LampAnatomy />}
+  code={`style={{ ["--lamp" as string]: color, ...style }}
+
+// Right cone — mirrored from the left
+className="… origin-right [background-image:conic-gradient(from_70deg_at_center_top,color-mix(in_oklch,var(--lamp)_60%,transparent),transparent,transparent)] [mask-image:linear-gradient(to_top,transparent,white)]"
+
+// Left cone
+className="… origin-left [background-image:conic-gradient(from_290deg_at_center_top,transparent,transparent,color-mix(in_oklch,var(--lamp)_60%,transparent))] …"`}
+>
 
 `Lamp` is a viewport-triggered light: two mirrored conic gradients widen from
 a center seam, a glowing bar and radial wash bloom where they meet, and the
 children rise into that light a beat later. Everything is compositor motion —
 `scaleX`, `opacity`, `y` — driven by Framer Motion `whileInView`.
-
-## Two cones, one seam
 
 The silhouette is four layers stacked in a single `isolate` stage. A right
 cone (`conic-gradient(from 70deg…)`, `origin-right`) mirrors a left cone
@@ -20,33 +33,15 @@ Accent color flows through one CSS variable: `--lamp`, set from the `color`
 prop (default `var(--primary)`). Cones mix it at 60% into transparent; the
 wash mixes at 25%.
 
-<LampAnatomy />
-
-```tsx
-style={{ ["--lamp" as string]: color, ...style }}
-
-// Right cone — mirrored from the left
-className="… origin-right [background-image:conic-gradient(from_70deg_at_center_top,color-mix(in_oklch,var(--lamp)_60%,transparent),transparent,transparent)] [mask-image:linear-gradient(to_top,transparent,white)]"
-
-// Left cone
-className="… origin-left [background-image:conic-gradient(from_290deg_at_center_top,transparent,transparent,color-mix(in_oklch,var(--lamp)_60%,transparent))] …"
-```
-
 Masks fade each cone toward the bottom so the light reads as a beam falling
 onto the stage, not a hard triangle.
 
-## The ignite: scaleX from half to full
+</LearnChapter>
 
-Both cones start unlit — `scaleX: 0.5`, `opacity: 0.5` — and tween to
-`scaleX: 1`, `opacity: 1` over **0.8s `easeInOut`**. The bar uses the same
-duration but only animates `scaleX`. Because origins sit on opposite sides of
-the seam, the light blooms *outward* from the center rather than growing from
-a shared pivot.
-
-<LampIgnite />
-
-```tsx
-const lit = { scaleX: 1, opacity: 1 };
+<LearnChapter
+  label="The ignite: scaleX from half to full"
+  scene={<LampIgnite />}
+  code={`const lit = { scaleX: 1, opacity: 1 };
 const unlit = { scaleX: 0.5, opacity: 0.5 };
 const VIEWPORT = { once: true, margin: "-20%" } as const;
 
@@ -55,15 +50,19 @@ const VIEWPORT = { once: true, margin: "-20%" } as const;
   whileInView={lit}
   viewport={VIEWPORT}
   transition={{ duration: 0.8, ease: "easeInOut" }}
-/>
-```
+/>`}
+>
+
+Both cones start unlit — `scaleX: 0.5`, `opacity: 0.5` — and tween to
+`scaleX: 1`, `opacity: 1` over **0.8s `easeInOut`**. The bar uses the same
+duration but only animates `scaleX`. Because origins sit on opposite sides of
+the seam, the light blooms *outward* from the center rather than growing from
+a shared pivot.
 
 `viewport.once: true` with `margin: "-20%"` means the section must be well
 into the viewport before ignition, and it never re-runs on scroll-away. That
 is intentional: a lamp that flickers every time you scroll past feels broken;
 a lamp that lights once feels like an entrance.
-
-## Why scaleX, not width
 
 Animating `width` on a 30rem cone would thrash layout every frame. `scaleX`
 stays on the compositor, keeps the conic gradient resolution stable, and
@@ -71,24 +70,35 @@ lets `origin-left` / `origin-right` do the directional work for free. The
 radial wash is a static div — it does not need to animate independently; its
 opacity reads brighter as the cones cover more of it.
 
-## Children rise after the light
+</LearnChapter>
 
-The headline slot starts at `opacity: 0`, `y: 40` and settles to
-`opacity: 1`, `y: 0` on the same 0.8s ease — but with a **0.2s delay**. The
-light arrives first; content follows into an already-lit stage.
-
-<LampRise />
-
-```tsx
-<motion.div
+<LearnChapter
+  label="Children rise after the light"
+  scene={<LampRise />}
+  code={`<motion.div
   initial={reduceMotion ? { opacity: 1, y: 0 } : { opacity: 0, y: 40 }}
   whileInView={{ opacity: 1, y: 0 }}
   viewport={VIEWPORT}
   transition={{ duration: 0.8, delay: 0.2, ease: "easeInOut" }}
 >
   {children}
-</motion.div>
-```
+</motion.div>`}
+>
+
+The headline slot starts at `opacity: 0`, `y: 40` and settles to
+`opacity: 1`, `y: 0` on the same 0.8s ease — but with a **0.2s delay**. The
+light arrives first; content follows into an already-lit stage.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<LampResult />} isResult>
+
+Two mirrored cones, one seam, one delayed rise — ignited once by
+`whileInView`, colored by `--lamp`, and compositor-cheap the whole way.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Reduced motion
 
@@ -100,10 +110,3 @@ experience.
 ## Motion Score
 
 <MotionScorePanel name="lamp" />
-
-## The result
-
-<LampResult />
-
-Two mirrored cones, one seam, one delayed rise — ignited once by
-`whileInView`, colored by `--lamp`, and compositor-cheap the whole way.

--- a/apps/docs/content/docs/components/effects/liquid-image/learn.mdx
+++ b/apps/docs/content/docs/components/effects/liquid-image/learn.mdx
@@ -1,30 +1,17 @@
 ---
 title: Anatomy of Liquid Image
 description: How an SVG turbulence + displacement filter, a zero-rerender rAF lerp, and pointer velocity compose a liquid ripple that falls back cleanly when filters or motion are unavailable.
+learnPlayer: true
 ---
 
-`LiquidImage` does not animate the `<img>` in React. It attaches an SVG
-`feTurbulence` + `feDisplacementMap` filter, then eases the displacement
-`scale` toward a target inside a single `requestAnimationFrame` loop —
-writing attributes directly so the image never re-renders.
+<LearnPlayer>
 
-## Filter chain: noise, then displace
+<LearnChapter
+  label="Filter chain: noise, then displace"
+  scene={<LiquidImageAnatomy />}
+  code={`const id = \`liquid-\${React.useId().replace(/:/g, "")}\`;
 
-A zero-size `<svg>` holds a `<filter>` whose id comes from `useId()`
-(colons stripped). Think of it as three stages of the **same** image:
-
-1. **Source** — the `<img>` enters the filter as `SourceGraphic`.
-2. **Noise** — `feTurbulence` builds a fractal noise field (slowly drifted by
-   an SMIL `<animate>` on `baseFrequency` so it never freezes).
-3. **Displaced** — `feDisplacementMap` uses that noise's R/G channels to
-   push each source pixel, with live `scale` controlling how hard.
-
-<LiquidImageAnatomy />
-
-```tsx
-const id = `liquid-${React.useId().replace(/:/g, "")}`;
-
-<img style={active ? { filter: `url(#${id})` } : undefined} … />
+<img style={active ? { filter: \`url(#\${id})\` } : undefined} … />
 
 <feTurbulence
   type="fractalNoise"
@@ -36,7 +23,7 @@ const id = `liquid-${React.useId().replace(/:/g, "")}`;
   <animate
     attributeName="baseFrequency"
     dur="16s"
-    values={`${frequency};${frequency * 1.7};${frequency}`}
+    values={\`\${frequency};\${frequency * 1.7};\${frequency}\`}
     repeatCount="indefinite"
   />
 </feTurbulence>
@@ -47,13 +34,41 @@ const id = `liquid-${React.useId().replace(/:/g, "")}`;
   scale="0"
   xChannelSelector="R"
   yChannelSelector="G"
-/>
-```
+/>`}
+>
+
+`LiquidImage` does not animate the `<img>` in React. It attaches an SVG
+`feTurbulence` + `feDisplacementMap` filter, then eases the displacement
+`scale` toward a target inside a single `requestAnimationFrame` loop —
+writing attributes directly so the image never re-renders.
+
+A zero-size `<svg>` holds a `<filter>` whose id comes from `useId()`
+(colons stripped). Think of it as three stages of the **same** image:
+
+1. **Source** — the `<img>` enters the filter as `SourceGraphic`.
+2. **Noise** — `feTurbulence` builds a fractal noise field (slowly drifted by
+   an SMIL `<animate>` on `baseFrequency` so it never freezes).
+3. **Displaced** — `feDisplacementMap` uses that noise's R/G channels to
+   push each source pixel, with live `scale` controlling how hard.
 
 The filter's region is padded (`x/y −20%`, `width/height 140%`) so edge
 pixels have room to displace without clipping hard against the image bounds.
 
-## Why the border boils
+</LearnChapter>
+
+<LearnChapter
+  label="Why the border boils"
+  scene={<LiquidImageEdge />}
+  code={`<feTurbulence …>
+  <animate
+    attributeName="baseFrequency"
+    dur="16s"
+    values={\`\${frequency};\${frequency * 1.7};\${frequency}\`}
+    repeatCount="indefinite"
+  />
+</feTurbulence>
+<feDisplacementMap … scale="0" /* rAF writes this */ />`}
+>
 
 The irregular silhouette you see on hover isn't a separate mask or
 `clip-path`. Displacement pushes the photo's own edge pixels outward using
@@ -64,41 +79,38 @@ the noise field. Two animations keep it alive:
 2. **Scale** — the rAF lerp (next section) raises `feDisplacementMap`'s
    `scale` on interaction. Higher scale → wilder fringe.
 
-<LiquidImageEdge />
+</LearnChapter>
 
-```tsx
-<feTurbulence …>
-  <animate
-    attributeName="baseFrequency"
-    dur="16s"
-    values={`${frequency};${frequency * 1.7};${frequency}`}
-    repeatCount="indefinite"
-  />
-</feTurbulence>
-<feDisplacementMap … scale="0" /* rAF writes this */ />
-```
-
-## The loop: lerp 0.12, no setState
+<LearnChapter
+  label="The loop: lerp 0.12, no setState"
+  scene={<LiquidImageLerp />}
+  code={`const next = current.current + (target.current - current.current) * 0.12;
+current.current = next;
+if (el) el.setAttribute("scale", next.toFixed(2));`}
+>
 
 `current` and `target` live in refs. Each frame:
-
-```tsx
-const next = current.current + (target.current - current.current) * 0.12;
-current.current = next;
-if (el) el.setAttribute("scale", next.toFixed(2));
-```
 
 That is the whole animation. No React state, no style recalculation on the
 img — only an SVG attribute write. The loop keeps running while
 `target > 0.01` or `current > 0.05`, then cancels itself so idle images cost
 nothing.
 
-<LiquidImageLerp />
-
 `ensureLoop()` starts a frame only when `raf.current == null`, so enter /
 move / always-mode never stack competing loops.
 
-## Who writes the target
+</LearnChapter>
+
+<LearnChapter
+  label="Who writes the target"
+  scene={<LiquidImageTrigger />}
+  code={`const speed = Math.hypot(e.clientX - prev.x, e.clientY - prev.y) / dt;
+const boost = Math.min(strength, strength * 0.5 + speed * 60);
+if (trigger === "hover" || boost > target.current) {
+  target.current = boost;
+  ensureLoop();
+}`}
+>
 
 Three writers feed the same lerp:
 
@@ -113,16 +125,16 @@ Velocity is `hypot(Δx, Δy) / dt` with a 16ms floor on `dt`. Faster cursors
 spike the ripple briefly; the lerp settles it back. On `always`, boosts only
 raise the target when they exceed the current hold.
 
-<LiquidImageTrigger />
+</LearnChapter>
 
-```tsx
-const speed = Math.hypot(e.clientX - prev.x, e.clientY - prev.y) / dt;
-const boost = Math.min(strength, strength * 0.5 + speed * 60);
-if (trigger === "hover" || boost > target.current) {
-  target.current = boost;
-  ensureLoop();
-}
-```
+<LearnChapter label="The result" scene={<LiquidImageResult />} isResult>
+
+One filter id, one rAF lerp, three target writers — and a CSS fallback when
+the GPU path is unavailable.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Fallback: unsupported filter or reduced motion
 
@@ -142,10 +154,3 @@ className={`… ${
 ## Motion Score
 
 <MotionScorePanel name="liquid-image" />
-
-## The result
-
-<LiquidImageResult />
-
-One filter id, one rAF lerp, three target writers — and a CSS fallback when
-the GPU path is unavailable.

--- a/apps/docs/content/docs/components/effects/marquee/learn.mdx
+++ b/apps/docs/content/docs/components/effects/marquee/learn.mdx
@@ -1,14 +1,25 @@
 ---
 title: Anatomy of Marquee
 description: How duplicated tracks, a CSS translate loop, and an edge mask make an infinite scroll that never paints twice.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="Duplicated tracks, not a longer row"
+  scene={<MarqueeAnatomy />}
+  code={`{Array.from({ length: Math.max(2, repeat) }, (_, i) => (
+  <div key={i} aria-hidden={i > 0} className={trackClass}>
+    {children}
+  </div>
+))}`}
+>
 
 `Marquee` doesn't measure content or run a JS ticker. It clones its children
 into enough identical tracks to tile the overflow box, then lets CSS
 `translateX` / `translateY` carry them — one duration token, reverse via
 `animation-direction`, pause via `animation-play-state`.
-
-## Duplicated tracks, not a longer row
 
 Children are rendered `Math.max(2, repeat)` times. Each copy is its own
 flex track with the same gap; track `i > 0` is `aria-hidden` so assistive
@@ -16,17 +27,20 @@ tech only announces the first. When the lead track has scrolled exactly
 one copy plus the gap, the next track has slid into the same visual slot
 and the loop restarts without a seam.
 
-<MarqueeAnatomy />
+</LearnChapter>
 
-```tsx
-{Array.from({ length: Math.max(2, repeat) }, (_, i) => (
-  <div key={i} aria-hidden={i > 0} className={trackClass}>
-    {children}
-  </div>
-))}
-```
+<LearnChapter
+  label="Pure CSS motion"
+  scene={<MarqueeTrack />}
+  code={`style={{ ["--duration" as string]: \`\${speed}s\`, ...style }}
 
-## Pure CSS motion
+const trackClass = [
+  TRACK_BASE,
+  vertical ? "flex-col animate-marquee-vertical" : "flex-row animate-marquee",
+  reverse ? "[animation-direction:reverse]" : "",
+  pauseOnHover ? "group-hover:[animation-play-state:paused]" : "",
+].filter(Boolean).join(" ");`}
+>
 
 Horizontal tracks get `animate-marquee`; vertical get
 `animate-marquee-vertical`. Both read `--duration` from the `speed` prop
@@ -35,24 +49,21 @@ Horizontal tracks get `animate-marquee`; vertical get
 `group-hover:[animation-play-state:paused]` on the tracks inside the
 `group` root. `motion-reduce:animate-none` kills the animation entirely.
 
-<MarqueeTrack />
-
-```tsx
-style={{ ["--duration" as string]: `${speed}s`, ...style }}
-
-const trackClass = [
-  TRACK_BASE,
-  vertical ? "flex-col animate-marquee-vertical" : "flex-row animate-marquee",
-  reverse ? "[animation-direction:reverse]" : "",
-  pauseOnHover ? "group-hover:[animation-play-state:paused]" : "",
-].filter(Boolean).join(" ");
-```
-
 The keyframes themselves are compositor-only — `translateX(0)` to
 `translateX(calc(-100% - var(--gap)))` — so the browser never lays out
 between frames.
 
-## Edge fade via mask, not an overlay
+</LearnChapter>
+
+<LearnChapter
+  label="Edge fade via mask, not an overlay"
+  scene={<MarqueeFade />}
+  code={`const fadeClass = fade
+  ? vertical
+    ? "[mask-image:linear-gradient(to_bottom,transparent,black_12%,black_88%,transparent)] …"
+    : "[mask-image:linear-gradient(to_right,transparent,black_12%,black_88%,transparent)] …"
+  : "";`}
+>
 
 When `fade` is on, the root gets a `mask-image` linear gradient:
 transparent → black at 12% / 88% → transparent. Horizontal uses
@@ -60,15 +71,16 @@ transparent → black at 12% / 88% → transparent. Horizontal uses
 `-webkit-mask-image`. Nothing sits on top of the content — the pixels at
 the edges simply aren't drawn.
 
-<MarqueeFade />
+</LearnChapter>
 
-```tsx
-const fadeClass = fade
-  ? vertical
-    ? "[mask-image:linear-gradient(to_bottom,transparent,black_12%,black_88%,transparent)] …"
-    : "[mask-image:linear-gradient(to_right,transparent,black_12%,black_88%,transparent)] …"
-  : "";
-```
+<LearnChapter label="The result" scene={<MarqueeResult />} isResult>
+
+Duplicate tracks, one CSS translate loop, a mask for soft edges — and
+nothing on the main thread after mount.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Reduced motion
 
@@ -79,10 +91,3 @@ one — and `aria-hidden` on the clones still holds.
 ## Motion Score
 
 <MotionScorePanel name="marquee" />
-
-## The result
-
-<MarqueeResult />
-
-Duplicate tracks, one CSS translate loop, a mask for soft edges — and
-nothing on the main thread after mount.

--- a/apps/docs/content/docs/components/effects/particle-dissolve/learn.mdx
+++ b/apps/docs/content/docs/components/effects/particle-dissolve/learn.mdx
@@ -1,21 +1,15 @@
 ---
 title: Anatomy of Particle Dissolve
 description: How an offscreen canvas samples text or an image into particles, then a rAF loop assembles, disperses, or loops them with per-particle delay — triggered by mount, in-view, or hover.
+learnPlayer: true
 ---
 
-`ParticleDissolve` is not a CSS effect. It rasterizes text (or an image) onto
-an offscreen canvas, samples opaque pixels into a `Particle[]`, then animates
-each particle from a random scatter point `(sx, sy)` toward its target
-`(tx, ty)` inside a canvas `requestAnimationFrame` loop.
+<LearnPlayer>
 
-## Sample once, animate forever
-
-`build()` creates an offscreen canvas matching `width` × `height`. For text it
-fills white glyphs centered with the given `font`; for `src` it contain-fits
-the image. Then it walks the pixel buffer in `density` steps:
-
-```tsx
-for (let y = 0; y < height; y += density) {
+<LearnChapter
+  label="Sample once, animate forever"
+  scene={<ParticleDissolveAnatomy />}
+  code={`for (let y = 0; y < height; y += density) {
   for (let x = 0; x < width; x += density) {
     const i = (y * width + x) * 4;
     if ((data[i + 3] as number) > 128) {
@@ -26,22 +20,39 @@ for (let y = 0; y < height; y += density) {
         sy: Math.random() * height,
         delay: Math.random() * 0.4,
         jitter: Math.random() * Math.PI * 2,
-        color: src ? `rgb(${r},${g},${b})` : resolvedColor,
+        color: src ? \`rgb(\${r},\${g},\${b})\` : resolvedColor,
       });
     }
   }
-}
-```
+}`}
+>
+
+`ParticleDissolve` is not a CSS effect. It rasterizes text (or an image) onto
+an offscreen canvas, samples opaque pixels into a `Particle[]`, then animates
+each particle from a random scatter point `(sx, sy)` toward its target
+`(tx, ty)` inside a canvas `requestAnimationFrame` loop.
+
+`build()` creates an offscreen canvas matching `width` × `height`. For text it
+fills white glyphs centered with the given `font`; for `src` it contain-fits
+the image. Then it walks the pixel buffer in `density` steps.
 
 Smaller `density` → denser (and heavier) clouds. Alpha threshold 128 keeps
 anti-aliased edges from spawning ghost particles.
 
-<ParticleDissolveAnatomy />
-
 Each particle carries its own `delay` (0–0.4) and `jitter` so the cloud never
 moves as a rigid sheet.
 
-## Progress, ease, and modes
+</LearnChapter>
+
+<LearnChapter
+  label="Progress, ease, and modes"
+  scene={<ParticleDissolveCycle />}
+  code={`const eff = easeInOut(
+  Math.max(0, Math.min(1, (prog - pt.delay) / (1 - pt.delay))),
+);
+const x = pt.sx + (pt.tx - pt.sx) * eff + breathe;
+const y = pt.sy + (pt.ty - pt.sy) * eff + breathe;`}
+>
 
 Runtime state is two refs: `p` (current progress) and `goal` (desired). Every
 frame:
@@ -52,14 +63,6 @@ p.current += (goal.current - p.current) * 0.06;
 
 Per particle, effective progress is eased:
 
-```tsx
-const eff = easeInOut(
-  Math.max(0, Math.min(1, (prog - pt.delay) / (1 - pt.delay))),
-);
-const x = pt.sx + (pt.tx - pt.sx) * eff + breathe;
-const y = pt.sy + (pt.ty - pt.sy) * eff + breathe;
-```
-
 `easeInOut` is the standard smoothstep quadratic. Once `eff > 0.98`, a tiny
 `sin(time / 600 + jitter)` breath keeps the formed shape alive.
 
@@ -69,25 +72,15 @@ Modes set the goal differently:
 - **disperse** — starts formed (`p = 1`), goal → 0 on trigger
 - **loop** — flips goal every 2600ms
 
-<ParticleDissolveCycle />
-
 Drawing is `fillRect` at `particleSize` with `globalAlpha = max(0.1, eff)` —
 cheap enough for thousands of dots at 60fps when density is sane.
 
-## Three triggers
+</LearnChapter>
 
-After particles are built, `start()` runs according to `trigger`:
-
-| Trigger | Behavior |
-| --- | --- |
-| `mount` | `start()` immediately |
-| `in-view` | `IntersectionObserver` at `threshold: 0.3`, then disconnect |
-| `hover` | pointer enter/leave flips `goal` (assemble ↔ disperse semantics) |
-
-<ParticleDissolveTrigger />
-
-```tsx
-if (trigger === "in-view") {
+<LearnChapter
+  label="Three triggers"
+  scene={<ParticleDissolveTrigger />}
+  code={`if (trigger === "in-view") {
   const io = new IntersectionObserver(
     (entries) => {
       if (entries.some((e) => e.isIntersecting)) {
@@ -98,11 +91,30 @@ if (trigger === "in-view") {
     { threshold: 0.3 },
   );
   io.observe(canvas);
-}
-```
+}`}
+>
+
+After particles are built, `start()` runs according to `trigger`:
+
+| Trigger | Behavior |
+| --- | --- |
+| `mount` | `start()` immediately |
+| `in-view` | `IntersectionObserver` at `threshold: 0.3`, then disconnect |
+| `hover` | pointer enter/leave flips `goal` (assemble ↔ disperse semantics) |
 
 Hover does not use Framer Motion — it mutates `goal.current` directly so the
 existing rAF loop picks up the new destination without a React re-render.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<ParticleDissolveResult />} isResult>
+
+One offscreen sample, one progress lerp, per-particle delay and jitter —
+triggered when you choose, quiet when motion is reduced.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Reduced motion
 
@@ -124,10 +136,3 @@ leaks timers.
 ## Motion Score
 
 <MotionScorePanel name="particle-dissolve" />
-
-## The result
-
-<ParticleDissolveResult />
-
-One offscreen sample, one progress lerp, per-particle delay and jitter —
-triggered when you choose, quiet when motion is reduced.

--- a/apps/docs/content/docs/components/effects/scroll-progress/learn.mdx
+++ b/apps/docs/content/docs/components/effects/scroll-progress/learn.mdx
@@ -1,14 +1,28 @@
 ---
 title: Anatomy of Scroll Progress
 description: How useScroll feeds a spring into scaleX (or a strokeDashoffset ring), and why reduced motion just stiffens the spring.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="A pinned bar that scales, not grows"
+  scene={<ScrollProgressAnatomy />}
+  code={`const pinned = container ? "sticky" : "fixed";
+
+<motion.div
+  role="progressbar"
+  aria-label="Scroll progress"
+  style={{ scaleX: progress, height }}
+  className={\`\${pinned} inset-x-0 top-0 left-0 z-sticky origin-left bg-primary\`}
+/>`}
+>
 
 `ScrollProgress` doesn't poll scroll position on a timer. It reads
 `scrollYProgress` from Framer Motion's `useScroll`, smooths it with
 `useSpring`, and maps that single number onto either a pinned bar's
 `scaleX` or a circle's `strokeDashoffset`.
-
-## A pinned bar that scales, not grows
 
 The bar variant is a `motion.div` with `role="progressbar"`,
 `origin-left`, and `style={{ scaleX: progress, height }}`. Pinning is
@@ -16,20 +30,17 @@ The bar variant is a `motion.div` with `role="progressbar"`,
 indicator stays inside a scrollable panel. Width never changes —
 `scaleX` keeps the paint cheap.
 
-<ScrollProgressAnatomy />
+</LearnChapter>
 
-```tsx
-const pinned = container ? "sticky" : "fixed";
-
-<motion.div
-  role="progressbar"
-  aria-label="Scroll progress"
-  style={{ scaleX: progress, height }}
-  className={`${pinned} inset-x-0 top-0 left-0 z-sticky origin-left bg-primary`}
-/>
-```
-
-## useScroll → useSpring → scaleX
+<LearnChapter
+  label="useScroll → useSpring → scaleX"
+  scene={<ScrollProgressSpring />}
+  code={`const { scrollYProgress } = useScroll(/* container | target | page */);
+const progress = useSpring(
+  scrollYProgress,
+  reduceMotion ? { stiffness: 1000, damping: 100 } : SPRING,
+);`}
+>
 
 `useScroll` yields a raw `MotionValue` that jumps with every wheel tick.
 `useSpring` wraps it with `{ stiffness: 120, damping: 24, restDelta: 0.001 }`
@@ -38,29 +49,12 @@ so the bar eases toward the true progress instead of stuttering. Under
 `{ stiffness: 1000, damping: 100 }` — still a spring, just near-instant, so
 the indicator keeps tracking without a visible lag.
 
-<ScrollProgressSpring />
+</LearnChapter>
 
-```tsx
-const { scrollYProgress } = useScroll(/* container | target | page */);
-const progress = useSpring(
-  scrollYProgress,
-  reduceMotion ? { stiffness: 1000, damping: 100 } : SPRING,
-);
-```
-
-## Circle: dashoffset, threshold, back-to-top
-
-`variant="circle"` maps the same spring through
-`useTransform` into `strokeDashoffset = circumference * (1 − progress)`.
-Visibility is gated by raw (unsprung) progress against `showAfter`
-(default `0.05`); `AnimatePresence` springs the button in and out
-(`stiffness: 520`, `damping: 32`). Click finds the nearest
-`[data-scroll-container]` or falls back to `window.scrollTo`.
-
-<ScrollProgressCircle />
-
-```tsx
-const dashoffset = useTransform(
+<LearnChapter
+  label="Circle: dashoffset, threshold, back-to-top"
+  scene={<ScrollProgressCircle />}
+  code={`const dashoffset = useTransform(
   progress,
   (v) => circumference * (1 - Math.min(Math.max(v, 0), 1)),
 );
@@ -69,22 +63,31 @@ React.useEffect(() => {
   const update = (v: number) => setVisible(v > (showAfter ?? 0.05));
   update(rawProgress.get());
   return rawProgress.on("change", update);
-}, [rawProgress, showAfter]);
-```
+}, [rawProgress, showAfter]);`}
+>
 
-## Why scaleX (and dashoffset) stay cheap
+`variant="circle"` maps the same spring through
+`useTransform` into `strokeDashoffset = circumference * (1 − progress)`.
+Visibility is gated by raw (unsprung) progress against `showAfter`
+(default `0.05`); `AnimatePresence` springs the button in and out
+(`stiffness: 520`, `damping: 32`). Click finds the nearest
+`[data-scroll-container]` or falls back to `window.scrollTo`.
 
 Neither variant animates layout. The bar never changes `width`; the ring
 never redraws path geometry — only `strokeDashoffset` updates. The spring
 runs on the MotionValue pipeline, not a React re-render per frame.
 
-## Motion Score
+</LearnChapter>
 
-<MotionScorePanel name="scroll-progress" />
-
-## The result
-
-<ScrollProgressResult />
+<LearnChapter label="The result" scene={<ScrollProgressResult />} isResult>
 
 One scroll signal, one spring, two skins — a bar that scales from the left,
 and a ring that fills until you send it home.
+
+</LearnChapter>
+
+</LearnPlayer>
+
+## Motion Score
+
+<MotionScorePanel name="scroll-progress" />

--- a/apps/docs/content/docs/components/effects/scroll-reveal/learn.mdx
+++ b/apps/docs/content/docs/components/effects/scroll-reveal/learn.mdx
@@ -1,24 +1,15 @@
 ---
 title: Anatomy of Scroll Reveal
 description: How useInView flips a spring from offset+blur to settled, and how scroll velocity optionally skews the plate.
+learnPlayer: true
 ---
 
-`ScrollReveal` waits until 30% of its node is on screen, then springs from
-a directional offset (plus optional blur) to rest. Optionally, scroll
-velocity skews the plate on the Y axis for a fluid, reactive feel —
-disabled entirely under reduced motion.
+<LearnPlayer>
 
-## Direction is a unit vector
-
-`OFFSET` maps each direction to `{ x, y }` multipliers. Hidden state is
-`offset * distance` (default 40px) with `opacity: 0` and, when `blur` is
-on, `filter: blur(10px)`. Visible zeros the translate, clears the blur,
-and sets opacity to 1.
-
-<ScrollRevealAnatomy />
-
-```tsx
-const OFFSET = {
+<LearnChapter
+  label="Direction is a unit vector"
+  scene={<ScrollRevealAnatomy />}
+  code={`const OFFSET = {
   up: { x: 0, y: 1 },
   down: { x: 0, y: -1 },
   left: { x: 1, y: 0 },
@@ -32,21 +23,25 @@ const hidden = reduceMotion
       x: offset.x * distance,
       y: offset.y * distance,
       filter: blur ? "blur(10px)" : "blur(0px)",
-    };
-```
+    };`}
+>
 
-## useInView drives the spring
+`ScrollReveal` waits until 30% of its node is on screen, then springs from
+a directional offset (plus optional blur) to rest. Optionally, scroll
+velocity skews the plate on the Y axis for a fluid, reactive feel —
+disabled entirely under reduced motion.
 
-`useInView(ref, { once, amount: 0.3 })` flips `isInView`. That boolean
-selects `animate={isInView ? visible : hidden}`. The spring is
-`damping: 32`, `stiffness: 320`, `mass: 0.9`, plus an optional `delay` for
-staggering siblings. With `once` (the default), the plate never re-hides
-after the first reveal.
+`OFFSET` maps each direction to `{ x, y }` multipliers. Hidden state is
+`offset * distance` (default 40px) with `opacity: 0` and, when `blur` is
+on, `filter: blur(10px)`. Visible zeros the translate, clears the blur,
+and sets opacity to 1.
 
-<ScrollRevealSpring />
+</LearnChapter>
 
-```tsx
-const isInView = useInView(ref, { once, amount: 0.3 });
+<LearnChapter
+  label="useInView drives the spring"
+  scene={<ScrollRevealSpring />}
+  code={`const isInView = useInView(ref, { once, amount: 0.3 });
 
 <motion.div
   initial={hidden}
@@ -58,20 +53,21 @@ const isInView = useInView(ref, { once, amount: 0.3 });
     mass: 0.9,
     delay,
   }}
-/>
-```
+/>`}
+>
 
-## Velocity skew (optional)
+`useInView(ref, { once, amount: 0.3 })` flips `isInView`. That boolean
+selects `animate={isInView ? visible : hidden}`. The spring is
+`damping: 32`, `stiffness: 320`, `mass: 0.9`, plus an optional `delay` for
+staggering siblings. With `once` (the default), the plate never re-hides
+after the first reveal.
 
-When `velocitySkew` is on, `useVelocity(scrollY)` feeds the same spring
-config, then `useTransform` maps `[-2000, 0, 2000]` → `[6, 0, -6]` degrees
-of `skewY` (clamped). Fast scroll tips the plate; settling returns it to
-square. Reduced motion skips the skew entirely — only opacity animates.
+</LearnChapter>
 
-<ScrollRevealSkew />
-
-```tsx
-const scrollVelocity = useVelocity(scrollY);
+<LearnChapter
+  label="Velocity skew (optional)"
+  scene={<ScrollRevealSkew />}
+  code={`const scrollVelocity = useVelocity(scrollY);
 const smoothVelocity = useSpring(scrollVelocity, {
   damping: 32,
   stiffness: 320,
@@ -81,8 +77,24 @@ const skew = useTransform(smoothVelocity, [-2000, 0, 2000], [6, 0, -6], {
   clamp: true,
 });
 
-style={velocitySkew && !reduceMotion ? { skewY: skew, ...style } : style}
-```
+style={velocitySkew && !reduceMotion ? { skewY: skew, ...style } : style}`}
+>
+
+When `velocitySkew` is on, `useVelocity(scrollY)` feeds the same spring
+config, then `useTransform` maps `[-2000, 0, 2000]` → `[6, 0, -6]` degrees
+of `skewY` (clamped). Fast scroll tips the plate; settling returns it to
+square. Reduced motion skips the skew entirely — only opacity animates.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<ScrollRevealResult />} isResult>
+
+One intersection threshold, one spring recipe, and an optional velocity
+skew — compositor transforms from the first pixel to the last.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Reduced motion
 
@@ -93,10 +105,3 @@ instant, but the plate never slides or warps.
 ## Motion Score
 
 <MotionScorePanel name="scroll-reveal" />
-
-## The result
-
-<ScrollRevealResult />
-
-One intersection threshold, one spring recipe, and an optional velocity
-skew — compositor transforms from the first pixel to the last.

--- a/apps/docs/content/docs/components/effects/spotlight-card/learn.mdx
+++ b/apps/docs/content/docs/components/effects/spotlight-card/learn.mdx
@@ -1,57 +1,69 @@
 ---
 title: Anatomy of Spotlight Card
 description: How a radial glow tracks the pointer via CSS variables with no React state, and how the same gradient is masked down to a 1px border ring.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="Three layers, one surface"
+  scene={<SpotlightCardAnatomy />}
+  code={`const GLOW_BASE =
+  "… opacity-0 … group-hover:opacity-100 … [transition:opacity_400ms_ease] " +
+  "[background:radial-gradient(var(--spotlight-radius)_circle_at_var(--x,50%)_var(--y,50%),…)]";
+
+<div aria-hidden className={GLOW_BASE} />
+{border ? <div aria-hidden className={BORDER_BASE} /> : null}
+<div className="relative z-raised">{children}</div>`}
+>
 
 `SpotlightCard` never re-renders on pointer move. It writes `--x` / `--y`
 straight onto the root with `style.setProperty`, and two absolute layers —
 a fill glow and an optional border ring — read those vars from a shared
 radial gradient. Content sits above both at `z-raised`.
 
-## Three layers, one surface
-
 The root is a `group relative overflow-hidden` card. Inside: a
 pointer-events-none glow, an optional border twin, and a relative content
 wrapper. The glow defaults `--x`/`--y` to `50%` so the first paint isn't a
 hard corner flash.
 
-<SpotlightCardAnatomy />
+</LearnChapter>
 
-```tsx
-const GLOW_BASE =
-  "… opacity-0 … group-hover:opacity-100 … [transition:opacity_400ms_ease] " +
-  "[background:radial-gradient(var(--spotlight-radius)_circle_at_var(--x,50%)_var(--y,50%),…)]";
-
-<div aria-hidden className={GLOW_BASE} />
-{border ? <div aria-hidden className={BORDER_BASE} /> : null}
-<div className="relative z-raised">{children}</div>
-```
-
-## Follow without React state
+<LearnChapter
+  label="Follow without React state"
+  scene={<SpotlightCardFollow />}
+  code={`const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+  const el = ref.current;
+  if (el) {
+    const rect = el.getBoundingClientRect();
+    el.style.setProperty("--x", \`\${e.clientX - rect.left}px\`);
+    el.style.setProperty("--y", \`\${e.clientY - rect.top}px\`);
+  }
+  onPointerMove?.(e);
+};`}
+>
 
 On every `pointermove`, the handler measures the card rect and writes
 pixel offsets. No `useState`, no context — the compositor just repaints
 the gradient at the new center. Hover fades the glow in over `400ms ease`;
 `motion-reduce` kills the transition.
 
-<SpotlightCardFollow />
-
-```tsx
-const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
-  const el = ref.current;
-  if (el) {
-    const rect = el.getBoundingClientRect();
-    el.style.setProperty("--x", `${e.clientX - rect.left}px`);
-    el.style.setProperty("--y", `${e.clientY - rect.top}px`);
-  }
-  onPointerMove?.(e);
-};
-```
-
 `glowColor` and `radius` land as `--spotlight-color` / `--spotlight-radius`
 on the root style, so the same class string works for any tint or size.
 
-## The border is the glow, masked to 1px
+</LearnChapter>
+
+<LearnChapter
+  label="The border is the glow, masked to 1px"
+  scene={<SpotlightCardBorder />}
+  code={`const BORDER_BASE =
+  "… [background:radial-gradient(…_at_var(--x,50%)_var(--y,50%),…)] " +
+  "[-webkit-mask:linear-gradient(#fff_0_0)_content-box,linear-gradient(#fff_0_0)] " +
+  "[-webkit-mask-composite:xor] " +
+  "[mask:linear-gradient(#fff_0_0)_content-box,linear-gradient(#fff_0_0)] " +
+  "[mask-composite:exclude] p-px";`}
+>
 
 When `border` is true (the default), a second layer reuses the identical
 radial gradient, then punches out the interior with a dual-layer mask and
@@ -59,27 +71,25 @@ radial gradient, then punches out the interior with a dual-layer mask and
 leaves only the 1px ring lit — so the edge brightens where the pointer is
 closest without a separate stroke color.
 
-<SpotlightCardBorder />
-
-```tsx
-const BORDER_BASE =
-  "… [background:radial-gradient(…_at_var(--x,50%)_var(--y,50%),…)] " +
-  "[-webkit-mask:linear-gradient(#fff_0_0)_content-box,linear-gradient(#fff_0_0)] " +
-  "[-webkit-mask-composite:xor] " +
-  "[mask:linear-gradient(#fff_0_0)_content-box,linear-gradient(#fff_0_0)] " +
-  "[mask-composite:exclude] p-px";
-```
-
 Pass `border={false}` and the ring layer is omitted entirely — fill glow
 only.
-
-## Why setProperty wins here
 
 Driving `--x`/`--y` through React state would re-render the whole card
 (and its children) on every pointer frame. Writing CSS variables on the
 DOM node keeps React out of the hot path: the glow and border are pure
 paint, content never reconciles, and the hover opacity transition stays a
 CSS animation.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<SpotlightCardResult />} isResult>
+
+Two CSS variables, one radial, an optional masked ring, and content that
+never re-renders for the pointer. Move across either card.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Reduced motion
 
@@ -90,10 +100,3 @@ the 400ms fade snaps instead of easing.
 ## Motion Score
 
 <MotionScorePanel name="spotlight-card" />
-
-## The result
-
-Two CSS variables, one radial, an optional masked ring, and content that
-never re-renders for the pointer. Move across either card.
-
-<SpotlightCardResult />

--- a/apps/docs/content/docs/components/effects/spotlight-reveal/learn.mdx
+++ b/apps/docs/content/docs/components/effects/spotlight-reveal/learn.mdx
@@ -1,23 +1,15 @@
 ---
 title: Anatomy of Spotlight Reveal
 description: How an inverted radial mask punches a hole through a cover layer, eased toward the pointer on a single rAF loop — with idle breathing and click-to-pin.
+learnPlayer: true
 ---
 
-`SpotlightReveal` stacks two full-bleed layers. The `reveal` prop sits
-underneath; `children` is the cover. An inverted radial mask on the cover
-makes a soft hole that follows the pointer — exposing whatever's beneath
-without unmounting either layer.
+<LearnPlayer>
 
-## Reveal under, cover on top
-
-Both layers are `absolute inset-0`. The cover owns the mask; the reveal
-is always painted and simply shows through the hole. Clicking the root
-toggles a `pinned` ref so the spotlight can freeze in place.
-
-<SpotlightRevealAnatomy />
-
-```tsx
-<div className="absolute inset-0">{reveal}</div>
+<LearnChapter
+  label="Reveal under, cover on top"
+  scene={<SpotlightRevealAnatomy />}
+  code={`<div className="absolute inset-0">{reveal}</div>
 
 <div
   ref={coverRef}
@@ -29,26 +21,44 @@ toggles a `pinned` ref so the spotlight can freeze in place.
   }
 >
   {children}
-</div>
-```
+</div>`}
+>
 
-## Softness is the hard edge
+`SpotlightReveal` stacks two full-bleed layers. The `reveal` prop sits
+underneath; `children` is the cover. An inverted radial mask on the cover
+makes a soft hole that follows the pointer — exposing whatever's beneath
+without unmounting either layer.
+
+Both layers are `absolute inset-0`. The cover owns the mask; the reveal
+is always painted and simply shows through the hole. Clicking the root
+toggles a `pinned` ref so the spotlight can freeze in place.
+
+</LearnChapter>
+
+<LearnChapter
+  label="Softness is the hard edge"
+  scene={<SpotlightRevealMask />}
+  code={`const inner = Math.max(0, radius * (1 - softness));
+const maskImage =
+  \`radial-gradient(circle \${radius}px at var(--x, 50%) var(--y, 50%), \` +
+  \`transparent 0, transparent \${inner}px, #000 \${radius}px)\`;`}
+>
 
 `softness` (0–1, default `0.55`) sets how wide the feather is.
 `inner = radius * (1 - softness)` is the fully transparent core; from
 there the mask ramps to opaque at `radius`. Hard edges keep the hole
 crisp; soft ones feel like a flashlight bloom.
 
-<SpotlightRevealMask />
+</LearnChapter>
 
-```tsx
-const inner = Math.max(0, radius * (1 - softness));
-const maskImage =
-  `radial-gradient(circle ${radius}px at var(--x, 50%) var(--y, 50%), ` +
-  `transparent 0, transparent ${inner}px, #000 ${radius}px)`;
-```
-
-## Eased follow, idle breathing, pin
+<LearnChapter
+  label="Eased follow, idle breathing, pin"
+  scene={<SpotlightRevealFollow />}
+  code={`cur.current.x += (target.current.x - cur.current.x) * ease;
+cur.current.y += (target.current.y - cur.current.y) * ease;
+cover.style.setProperty("--x", \`\${cur.current.x}px\`);
+cover.style.setProperty("--y", \`\${cur.current.y}px\`);`}
+>
 
 A single `requestAnimationFrame` loop owns motion. Each frame:
 
@@ -61,14 +71,16 @@ Pointer enter/move updates `target` (unless pinned). Click flips
 `pinned`. No React state for position — same cheap path as
 `SpotlightCard`, plus the lag that makes the light feel liquid.
 
-<SpotlightRevealFollow />
+</LearnChapter>
 
-```tsx
-cur.current.x += (target.current.x - cur.current.x) * ease;
-cur.current.y += (target.current.y - cur.current.y) * ease;
-cover.style.setProperty("--x", `${cur.current.x}px`);
-cover.style.setProperty("--y", `${cur.current.y}px`);
-```
+<LearnChapter label="The result" scene={<SpotlightRevealResult />} isResult>
+
+Two layers, one inverted mask, a 0.16 ease, and an idle ellipse that
+invites the hover. Move to follow; click to pin.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Reduced motion
 
@@ -87,10 +99,3 @@ style={
 ## Motion Score
 
 <MotionScorePanel name="spotlight-reveal" />
-
-## The result
-
-Two layers, one inverted mask, a 0.16 ease, and an idle ellipse that
-invites the hover. Move to follow; click to pin.
-
-<SpotlightRevealResult />

--- a/apps/docs/content/docs/components/effects/terminal/learn.mdx
+++ b/apps/docs/content/docs/components/effects/terminal/learn.mdx
@@ -1,25 +1,15 @@
 ---
 title: Anatomy of Terminal
 description: How a count/typed state machine types commands character-by-character, gates playback with IntersectionObserver, and loops after a two-second pause.
+learnPlayer: true
 ---
 
-`Terminal` is a small state machine dressed as a window. Commands type
-out one character at a time; output and comment lines appear after a
-beat. An optional chrome bar with traffic lights frames the mono body,
-and a pulsing caret marks the active line.
+<LearnPlayer>
 
-## Chrome, body, line roles
-
-`showChrome` (default true) renders the header — three dots, optional
-centered `title`, and a balancing spacer. The body is
-`font-mono text-[13px]` with ligatures off so glyphs don't shift as they
-type. Each line is `command`, `output`, or `comment`, each with its own
-foreground opacity.
-
-<TerminalAnatomy />
-
-```tsx
-{showChrome ? (
+<LearnChapter
+  label="Chrome, body, line roles"
+  scene={<TerminalAnatomy />}
+  code={`{showChrome ? (
   <div className={HEADER_BASE}>
     <div className="flex gap-1.5" aria-hidden>
       <span className="size-3 rounded-full bg-red-500/80" />
@@ -28,21 +18,26 @@ foreground opacity.
     </div>
     {title ? <span className="…">{title}</span> : null}
   </div>
-) : null}
-```
+) : null}`}
+>
 
-## The typing state machine
+`Terminal` is a small state machine dressed as a window. Commands type
+out one character at a time; output and comment lines appear after a
+beat. An optional chrome bar with traffic lights frames the mono body,
+and a pulsing caret marks the active line.
 
-Two pieces of state drive the script: `count` (fully finished lines) and
-`typed` (characters revealed on the current command). While
-`typed < line.text.length` on a command, a timeout bumps `typed` every
-`typingSpeed` ms (default `38`). Then a pause (`320` after a command,
-`line.delay ?? 380` otherwise) advances `count` and resets `typed`.
+`showChrome` (default true) renders the header — three dots, optional
+centered `title`, and a balancing spacer. The body is
+`font-mono text-[13px]` with ligatures off so glyphs don't shift as they
+type. Each line is `command`, `output`, or `comment`, each with its own
+foreground opacity.
 
-<TerminalTyping />
+</LearnChapter>
 
-```tsx
-if (isCommand && typed < line.text.length) {
+<LearnChapter
+  label="The typing state machine"
+  scene={<TerminalTyping />}
+  code={`if (isCommand && typed < line.text.length) {
   const id = window.setTimeout(() => setTyped((t) => t + 1), typingSpeed);
   return () => window.clearTimeout(id);
 }
@@ -51,26 +46,25 @@ const pause = isCommand ? 320 : (line.delay ?? 380);
 const id = window.setTimeout(() => {
   setCount((c) => c + 1);
   setTyped(0);
-}, pause);
-```
+}, pause);`}
+>
+
+Two pieces of state drive the script: `count` (fully finished lines) and
+`typed` (characters revealed on the current command). While
+`typed < line.text.length` on a command, a timeout bumps `typed` every
+`typingSpeed` ms (default `38`). Then a pause (`320` after a command,
+`line.delay ?? 380` otherwise) advances `count` and resets `typed`.
 
 The caret is a primary-colored block with `animate-pulse`, shown on the
 active command — or on the last line when the script is done and
 `loop` is false.
 
-## Start on view, loop, reduce
+</LearnChapter>
 
-Playback stays cold until the terminal crosses an
-`IntersectionObserver` at `threshold: 0.35` (when `startOnView` is
-true). Once active, finishing the script with `loop` waits **2s**, then
-resets `count` and `typed` to zero. Under `prefers-reduced-motion`, the
-machine skips typing entirely and dumps `lines.length` in one shot —
-caret off, full transcript still in `sr-only` for assistive tech.
-
-<TerminalLifecycle />
-
-```tsx
-const io = new IntersectionObserver(
+<LearnChapter
+  label="Start on view, loop, reduce"
+  scene={<TerminalLifecycle />}
+  code={`const io = new IntersectionObserver(
   (entries) => {
     if (entries.some((e) => e.isIntersecting)) {
       setActive(true);
@@ -90,8 +84,26 @@ window.setTimeout(() => {
 if (reduced && active) {
   setCount(lines.length);
   setTyped(0);
-}
-```
+}`}
+>
+
+Playback stays cold until the terminal crosses an
+`IntersectionObserver` at `threshold: 0.35` (when `startOnView` is
+true). Once active, finishing the script with `loop` waits **2s**, then
+resets `count` and `typed` to zero. Under `prefers-reduced-motion`, the
+machine skips typing entirely and dumps `lines.length` in one shot —
+caret off, full transcript still in `sr-only` for assistive tech.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<TerminalResult />} isResult>
+
+A count/typed machine, a 0.35 IO gate, a 2s loop pause, and a caret that
+only blinks when motion is welcome.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility
 
@@ -102,10 +114,3 @@ the rest — so screen readers never wait on the typewriter.
 ## Motion Score
 
 <MotionScorePanel name="terminal" />
-
-## The result
-
-A count/typed machine, a 0.35 IO gate, a 2s loop pause, and a caret that
-only blinks when motion is welcome.
-
-<TerminalResult />

--- a/apps/docs/content/docs/components/glass/liquid-glass-card/learn.mdx
+++ b/apps/docs/content/docs/components/glass/liquid-glass-card/learn.mdx
@@ -1,15 +1,25 @@
 ---
 title: Anatomy of the Liquid Glass Card
 description: How a rim-banded displacement map, a chromatic triple-displace filter, and a pointer sheen turn backdrop-filter into living glass — with a clean frost fallback when url() is unsupported.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="Frost, sheen, rim — three layers"
+  scene={<LiquidGlassCardAnatomy />}
+  code={`backdropFilter: active
+  ? \`blur(\${blur}px) saturate(\${saturation}) url(#\${filterId})\`
+  : \`blur(\${blur}px) saturate(\${saturation})\`;
+// WebkitBackdropFilter stays blur+saturate only — Safari can't take url()`}
+>
 
 `LiquidGlassCard` is not a PNG overlay or a static blur. It samples the
 **live DOM** behind the panel through `backdrop-filter`, bends that sample
 with an SVG displacement map sized to the card, and fringes color at the rim
 by running the bend at three scales. Children stay crisp above the glass in
 `relative z-raised`.
-
-## Frost, sheen, rim — three layers
 
 Three absolute layers share the same rounded box:
 
@@ -19,19 +29,10 @@ Three absolute layers share the same rounded box:
 | Sheen | `mix-blend-screen` radial that tracks the pointer |
 | Rim | static inset highlight / shadow for a wet edge |
 
-```tsx
-backdropFilter: active
-  ? `blur(${blur}px) saturate(${saturation}) url(#${filterId})`
-  : `blur(${blur}px) saturate(${saturation})`;
-// WebkitBackdropFilter stays blur+saturate only — Safari can't take url()
-```
-
 Defaults: `radius={28}`, `blur={2}`, `strength={60}`, `dispersion={0.15}`,
 `saturation={1.6}`, `sheen={0.5}`.
 
-<LiquidGlassCardAnatomy />
-
-## The map bends the rim, not the center
+**The map bends the rim, not the center**
 
 `buildDisplacementMap(w, h, band)` paints a data-URL SVG. Under the hood, red
 encodes horizontal shift and green vertical; mid-gray `128`
@@ -54,7 +55,18 @@ reflows.
 const map = buildDisplacementMap(size.width, size.height, 0.3);
 ```
 
-## Chromatic triple displace
+</LearnChapter>
+
+<LearnChapter
+  label="Chromatic triple displace"
+  scene={<LiquidGlassCardDispersion />}
+  code={`<feImage href={map} result="map" preserveAspectRatio="none" />
+<feDisplacementMap scale={strength * (1 + dispersion)} result="dispR" />
+<feColorMatrix in="dispR" values={RED_CHANNEL} result="red" />
+{/* green @ strength, blue @ strength * (1 - dispersion) */}
+<feBlend in="red" in2="green" mode="screen" result="rg" />
+<feBlend in="rg" in2="blue" mode="screen" />`}
+>
 
 `RefractionFilter` runs `feDisplacementMap` three times against the same map,
 isolates R / G / B with `feColorMatrix`, then recombines with
@@ -68,35 +80,26 @@ mechanism is the scale difference, not a rainbow UI.
 | Green | `strength` |
 | Blue | `strength * (1 - dispersion)` |
 
-```tsx
-<feImage href={map} result="map" preserveAspectRatio="none" />
-<feDisplacementMap scale={strength * (1 + dispersion)} result="dispR" />
-<feColorMatrix in="dispR" values={RED_CHANNEL} result="red" />
-{/* green @ strength, blue @ strength * (1 - dispersion) */}
-<feBlend in="red" in2="green" mode="screen" result="rg" />
-<feBlend in="rg" in2="blue" mode="screen" />
-```
-
-<LiquidGlassCardDispersion />
-
 Push `strength` / `dispersion` up for a heavier prismatic edge; drop them for
 subtle frost.
 
-## Pointer sheen
+</LearnChapter>
 
-On `pointermove`, the card writes CSS variables as **percentages** of its own
-box (not pixels):
-
-```tsx
-node.style.setProperty(
+<LearnChapter
+  label="Pointer sheen"
+  scene={<LiquidGlassCardSheen />}
+  code={`node.style.setProperty(
   "--lg-x",
-  `${((e.clientX - rect.left) / rect.width) * 100}%`,
+  \`\${((e.clientX - rect.left) / rect.width) * 100}%\`,
 );
 node.style.setProperty(
   "--lg-y",
-  `${((e.clientY - rect.top) / rect.height) * 100}%`,
-);
-```
+  \`\${((e.clientY - rect.top) / rect.height) * 100}%\`,
+);`}
+>
+
+On `pointermove`, the card writes CSS variables as **percentages** of its own
+box (not pixels):
 
 The sheen layer paints
 `radial-gradient(circle at var(--lg-x) var(--lg-y), …)` and toggles opacity
@@ -105,9 +108,7 @@ on enter / leave with `transition-opacity duration-200`.
 Under `prefers-reduced-motion`, pointer updates are **skipped** and the sheen
 layer is `motion-reduce:hidden` — frost stays, specular dies.
 
-<LiquidGlassCardSheen />
-
-## Chrome-only `url()`, clean fallback
+**Chrome-only `url()`, clean fallback**
 
 Live-DOM refraction needs `backdrop-filter: url(#id)` — Chrome and Edge
 today. `useRefractionSupport` probes once:
@@ -121,15 +122,19 @@ Safari and Firefox still get a believable glass panel; they never render as a
 broken transparent box. Decorative layers and the filter SVG are
 `aria-hidden`.
 
-## Motion Score
+</LearnChapter>
 
-<MotionScorePanel name="liquid-glass-card" />
-
-## The result
+<LearnChapter label="The result" scene={<LiquidGlassCardResult />} isResult>
 
 Move across the panel. Watch the rim fringe and the specular follow.
 
-<LiquidGlassCardResult />
-
 One map, three displaces, one CSS sheen — and a frost fallback when the GPU
 path is unavailable.
+
+</LearnChapter>
+
+</LearnPlayer>
+
+## Motion Score
+
+<MotionScorePanel name="liquid-glass-card" />

--- a/apps/docs/content/docs/components/glass/liquid-glass-lens/learn.mdx
+++ b/apps/docs/content/docs/components/glass/liquid-glass-lens/learn.mdx
@@ -1,7 +1,21 @@
 ---
 title: Anatomy of the Liquid Glass Lens
 description: How a parent-owned pointer, a band=0 displacement map, and a fixed sphere glint turn the same refraction stack into a floating magnifier that never steals clicks.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="Disc, fixed glint, full map"
+  scene={<LiquidGlassLensAnatomy />}
+  code={`backgroundImage: \`radial-gradient(
+  circle at 32% 28%,
+  rgba(255,255,255,\${0.7 * sheen}) 0%,
+  rgba(255,255,255,0) 55%
+)\`
+boxShadow: \`inset 0 2px 2px …, inset 0 -6px 12px …\``}
+>
 
 `LiquidGlassLens` shares `RefractionFilter` and `buildDisplacementMap` with
 the card — but the **geometry**, **pointer contract**, and **reduced-motion
@@ -12,21 +26,10 @@ cursor over a positioned parent, and it disappears entirely under
 Think of the card as a frosted pane on your UI; the lens is a loupe you drag
 across it.
 
-## Disc, fixed glint, full map
-
 The root is `rounded-full` with frost via `backdrop-filter`. Unlike the
 card's pointer-tracked sheen, the specular is a **fixed** radial at
 `32% 28%` — a sphere highlight that stays put relative to the disc, plus an
 inset depth shadow:
-
-```tsx
-backgroundImage: `radial-gradient(
-  circle at 32% 28%,
-  rgba(255,255,255,${0.7 * sheen}) 0%,
-  rgba(255,255,255,0) 55%
-)`
-boxShadow: `inset 0 2px 2px …, inset 0 -6px 12px …`
-```
 
 The displacement map uses `band={0}`: a continuous ramp from edge to edge,
 so the bend feels like a solid converging lens rather than a flat pane with
@@ -40,19 +43,19 @@ Defaults push harder than the card (`strength={80}` vs `60`, `size={160}`)
 because a smaller circular optic needs more bend to read. Storybook demos
 often use `size={220}`.
 
-<LiquidGlassLensAnatomy />
+</LearnChapter>
 
-## Parent owns the pointer
+<LearnChapter
+  label="Parent owns the pointer"
+  scene={<LiquidGlassLensParent />}
+  code={`node.style.setProperty("--lg-px", \`\${e.clientX - rect.left}px\`);
+node.style.setProperty("--lg-py", \`\${e.clientY - rect.top}px\`);`}
+>
 
 Listeners attach to `rootRef.current.parentElement`, **not** the lens. The
 parent must be `relative`; the lens never blocks clicks
 (`pointer-events-none`). On move it writes **pixel** offsets relative to the
 parent box — different units from the card's percentages:
-
-```tsx
-node.style.setProperty("--lg-px", `${e.clientX - rect.left}px`);
-node.style.setProperty("--lg-py", `${e.clientY - rect.top}px`);
-```
 
 Centering is a transform that subtracts half the lens size:
 
@@ -65,8 +68,6 @@ className="… [will-change:transform] z-popover …"
 Opacity fades with `duration-200` while `hovering` is true (enter / leave on
 the parent).
 
-<LiquidGlassLensParent />
-
 ```tsx
 parent.addEventListener("pointermove", move);
 parent.addEventListener("pointerenter", enter);
@@ -74,7 +75,9 @@ parent.addEventListener("pointerleave", leave);
 // cleanup removes all three
 ```
 
-## Rim band vs lens band
+</LearnChapter>
+
+<LearnChapter label="Rim band vs lens band" scene={<LiquidGlassLensMap />}>
 
 Same builder, different `band`. This is the entire optical difference in one
 number. Diagrams use a grayscale ramp (dashed mid = no shift) — the real SVG
@@ -90,7 +93,19 @@ token-neutral:
 | Pointer vars | `--lg-x/y` as `%` | `--lg-px/py` as `px` |
 | Reduced motion | hide sheen, keep frost | hide **entire** lens |
 
-<LiquidGlassLensMap />
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<LiquidGlassLensResult />} isResult>
+
+Hover the stage. The lens tracks without stealing clicks from the content
+beneath.
+
+Same refraction chain as the card — different map, different owner of the
+pointer, different contract with reduced motion.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility
 
@@ -106,13 +121,3 @@ Same `useRefractionSupport` probe as the card — without
 ## Motion Score
 
 <MotionScorePanel name="liquid-glass-lens" />
-
-## The result
-
-Hover the stage. The lens tracks without stealing clicks from the content
-beneath.
-
-<LiquidGlassLensResult />
-
-Same refraction chain as the card — different map, different owner of the
-pointer, different contract with reduced motion.

--- a/apps/docs/content/docs/components/inputs/magic-input/learn.mdx
+++ b/apps/docs/content/docs/components/inputs/magic-input/learn.mdx
@@ -1,7 +1,20 @@
 ---
 title: Anatomy of the Magic Input
 description: How a flat text field lifts into a 3D card on focus, runs a rainbow edge, and turns its own depth layer into a submit progress bar — all on transform and opacity.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="The three-layer stack"
+  scene={<MagicInputAnatomy />}
+  code={`<div className="group relative inline-block rounded-xl">
+  <span className={shadowClass} aria-hidden="true" />
+  <span className={edgeClass} aria-hidden="true" />
+  <input className={frontClass} {...props} />
+</div>`}
+>
 
 Most inputs draw a border and change its color on focus. Magic Input does
 something physical instead: the field lifts off the page, casts a shadow, and
@@ -9,54 +22,40 @@ reveals a colored edge underneath — then reuses that same edge as a progress
 bar when you submit. None of it touches layout. It's three stacked layers and a
 handful of `transform` / `opacity` transitions.
 
-## The three-layer stack
-
 The component renders one `group` wrapper containing three absolutely-positioned
 layers pinned to the same bounds: a blurred **shadow**, a colored **edge**, and
 the real `<input>` on top. At rest the shadow and edge are hidden; the field
 looks flat.
 
-<MagicInputAnatomy />
-
-```tsx
-<div className="group relative inline-block rounded-xl">
-  <span className={shadowClass} aria-hidden="true" />
-  <span className={edgeClass} aria-hidden="true" />
-  <input className={frontClass} {...props} />
-</div>
-```
-
 Because all three share `inset-0`, they stack perfectly. The 3D illusion is
 entirely a matter of how far apart they sit on the Y axis — which is what the
 lift animates.
 
-## The lift
+</LearnChapter>
 
-Focus lives on `group-focus-within`, so tabbing into the `<input>` drives every
-layer at once. The front translates up, the shadow drops down + fades in +
-blurs, and the edge fades in. That divergence — front going one way, shadow the
-other — is what sells the depth.
-
-<MagicInputLift />
-
-```tsx
-// front: springy overshoot into the lifted position
+<LearnChapter
+  label="The lift"
+  scene={<MagicInputLift />}
+  code={`// front: springy overshoot into the lifted position
 "group-focus-within:-translate-y-[4px] " +
   "group-focus-within:[transition:translate_250ms_cubic-bezier(0.3,0.7,0.4,1.5)]";
 
 // shadow: opacity 0 → 1, translate-y 0 → 4px, on a slower settle
 "opacity-0 translate-y-0 group-focus-within:opacity-100 " +
   "group-focus-within:translate-y-[4px] " +
-  "[transition:translate_600ms_cubic-bezier(0.3,0.7,0.4,1),opacity_250ms_ease]";
-```
+  "[transition:translate_600ms_cubic-bezier(0.3,0.7,0.4,1),opacity_250ms_ease]";`}
+>
+
+Focus lives on `group-focus-within`, so tabbing into the `<input>` drives every
+layer at once. The front translates up, the shadow drops down + fades in +
+blurs, and the edge fades in. That divergence — front going one way, shadow the
+other — is what sells the depth.
 
 The front uses an overshoot bezier (`…,1.5`) so it springs slightly past its
 target and settles — the "pop" you feel on focus. The shadow rides a calmer
 `…,1` curve over `600ms`, because a shadow that snapped would read as a glitch
 rather than a cast. `depth="always"` simply moves the resting position to the
 lifted one, so the field is raised before you ever focus it.
-
-## Everything is transform and opacity
 
 There's no `box-shadow` transition, no `width` or `top` animation, no
 `clip-path`. The shadow is a solid blurred span whose `translate` and `opacity`
@@ -75,43 +74,36 @@ const frontClass =
 hitch, and `motion-reduce:[transition:none]` drops the whole thing to an instant
 state change for anyone who asks for reduced motion.
 
-## The rainbow edge
+</LearnChapter>
+
+<LearnChapter
+  label="The rainbow edge"
+  scene={<MagicInputRainbow />}
+  code={`const RAINBOW_FOCUS_FILL =
+  "group-focus-within:[background-image:linear-gradient(90deg," +
+  "var(--rainbow-1),var(--rainbow-5),var(--rainbow-3)," +
+  "var(--rainbow-4),var(--rainbow-2))] " +
+  "group-focus-within:[background-size:200%_100%] " +
+  "group-focus-within:animate-magic-rainbow " +
+  "motion-reduce:group-focus-within:animate-none";`}
+>
 
 With `rainbow` (the default), focus swaps the edge **and** shadow fill for a
 single `200%`-wide linear gradient, and `animate-magic-rainbow` slides
 `background-position` across it. The front stays neutral, so the color reads as a
 glowing edge peeking out from under a plain field — not a tinted input.
 
-<MagicInputRainbow />
-
-```tsx
-const RAINBOW_FOCUS_FILL =
-  "group-focus-within:[background-image:linear-gradient(90deg," +
-  "var(--rainbow-1),var(--rainbow-5),var(--rainbow-3)," +
-  "var(--rainbow-4),var(--rainbow-2))] " +
-  "group-focus-within:[background-size:200%_100%] " +
-  "group-focus-within:animate-magic-rainbow " +
-  "motion-reduce:group-focus-within:animate-none";
-```
-
 The gradient is a full literal, not an interpolated string, because Tailwind's
 class scanner can't resolve a `${var}` nested inside an arbitrary value — so the
 colors are written out. Only `background-position` animates; the gradient itself
 never re-renders.
 
-## The submit lifecycle
+</LearnChapter>
 
-Pass `onSubmit` (or `submitButton`) and the field grows a submit button. Drive
-`status` and it runs a lifecycle: `loading` → `success` / `error`. The elegant
-part is that the **same edge/shadow layer that draws the depth becomes the
-progress bar** — its `background-size` grows for determinate progress, or a
-segment bounces end to end for indeterminate — while the button's icon
-cross-fades arrow → ring → check.
-
-<MagicInputLifecycle />
-
-```tsx
-const statusFill =
+<LearnChapter
+  label="The submit lifecycle"
+  scene={<MagicInputLifecycle />}
+  code={`const statusFill =
   isLoading && isDeterminate
     ? "[background-position:right_center] " +
       "[background-size:var(--magic-progress,0%)_100%]"
@@ -119,8 +111,15 @@ const statusFill =
       ? "[background-image:linear-gradient(90deg,transparent," +
         "var(--magic-fill),transparent)] " +
         "[background-size:45%_100%] animate-magic-input-indeterminate"
-      : "[background-color:var(--primary)] animate-magic-input-sweep";
-```
+      : "[background-color:var(--primary)] animate-magic-input-sweep";`}
+>
+
+Pass `onSubmit` (or `submitButton`) and the field grows a submit button. Drive
+`status` and it runs a lifecycle: `loading` → `success` / `error`. The elegant
+part is that the **same edge/shadow layer that draws the depth becomes the
+progress bar** — its `background-size` grows for determinate progress, or a
+segment bounces end to end for indeterminate — while the button's icon
+cross-fades arrow → ring → check.
 
 The four submit icons — arrow, ring/spinner, check, X — are all stacked in the
 same box; only the active one is `opacity-100 scale(1)`, the rest sit at
@@ -133,6 +132,18 @@ const iconClass = (active: boolean) =>
     ? "… opacity-100 [transform:scale(1)_rotate(0deg)]"
     : "… opacity-0 [transform:scale(0.4)_rotate(-35deg)]";
 ```
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<MagicInputResult />} isResult>
+
+Three stacked layers, a focus-driven lift, and a progress bar that's really just
+the depth layer wearing a different fill — the whole component is `transform`
+and `opacity` doing the work that borders and box-shadows usually fake.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Locked, not disabled
 
@@ -154,11 +165,3 @@ users get an outline without mouse clicks painting one.
 ## Motion Score
 
 <MotionScorePanel name="magic-input" />
-
-## The result
-
-<MagicInputResult />
-
-Three stacked layers, a focus-driven lift, and a progress bar that's really just
-the depth layer wearing a different fill — the whole component is `transform`
-and `opacity` doing the work that borders and box-shadows usually fake.

--- a/apps/docs/content/docs/components/inputs/otp-input/learn.mdx
+++ b/apps/docs/content/docs/components/inputs/otp-input/learn.mdx
@@ -1,23 +1,15 @@
 ---
 title: Anatomy of the OTP Input
 description: How a segmented code field is really one hidden input behind display-only cells — with a traveling caret, free paste-to-fill, and a single-keyframe error shake.
+learnPlayer: true
 ---
 
-A six-box verification code looks like six inputs. Building it that way is a
-trap: you end up hand-syncing focus across six refs, forwarding backspace, and
-fighting the browser's paste and autofill. OTP Input does the opposite — there's
-exactly **one** real input, and the boxes are just paint.
+<LearnPlayer>
 
-## One input, many cells
-
-The row renders `length` display cells plus a single `<input>` sized to zero and
-made transparent, layered over the top. Every keystroke, paste, and autofill
-lands on that one field; the cells read straight off its value.
-
-<OtpAnatomy />
-
-```tsx
-<motion.div onClick={() => inputRef.current?.focus()}>
+<LearnChapter
+  label="One input, many cells"
+  scene={<OtpAnatomy />}
+  code={`<motion.div onClick={() => inputRef.current?.focus()}>
   {Array.from({ length }).map((_, i) => {
     const char = value[i];
     return <div key={i}>{/* display cell for value[i] */}</div>;
@@ -29,27 +21,36 @@ lands on that one field; the cells read straight off its value.
     autoComplete="one-time-code"
     className="absolute size-0 opacity-0"
   />
-</motion.div>
-```
+</motion.div>`}
+>
+
+A six-box verification code looks like six inputs. Building it that way is a
+trap: you end up hand-syncing focus across six refs, forwarding backspace, and
+fighting the browser's paste and autofill. OTP Input does the opposite — there's
+exactly **one** real input, and the boxes are just paint.
+
+The row renders `length` display cells plus a single `<input>` sized to zero and
+made transparent, layered over the top. Every keystroke, paste, and autofill
+lands on that one field; the cells read straight off its value.
 
 Because the real field is a normal text input, the platform gives you paste,
 SMS autofill (`autocomplete="one-time-code"`), and IME support for free — no
 per-cell wiring. Clicking anywhere in the row just calls
 `inputRef.current?.focus()`.
 
-## The traveling caret
+</LearnChapter>
+
+<LearnChapter
+  label="The traveling caret"
+  scene={<OtpCaret />}
+  code={`const activeIndex = Math.min(value.length, length - 1);`}
+>
 
 There's no per-cell focus to manage, so "which cell is active" is pure math:
-
-```tsx
-const activeIndex = Math.min(value.length, length - 1);
-```
 
 The next character always lands at `value.length`, clamped to the last cell when
 the code is full. A single highlight — scaled up, outlined, with a blinking caret
 bar — follows that index as the value grows.
-
-<OtpCaret />
 
 ```tsx
 const isActive = focused && i === activeIndex && !disabled;
@@ -60,8 +61,6 @@ className={`${CELL_BASE} ${borderState} ${isActive ? "scale-105" : ""}`}
 Each filled character fades and rises into place (`opacity: 0 → 1`, `y: 4 → 0`
 over `0.15s`); the active-but-empty cell shows an `animate-pulse` bar standing in
 for a text caret. `mask` swaps the character for a solid dot for sensitive codes.
-
-## Paste and auto-advance for free
 
 Typing and pasting go through the exact same path, because both are just the
 input's value changing. `sanitize` strips disallowed characters and slices to
@@ -85,31 +84,29 @@ const commit = (next) => {
 sixth keystroke or a single paste. There's no "advance to the next box" logic to
 write, because there's only ever one box receiving input.
 
-## The error shake
+</LearnChapter>
 
-`status="error"` runs one framer keyframe on the whole row: a quick left-right
-shake that reads as "no, try again" without a word of copy. `success` does the
-inverse — it settles, borders to `primary`, and stays still.
-
-<OtpShake />
-
-```tsx
-React.useEffect(() => {
+<LearnChapter
+  label="The error shake"
+  scene={<OtpShake />}
+  code={`React.useEffect(() => {
   if (status === "error" && !reduceMotion) {
     controls.start({
       x: [0, -6, 6, -4, 4, 0],
       transition: { duration: 0.4, ease: "easeInOut" },
     });
   }
-}, [status, reduceMotion, controls]);
-```
+}, [status, reduceMotion, controls]);`}
+>
+
+`status="error"` runs one framer keyframe on the whole row: a quick left-right
+shake that reads as "no, try again" without a word of copy. `success` does the
+inverse — it settles, borders to `primary`, and stays still.
 
 The shake is fired from an effect keyed on `status`, so consumers re-arm it by
 flipping back to `idle` and then to `error` again — the same failed code can
 shake twice. `useReducedMotion` gates it entirely: reduced-motion users get the
 destructive border color and no movement.
-
-## Controlled or uncontrolled, one value
 
 Whether you pass `value` or let it manage its own, everything downstream reads a
 single sanitized string — so the cells, the active index, and completion can
@@ -127,14 +124,18 @@ Sanitizing on the way *out* (not just on change) means even a controlled value
 with stray characters or an over-long string renders correctly — the display can
 only ever show valid, length-bounded input.
 
-## Motion Score
+</LearnChapter>
 
-<MotionScorePanel name="otp-input" />
-
-## The result
-
-<OtpResult />
+<LearnChapter label="The result" scene={<OtpResult />} isResult>
 
 One hidden input, `length` display cells, and `min(value.length, length − 1)` to
 place the caret — that's the whole component. Paste, autofill, and backspace come
 from the platform; all the code adds is the look and a shake.
+
+</LearnChapter>
+
+</LearnPlayer>
+
+## Motion Score
+
+<MotionScorePanel name="otp-input" />

--- a/apps/docs/content/docs/components/layout/accordion/learn.mdx
+++ b/apps/docs/content/docs/components/layout/accordion/learn.mdx
@@ -1,23 +1,15 @@
 ---
 title: Anatomy of the Accordion
 description: How a spring-driven height animation and a flat CSS rotate can share one click without ever touching each other's timing.
+learnPlayer: true
 ---
 
-An accordion looks like a single animation — click, and the panel opens.
-It's actually two unrelated timing systems firing off the same state change:
-Framer Motion drives the panel, plain CSS drives the chevron, and neither
-knows the other exists.
+<LearnPlayer>
 
-## One border, N rows, one open flag
-
-`Accordion` isn't a stack of cards. It's a single `rounded-xl border`
-wrapper with `divide-y` between rows, and each row's "open-ness" lives in one
-piece of state — an array of open values, not a boolean per item:
-
-<AccordionAnatomy />
-
-```tsx
-const [open, setOpen] = React.useState<string[]>(/* … */);
+<LearnChapter
+  label="One border, N rows, one open flag"
+  scene={<AccordionAnatomy />}
+  code={`const [open, setOpen] = React.useState<string[]>(/* … */);
 
 <div className="w-full divide-y divide-border overflow-hidden rounded-xl border border-border">
   {items.map((item) => {
@@ -34,23 +26,28 @@ const [open, setOpen] = React.useState<string[]>(/* … */);
       </div>
     );
   })}
-</div>
-```
+</div>`}
+>
+
+An accordion looks like a single animation — click, and the panel opens.
+It's actually two unrelated timing systems firing off the same state change:
+Framer Motion drives the panel, plain CSS drives the chevron, and neither
+knows the other exists.
+
+`Accordion` isn't a stack of cards. It's a single `rounded-xl border`
+wrapper with `divide-y` between rows, and each row's "open-ness" lives in one
+piece of state — an array of open values, not a boolean per item:
 
 `type="single"` collapses that array to at most one value; `type="multiple"`
 just lets it grow. Same render tree, same toggle function — the mode is a
 three-line branch inside `toggle()`, not a different component.
 
-## A spring for height, a flat ease for the chevron
+</LearnChapter>
 
-The panel's entrance and exit are one `motion.div` inside `AnimatePresence`,
-and its `height`/`opacity` are driven by two different transitions on the
-*same* animate call:
-
-<AccordionHeight />
-
-```tsx
-<motion.div
+<LearnChapter
+  label="A spring for height, a flat ease for the chevron"
+  scene={<AccordionHeight />}
+  code={`<motion.div
   initial={reduceMotion ? false : { height: 0, opacity: 0 }}
   animate={{ height: "auto", opacity: 1 }}
   exit={reduceMotion ? undefined : { height: 0, opacity: 0 }}
@@ -61,8 +58,12 @@ and its `height`/`opacity` are driven by two different transitions on the
   className="overflow-hidden"
 >
   {item.content}
-</motion.div>
-```
+</motion.div>`}
+>
+
+The panel's entrance and exit are one `motion.div` inside `AnimatePresence`,
+and its `height`/`opacity` are driven by two different transitions on the
+*same* animate call:
 
 `stiffness: 500` with `damping: 40` is slightly underdamped — the panel
 overshoots its resting height by a hair before settling, instead of easing
@@ -86,13 +87,24 @@ no shared animation controller. The chevron's `250ms ease` and the panel's
 spring are unrelated curves that happen to start on the same click; nothing
 keeps them in lockstep, and nothing needs to.
 
-## `overflow-hidden` does the real clipping
-
 The panel's `className="overflow-hidden"` isn't decoration — it's what
 makes animating a growing/shrinking `height` look clean instead of showing
 un-clipped content flash at the edges mid-animation. Framer measures the
 child's natural height for `"auto"`, but the visible box is clipped by that
 one utility for the whole transition.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<AccordionResult />} isResult>
+
+One `open` array, one `AnimatePresence` panel per row, one spring for the
+height and a completely separate 250ms ease for the chevron — click through
+the questions above and watch the two curves run independently on the same
+click.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Reduced motion skips the spring, not the state
 
@@ -136,12 +148,3 @@ disabled>`, which removes it from the tab order for free.
 ## Motion Score
 
 <MotionScorePanel name="accordion" />
-
-## The result
-
-<AccordionResult />
-
-One `open` array, one `AnimatePresence` panel per row, one spring for the
-height and a completely separate 250ms ease for the chevron — click through
-the questions above and watch the two curves run independently on the same
-click.

--- a/apps/docs/content/docs/components/layout/animated-testimonials/learn.mdx
+++ b/apps/docs/content/docs/components/layout/animated-testimonials/learn.mdx
@@ -1,24 +1,15 @@
 ---
 title: Anatomy of Animated Testimonials
 description: A stack that never slides, a quote that fades as a block and dissolves word by word at the same time — two independent motion layers on one 5-second clock.
+learnPlayer: true
 ---
 
-Testimonial carousels usually fake depth with a sliding track and a fixed
-crop. `AnimatedTestimonials` doesn't slide anything — every portrait is
-mounted in the same box for the component's whole lifetime, and "advancing"
-is just every plate re-targeting the same four properties on a spring.
+<LearnPlayer>
 
-## Every portrait, one box, always mounted
-
-`testimonials.map` renders every image up front, absolutely positioned on
-top of each other inside one `relative` box with `[perspective:1000px]`.
-`isActive` is the only thing that differs per render — there's no separate
-"current slide" node swapped in and out:
-
-<AnimatedTestimonialsAnatomy />
-
-```tsx
-<div className="relative h-72 [perspective:1000px]">
+<LearnChapter
+  label="Every portrait, one box, always mounted"
+  scene={<AnimatedTestimonialsAnatomy />}
+  code={`<div className="relative h-72 [perspective:1000px]">
   <AnimatePresence>
     {testimonials.map((t, i) => {
       const isActive = i === active;
@@ -38,8 +29,18 @@ top of each other inside one `relative` box with `[perspective:1000px]`.
       );
     })}
   </AnimatePresence>
-</div>
-```
+</div>`}
+>
+
+Testimonial carousels usually fake depth with a sliding track and a fixed
+crop. `AnimatedTestimonials` doesn't slide anything — every portrait is
+mounted in the same box for the component's whole lifetime, and "advancing"
+is just every plate re-targeting the same four properties on a spring.
+
+`testimonials.map` renders every image up front, absolutely positioned on
+top of each other inside one `relative` box with `[perspective:1000px]`.
+`isActive` is the only thing that differs per render — there's no separate
+"current slide" node swapped in and out:
 
 `rotations` is computed once with `useMemo` — `Math.floor(Math.random() * 16)
 - 8` per testimonial — and reused as both the `initial` and the resting
@@ -47,13 +48,13 @@ top of each other inside one `relative` box with `[perspective:1000px]`.
 of a uniform deck: each portrait has its own fixed tilt for the component's
 whole life, not a fresh random value every re-render.
 
-## Advancing re-targets, it doesn't slide
+</LearnChapter>
 
-<AnimatedTestimonialsStack />
-
-```tsx
-transition={{ type: "spring", stiffness: 320, damping: 32, mass: 0.9 }}
-```
+<LearnChapter
+  label="Advancing re-targets, it doesn't slide"
+  scene={<AnimatedTestimonialsStack />}
+  code={`transition={{ type: "spring", stiffness: 320, damping: 32, mass: 0.9 }}`}
+>
 
 When `active` changes, React re-renders every `motion.img` with new
 `animate` values — the previously-active plate's `scale`/`rotate`/`zIndex`
@@ -67,15 +68,12 @@ readable: cards near the active index stay closer to the front than ones
 several positions away, so even mid-transition the depth order never looks
 scrambled.
 
-## The quote fades as a block *and* dissolves per word
+</LearnChapter>
 
-The name/role/quote block and the individual words inside it are two
-separate `AnimatePresence` layers with two separate transitions:
-
-<AnimatedTestimonialsWords />
-
-```tsx
-<AnimatePresence mode="wait">
+<LearnChapter
+  label="The quote fades as a block and dissolves per word"
+  scene={<AnimatedTestimonialsWords />}
+  code={`<AnimatePresence mode="wait">
   <motion.div
     key={active}
     initial={{ opacity: 0, y: 12 }}
@@ -86,7 +84,7 @@ separate `AnimatePresence` layers with two separate transitions:
     <p>
       {current.quote.split(" ").map((word, i) => (
         <motion.span
-          key={`${active}-${i}`}
+          key={\`\${active}-\${i}\`}
           initial={{ opacity: 0, filter: "blur(6px)", y: 6 }}
           animate={{ opacity: 1, filter: "blur(0px)", y: 0 }}
           transition={{ duration: 0.2, delay: 0.02 * i }}
@@ -97,8 +95,11 @@ separate `AnimatePresence` layers with two separate transitions:
     </p>
     {/* name / role, part of the same block */}
   </motion.div>
-</AnimatePresence>
-```
+</AnimatePresence>`}
+>
+
+The name/role/quote block and the individual words inside it are two
+separate `AnimatePresence` layers with two separate transitions.
 
 `mode="wait"` on the outer `AnimatePresence` means the *previous* quote
 block fully exits (`y: -12`, fading out) before the next one mounts — so the
@@ -108,7 +109,7 @@ just disappear with their parent block's exit animation. Only the entrance
 is staggered; the departure is one motion, not twenty-four unwinding in
 reverse.
 
-## The clock resets on every navigation, not just autoplay
+The clock resets on every navigation, not just autoplay:
 
 ```tsx
 const next = React.useCallback(
@@ -129,15 +130,19 @@ timeout is cleared and a fresh 5-second one starts. Click "next" right
 before autoplay would have fired, and you get a full 5 seconds again instead
 of an almost-immediate second flip.
 
-## Motion Score
+</LearnChapter>
 
-<MotionScorePanel name="animated-testimonials" />
-
-## The result
-
-<AnimatedTestimonialsResult />
+<LearnChapter label="The result" scene={<AnimatedTestimonialsResult />} isResult>
 
 One stack of always-mounted portraits re-targeting a shared spring, one
 quote block that fades as a unit while its words dissolve on their own
 staggered clock, one timeout that restarts on any navigation — three
 independent timing systems that read as a single, cohesive carousel.
+
+</LearnChapter>
+
+</LearnPlayer>
+
+## Motion Score
+
+<MotionScorePanel name="animated-testimonials" />

--- a/apps/docs/content/docs/components/layout/app-showcase/learn.mdx
+++ b/apps/docs/content/docs/components/layout/app-showcase/learn.mdx
@@ -1,23 +1,15 @@
 ---
 title: Anatomy of the App Showcase
 description: A device frame built entirely from width ratios, an entrance and a scroll pan sharing one spring config, and a loop mode that never touches JavaScript per frame.
+learnPlayer: true
 ---
 
-A device mockup that looks convincing at every size usually means someone
-hand-tuned the notch and corner radius for 2–3 fixed breakpoints.
-`AppShowcase` doesn't have breakpoints — every radius, every inset, the
-notch itself, is a ratio of one `width` prop, computed once per render.
+<LearnPlayer>
 
-## The whole frame is derived from one number
-
-`PhoneFrame` reads a `DEVICE` table keyed by `shellR`, `padR`, and `screenR`
-— ratios, not pixels — and multiplies them by `width` to get every geometric
-value the frame needs:
-
-<AppShowcaseAnatomy />
-
-```tsx
-const DEVICE = {
+<LearnChapter
+  label="The whole frame is derived from one number"
+  scene={<AppShowcaseAnatomy />}
+  code={`const DEVICE = {
   iphone: { aspect: "aspect-[433/882]", shellR: 0.17, padR: 0.035, screenR: 0.13 },
   android: { aspect: "aspect-[9/19.5]", shellR: 0.11, padR: 0.028, screenR: 0.085 },
 };
@@ -26,8 +18,17 @@ const geo = DEVICE[device];
 const pad = w * geo.padR;
 const shellRadius = w * geo.shellR;
 const screenRadius = w * geo.screenR;
-const notchW = w * 0.3;
-```
+const notchW = w * 0.3;`}
+>
+
+A device mockup that looks convincing at every size usually means someone
+hand-tuned the notch and corner radius for 2–3 fixed breakpoints.
+`AppShowcase` doesn't have breakpoints — every radius, every inset, the
+notch itself, is a ratio of one `width` prop, computed once per render.
+
+`PhoneFrame` reads a `DEVICE` table keyed by `shellR`, `padR`, and `screenR`
+— ratios, not pixels — and multiplies them by `width` to get every geometric
+value the frame needs:
 
 Nothing here is a fixed `rem` value. Render the same `AppShowcase` at
 `width={140}` and `width={400}` and the shell radius, the padding gap, and
@@ -36,15 +37,12 @@ the notch all scale together — a hand-picked radius would look chunky at
 table (`shellR: 0.11`, hole-punch instead of a notch), not a fork of the
 component.
 
-## One `SPRING`, two motion sources
+</LearnChapter>
 
-`scroll` mode — the default — runs Framer twice off the same config,
-for two unrelated things:
-
-<AppShowcaseScroll />
-
-```tsx
-const SPRING = { stiffness: 320, damping: 32, mass: 0.9 };
+<LearnChapter
+  label="One SPRING, two motion sources"
+  scene={<AppShowcaseScroll />}
+  code={`const SPRING = { stiffness: 320, damping: 32, mass: 0.9 };
 
 // 1. Entrance — fires once, on scroll-into-view
 <motion.div
@@ -57,8 +55,11 @@ const SPRING = { stiffness: 320, damping: 32, mass: 0.9 };
 
 // 2. Scroll pan — tracks scroll position continuously
 const { scrollYProgress } = useScroll({ target: sectionRef, offset: ["start end", "end start"] });
-const y = useSpring(useTransform(scrollYProgress, [0, 1], ["0%", "-45%"]), SPRING);
-```
+const y = useSpring(useTransform(scrollYProgress, [0, 1], ["0%", "-45%"]), SPRING);`}
+>
+
+`scroll` mode — the default — runs Framer twice off the same config,
+for two unrelated things:
 
 The entrance is a one-shot spring gated by `viewport={{ once: true }}` — it
 plays exactly once and never re-triggers on re-scroll. The pan is the
@@ -69,20 +70,20 @@ completely different job. `rotateX: 10 → 0` on the entrance, combined with
 `[perspective:1200px]` on the wrapper, is what gives the phone a slight
 "tilting up out of the page" feel rather than a flat slide-up.
 
-## `loop` mode skips Framer entirely
+</LearnChapter>
 
-<AppShowcaseLoop />
-
-```tsx
-<div
-  className={`flex flex-col ${running ? "animate-app-showcase-scroll" : ""} motion-reduce:animate-none`}
-  style={{ willChange: "transform", ["--as-loop"]: `${interval * 6}s` }}
+<LearnChapter
+  label="loop mode skips Framer entirely"
+  scene={<AppShowcaseLoop />}
+  code={`<div
+  className={\`flex flex-col \${running ? "animate-app-showcase-scroll" : ""} motion-reduce:animate-none\`}
+  style={{ willChange: "transform", ["--as-loop"]: \`\${interval * 6}s\` }}
 >
   <img src={src} className="w-full" />
   {/* Duplicate for a seamless wrap. */}
   <img src={src} aria-hidden className="w-full" />
-</div>
-```
+</div>`}
+>
 
 ```css
 @keyframes app-showcase-scroll {
@@ -100,8 +101,6 @@ inView && !reduce && !videoSrc`) rather than a `useAnimationFrame` loop —
 once the class is attached, the browser's compositor drives every frame with
 zero React re-renders and zero Framer Motion overhead.
 
-## Idle when it can't be seen
-
 ```tsx
 const io = new IntersectionObserver(
   ([entry]) => setInView(entry.isIntersecting),
@@ -113,6 +112,18 @@ const io = new IntersectionObserver(
 showcase off-screen and its class drops, the CSS animation pauses, and the
 compositor has nothing left to do for that element. No `requestAnimationFrame`
 loop to cancel, because there never was one.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<AppShowcaseResult />} isResult>
+
+One ratio table building the whole shell, one shared spring config doing two
+unrelated jobs in `scroll` mode, and a `loop` mode that hands the browser's
+compositor a two-copy track and gets out of the way entirely.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Reduced motion, mode by mode
 
@@ -129,11 +140,3 @@ boolean, no mode left animating for a user who asked it to stop.
 ## Motion Score
 
 <MotionScorePanel name="app-showcase" />
-
-## The result
-
-<AppShowcaseResult />
-
-One ratio table building the whole shell, one shared spring config doing two
-unrelated jobs in `scroll` mode, and a `loop` mode that hands the browser's
-compositor a two-copy track and gets out of the way entirely.

--- a/apps/docs/content/docs/components/layout/avatar-group/learn.mdx
+++ b/apps/docs/content/docs/components/layout/avatar-group/learn.mdx
@@ -1,23 +1,15 @@
 ---
 title: Anatomy of the Avatar Group
 description: An overlapping stack built from ordinary flex flow, and two hover-triggered springs — one on the whole row, one on a single avatar — that layer on top of each other.
+learnPlayer: true
 ---
 
-Overlapping avatar stacks are usually faked with `position: absolute` and
-manually offset `left` values. `AvatarGroup` doesn't reach for absolute
-positioning at all — it overlaps avatars with plain flex flow and negative
-margin, which is what lets the "fan out on hover" motion be a single
-`marginLeft` spring instead of a layout rewrite.
+<LearnPlayer>
 
-## Negative margin, not absolute position
-
-Every avatar past the first pulls itself left into its neighbor by a fixed
-overlap, and `zIndex: i` stacks later avatars on top:
-
-<AvatarGroupAnatomy />
-
-```tsx
-const overlap = { sm: 10, md: 12, lg: 14 };
+<LearnChapter
+  label="Negative margin, not absolute position"
+  scene={<AvatarGroupAnatomy />}
+  code={`const overlap = { sm: 10, md: 12, lg: 14 };
 const margin = -overlap[size];
 
 <motion.div
@@ -26,8 +18,17 @@ const margin = -overlap[size];
   className="relative size-10 ring-2 ring-background rounded-full overflow-hidden bg-background"
 >
   <Initials avatar={avatar} />
-</motion.div>
-```
+</motion.div>`}
+>
+
+Overlapping avatar stacks are usually faked with `position: absolute` and
+manually offset `left` values. `AvatarGroup` doesn't reach for absolute
+positioning at all — it overlaps avatars with plain flex flow and negative
+margin, which is what lets the "fan out on hover" motion be a single
+`marginLeft` spring instead of a layout rewrite.
+
+Every avatar past the first pulls itself left into its neighbor by a fixed
+overlap, and `zIndex: i` stacks later avatars on top.
 
 Because it's real flow layout, the `+N` overflow chip is just one more item
 in the same row with the same negative-margin treatment — not a
@@ -37,12 +38,12 @@ instead of clipped rectangles — the ring is the same color as the page
 background, so it fakes a gap between avatars that don't actually have one
 in the DOM.
 
-## Two springs, two independent triggers
+</LearnChapter>
 
-<AvatarGroupSpread />
-
-```tsx
-<motion.div
+<LearnChapter
+  label="Two springs, two independent triggers"
+  scene={<AvatarGroupSpread />}
+  code={`<motion.div
   initial="rest"
   whileHover={spreadOnHover && !reduceMotion ? "spread" : undefined}
   animate="rest"
@@ -59,8 +60,8 @@ in the DOM.
       <Initials avatar={avatar} />
     </motion.div>
   ))}
-</motion.div>
-```
+</motion.div>`}
+>
 
 Hovering anywhere over the outer `motion.div` flips every avatar's
 `variants` from `rest` to `spread` — `marginLeft` relaxes from a tight
@@ -73,13 +74,24 @@ vs. the individual avatar), and Framer resolves both onto the same node.
 Move the pointer across the row and you get the fan-out; stop over one
 avatar and it additionally pops up above its neighbors.
 
-## The overflow chip spreads, but never lifts
-
 The `+N` chip shares the row's `spread` variant — hover the group and it
 slides right along with everything else — but it has no `whileHover` of its
 own, so it never gets the individual `y`/`scale` lift. It communicates
 "more people, not a person" by opting out of exactly one of the two
 animations everything else has both of.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<AvatarGroupResult />} isResult>
+
+Ordinary flex flow with negative margins for the overlap, one spring on the
+group's hover and a second, independent spring on each avatar's own hover —
+sweep the row, then rest on one avatar, and watch both springs settle
+without ever touching each other's state.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Reduced motion removes the trigger, not just the transition
 
@@ -116,12 +128,3 @@ at a time.
 ## Motion Score
 
 <MotionScorePanel name="avatar-group" />
-
-## The result
-
-<AvatarGroupResult />
-
-Ordinary flex flow with negative margins for the overlap, one spring on the
-group's hover and a second, independent spring on each avatar's own hover —
-sweep the row, then rest on one avatar, and watch both springs settle
-without ever touching each other's state.

--- a/apps/docs/content/docs/components/layout/bento-grid/learn.mdx
+++ b/apps/docs/content/docs/components/layout/bento-grid/learn.mdx
@@ -1,13 +1,26 @@
 ---
 title: Anatomy of the Bento Grid
 description: How a modular bento layout gets its shape from plain CSS grid spans, its entrance from one shared spring, and its hover glow from a single pointer-tracked custom property.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="Spans, not a masonry engine"
+  scene={<BentoGridAnatomy />}
+  code={`const GRID_COLS = { 2: "md:grid-cols-2", 3: "md:grid-cols-3", 4: "md:grid-cols-4" };
+const COL_SPAN = { 1: "md:col-span-1", 2: "md:col-span-2", 3: "md:col-span-3" };
+const ROW_SPAN = { 1: "md:row-span-1", 2: "md:row-span-2" };
+
+<motion.div className={\`grid auto-rows-[minmax(11rem,auto)] grid-cols-1 gap-4 \${GRID_COLS[columns]}\`}>
+  {/* each BentoCard: \`\${COL_SPAN[colSpan]} \${ROW_SPAN[rowSpan]}\` */}
+</motion.div>`}
+>
 
 A bento grid looks like it needs a layout engine — cards of different sizes,
 packed with no gaps. It doesn't. `BentoGrid` is `display: grid` with three
 columns; every card just claims more of it.
-
-## Spans, not a masonry engine
 
 `BentoGrid` renders a plain grid — `grid-cols-3` (or however many `columns`
 you pass), `auto-rows-[minmax(11rem,auto)]`. There's no measuring pass, no
@@ -15,34 +28,16 @@ packing algorithm. Each `BentoCard` declares how much room it wants with
 `colSpan`/`rowSpan`, and the browser's normal row-major auto-flow drops it
 into the next cell that fits:
 
-<BentoGridAnatomy />
-
-```tsx
-const GRID_COLS = { 2: "md:grid-cols-2", 3: "md:grid-cols-3", 4: "md:grid-cols-4" };
-const COL_SPAN = { 1: "md:col-span-1", 2: "md:col-span-2", 3: "md:col-span-3" };
-const ROW_SPAN = { 1: "md:row-span-1", 2: "md:row-span-2" };
-
-<motion.div className={`grid auto-rows-[minmax(11rem,auto)] grid-cols-1 gap-4 ${GRID_COLS[columns]}`}>
-  {/* each BentoCard: `${COL_SPAN[colSpan]} ${ROW_SPAN[rowSpan]}` */}
-</motion.div>
-```
-
 Those lookup objects exist because the Tailwind scanner can't see an
 interpolated class like `` `md:col-span-${n}` `` — every valid span has to be a
 literal string somewhere in the source for the class to ship.
 
-## One stagger, driven by scroll-in
+</LearnChapter>
 
-The grid and its cards share one Framer `variants` pair. The grid is
-`hidden`/`visible` with `staggerChildren: 0.08`; every card's `itemVariants`
-resolves `opacity 0→1` and `y 20→0` on a spring. `whileInView` fires it once,
-the moment the grid crosses 15% into the viewport — nothing plays until then,
-and it never replays on its own:
-
-<BentoGridStagger />
-
-```tsx
-const containerVariants: Variants = {
+<LearnChapter
+  label="One stagger, driven by scroll-in"
+  scene={<BentoGridStagger />}
+  code={`const containerVariants: Variants = {
   hidden: {},
   visible: { transition: { staggerChildren: 0.08 } },
 };
@@ -60,35 +55,41 @@ const itemVariants: Variants = {
   viewport={{ once: true, amount: 0.15 }}
 >
   {/* each BentoCard is a motion.div with variants={itemVariants} */}
-</motion.div>
-```
+</motion.div>`}
+>
+
+The grid and its cards share one Framer `variants` pair. The grid is
+`hidden`/`visible` with `staggerChildren: 0.08`; every card's `itemVariants`
+resolves `opacity 0→1` and `y 20→0` on a spring. `whileInView` fires it once,
+the moment the grid crosses 15% into the viewport — nothing plays until then,
+and it never replays on its own:
 
 Because `staggerChildren` lives on the *parent's* transition, no card needs to
 know its own index or delay — Framer walks the children in DOM order and
 staggers them for you.
 
-## Why the spotlight is a CSS variable, not React state
+</LearnChapter>
+
+<LearnChapter
+  label="Why the spotlight is a CSS variable, not React state"
+  scene={<BentoGridGlow />}
+  code={`const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+  const rect = ref.current?.getBoundingClientRect();
+  if (rect) {
+    ref.current.style.setProperty("--x", \`\${e.clientX - rect.left}px\`);
+    ref.current.style.setProperty("--y", \`\${e.clientY - rect.top}px\`);
+  }
+};`}
+>
 
 Hovering a card reveals a soft radial glow that follows the pointer. Tracking
 that in React state would mean a re-render on every `pointermove` — instead,
 `onPointerMove` writes straight to the DOM:
 
-```tsx
-const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
-  const rect = ref.current?.getBoundingClientRect();
-  if (rect) {
-    ref.current.style.setProperty("--x", `${e.clientX - rect.left}px`);
-    ref.current.style.setProperty("--y", `${e.clientY - rect.top}px`);
-  }
-};
-```
-
 `--x`/`--y` feed a `radial-gradient` that's already painted and just waiting
 for its center to move — the glow itself only animates `opacity` on
 `group-hover`, so lift and glow both stay off the main thread once they're
 running:
-
-<BentoGridGlow />
 
 ```tsx
 const CARD_BASE =
@@ -103,6 +104,17 @@ const CARD_GLOW =
 to whatever primary color the theme is running, without a second custom
 property just for opacity.
 
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<BentoGridResult />} isResult>
+
+Three columns, a couple of `colSpan`/`rowSpan` numbers, one shared spring for
+the entrance, and a CSS variable for the glow — no layout library required.
+
+</LearnChapter>
+
+</LearnPlayer>
+
 ## Accessibility
 
 Both the stagger and the hover lift respect `motion-reduce`: the card's
@@ -115,10 +127,3 @@ focusable CTAs) works exactly as it would outside the grid.
 ## Motion Score
 
 <MotionScorePanel name="bento-grid" />
-
-## The result
-
-<BentoGridResult />
-
-Three columns, a couple of `colSpan`/`rowSpan` numbers, one shared spring for
-the entrance, and a CSS variable for the glow — no layout library required.

--- a/apps/docs/content/docs/components/layout/card-swap/learn.mdx
+++ b/apps/docs/content/docs/components/layout/card-swap/learn.mdx
@@ -1,13 +1,26 @@
 ---
 title: Anatomy of the Card Swap
 description: How a 3D card stack cycles through a showcase loop with one array rotation, a shared spring, and a pointer-driven tilt — no per-card timers.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="Rank, not position"
+  scene={<CardSwapAnatomy />}
+  code={`animate={{
+  x: r * offsetX,
+  y: -r * offsetY,
+  scale: 1 - r * scaleStep,
+  rotateZ: r * -2.5,
+  opacity: r > 3 ? 0 : 1,
+}}`}
+>
 
 A stack that fans out and cycles through itself looks like it needs one
 timeline per card. It doesn't. `CardSwap` keeps a single `order` array; every
 card reads its own position out of it and springs there.
-
-## Rank, not position
 
 Nothing about a card's depth lives on the card. `CardSwap` keeps one `order`
 array — `order[r]` is the item index currently at rank `r`, `0` being the
@@ -25,31 +38,14 @@ const rankOf = React.useMemo(() => {
 
 That one number then drives four transforms at once — `x`, `y`, `scale`,
 `rotateZ` all step together as rank increases, so the whole fan reads as one
-consistent recession into the stack:
+consistent recession into the stack.
 
-<CardSwapAnatomy />
+</LearnChapter>
 
-```tsx
-animate={{
-  x: r * offsetX,
-  y: -r * offsetY,
-  scale: 1 - r * scaleStep,
-  rotateZ: r * -2.5,
-  opacity: r > 3 ? 0 : 1,
-}}
-```
-
-## The swap is an array rotation
-
-Advancing doesn't tween anyone's position directly — it rewrites `order` so
-the front item's index moves to the back, and lets every card's `rank`
-(and therefore its `animate` target) fall out of that new array on the next
-render:
-
-<CardSwapCycle />
-
-```tsx
-const advance = React.useCallback(() => {
+<LearnChapter
+  label="The swap is an array rotation"
+  scene={<CardSwapCycle />}
+  code={`const advance = React.useCallback(() => {
   setOrder((o) => (o.length ? [...o.slice(1), o[0] as number] : o));
 }, []);
 
@@ -57,24 +53,25 @@ React.useEffect(() => {
   if (!interval || paused || n < 2) return;
   const t = setInterval(advance, interval);
   return () => clearInterval(t);
-}, [interval, paused, n, advance]);
-```
+}, [interval, paused, n, advance]);`}
+>
+
+Advancing doesn't tween anyone's position directly — it rewrites `order` so
+the front item's index moves to the back, and lets every card's `rank`
+(and therefore its `animate` target) fall out of that new array on the next
+render:
 
 Because every card's `animate` prop is just "whatever `rankOf[i]` says right
 now," Framer's own diffing handles the transition — there's no manual
 tween between old and new slot, just a spring (`stiffness 320 / damping 32 /
 mass 0.9`) chasing a new target.
 
-## Why the whole stack tilts, not each card
+</LearnChapter>
 
-The pointer parallax lives one level up from the cards — on the
-`[transform-style:preserve-3d]` wrapper that holds all of them, not on any
-individual card:
-
-<CardSwapTilt />
-
-```tsx
-const handleMove = (e: React.PointerEvent<HTMLDivElement>) => {
+<LearnChapter
+  label="Why the whole stack tilts, not each card"
+  scene={<CardSwapTilt />}
+  code={`const handleMove = (e: React.PointerEvent<HTMLDivElement>) => {
   const rect = ref.current?.getBoundingClientRect();
   if (!rect) return;
   const px = (e.clientX - rect.left) / rect.width - 0.5;
@@ -88,12 +85,27 @@ const handleMove = (e: React.PointerEvent<HTMLDivElement>) => {
   transition={{ type: "spring", stiffness: 170, damping: 12, mass: 0.1 }}
 >
   {/* every card, already offset by its own rank */}
-</motion.div>
-```
+</motion.div>`}
+>
+
+The pointer parallax lives one level up from the cards — on the
+`[transform-style:preserve-3d]` wrapper that holds all of them, not on any
+individual card:
 
 One spring, applied once, tilts the entire fan together — cards don't fight
 each other for depth because their individual `rotateZ` offsets and the
 group's `rotateX`/`rotateY` compose on the same 3D stage.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<CardSwapResult />} isResult>
+
+One array, one lookup from index to rank, two springs (fast for the tilt,
+smooth for the re-flow) — that's the entire stack, cycling itself forever.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility
 
@@ -111,10 +123,3 @@ transition={reduce ? { duration: 0 } : { type: "spring", stiffness: 320, damping
 ## Motion Score
 
 <MotionScorePanel name="card-swap" />
-
-## The result
-
-<CardSwapResult />
-
-One array, one lookup from index to rank, two springs (fast for the tilt,
-smooth for the re-flow) — that's the entire stack, cycling itself forever.

--- a/apps/docs/content/docs/components/layout/container-scroll/learn.mdx
+++ b/apps/docs/content/docs/components/layout/container-scroll/learn.mdx
@@ -1,23 +1,15 @@
 ---
 title: Anatomy of the Container Scroll
 description: How a product-hero device frame un-tilts from 3D as you scroll, driven by one scroll-progress value feeding three independent springs.
+learnPlayer: true
 ---
 
-A hero that un-tilts as you scroll past it looks like it needs a scroll
-listener, some math, and a `requestAnimationFrame` loop. `ContainerScroll` is
-one `useScroll` call and three `useTransform`s riding it.
+<LearnPlayer>
 
-## Header and frame, sharing one section
-
-`ContainerScroll` renders two children into the same tall section: a
-`header` block above, and the device `frame` below it in its own
-`[perspective:1000px]` stage. Neither knows about the other — both just read
-transforms handed down from the same scroll progress:
-
-<ContainerScrollAnatomy />
-
-```tsx
-<div ref={containerRef} className="relative flex h-[60rem] items-center justify-center md:h-[80rem]">
+<LearnChapter
+  label="Header and frame, sharing one section"
+  scene={<ContainerScrollAnatomy />}
+  code={`<div ref={containerRef} className="relative flex h-[60rem] items-center justify-center md:h-[80rem]">
   <div className="relative w-full [perspective:1000px]">
     <motion.div style={{ translateY }} className="mx-auto mb-10 max-w-3xl text-center">
       {header}
@@ -26,14 +18,35 @@ transforms handed down from the same scroll progress:
       {frame /* the border + aspect-[16/10] screen */}
     </motion.div>
   </div>
-</div>
-```
+</div>`}
+>
+
+A hero that un-tilts as you scroll past it looks like it needs a scroll
+listener, some math, and a `requestAnimationFrame` loop. `ContainerScroll` is
+one `useScroll` call and three `useTransform`s riding it.
+
+`ContainerScroll` renders two children into the same tall section: a
+`header` block above, and the device `frame` below it in its own
+`[perspective:1000px]` stage. Neither knows about the other — both just read
+transforms handed down from the same scroll progress:
 
 The section is deliberately tall (`60rem`, `80rem` on `md:`) — there has to be
 enough scroll distance for `scrollYProgress` to move from `0` to `1` at a
 readable pace, or the whole animation resolves in a couple of frames.
 
-## One progress value, three springs
+</LearnChapter>
+
+<LearnChapter
+  label="One progress value, three springs"
+  scene={<ContainerScrollScrub />}
+  code={`const SPRING = { stiffness: 320, damping: 32, mass: 0.9 } as const;
+
+const { scrollYProgress } = useScroll({ target: containerRef });
+
+const rotateX    = useSpring(useTransform(scrollYProgress, [0, 1], [20, 0]), SPRING);
+const scale      = useSpring(useTransform(scrollYProgress, [0, 1], [1.05, 1]), SPRING);
+const translateY = useSpring(useTransform(scrollYProgress, [0, 1], [0, -100]), SPRING);`}
+>
 
 `useScroll({ target: containerRef })` returns `scrollYProgress` — `0` when
 the section's top hits the bottom of the viewport, `1` when its bottom hits
@@ -41,24 +54,10 @@ the top. Three `useTransform`s remap that single number to three different
 ranges, and each gets its own `useSpring` for the smoothing, so all three
 settle with the same feel without being coupled to each other's code:
 
-<ContainerScrollScrub />
-
-```tsx
-const SPRING = { stiffness: 320, damping: 32, mass: 0.9 } as const;
-
-const { scrollYProgress } = useScroll({ target: containerRef });
-
-const rotateX    = useSpring(useTransform(scrollYProgress, [0, 1], [20, 0]), SPRING);
-const scale      = useSpring(useTransform(scrollYProgress, [0, 1], [1.05, 1]), SPRING);
-const translateY = useSpring(useTransform(scrollYProgress, [0, 1], [0, -100]), SPRING);
-```
-
 Scroll down and `rotateX`, `scale`, and `translateY` all move together
 because they're three views onto the same underlying `scrollYProgress` motion
 value — there's no explicit synchronization code because there's nothing to
 synchronize.
-
-## Why the frame gets its own perspective stage
 
 `rotateX` only reads as "tilting back in 3D" if the browser has a vanishing
 point to rotate toward — that's what `[perspective:1000px]` on the *parent*
@@ -67,6 +66,17 @@ frame itself keeps its own children (the border, the screen) flat against it
 instead of each getting their own independent 3D space. Get the perspective
 container wrong — put it too close, or nest it one level off — and the tilt
 looks like a lopsided `scaleY` instead of a plane rotating in depth.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<ContainerScrollResult />} isResult>
+
+One `useScroll`, three `useTransform`s, three springs for the smoothing — the
+entire "product hero" moment, tied to nothing but how far you've scrolled.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Reduced motion is a different tree, not a toggle
 
@@ -94,10 +104,3 @@ whatever comes next.
 ## Motion Score
 
 <MotionScorePanel name="container-scroll" />
-
-## The result
-
-<ContainerScrollResult />
-
-One `useScroll`, three `useTransform`s, three springs for the smoothing — the
-entire "product hero" moment, tied to nothing but how far you've scrolled.

--- a/apps/docs/content/docs/components/layout/cover-flow/learn.mdx
+++ b/apps/docs/content/docs/components/layout/cover-flow/learn.mdx
@@ -1,35 +1,49 @@
 ---
 title: Anatomy of Cover Flow
 description: How a 3D album-cover carousel derives every slide's rotation, depth, and scale from one signed distance, and turns a drag into a spring-settled index.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="One signed distance, five slides"
+  scene={<CoverFlowAnatomy />}
+  code={`const near = Math.min(abs, 1);
+const far = Math.max(abs - 1, 0);
+const x = sign * (near * spacing + far * spacing * 0.55);
+const rotateY = -Math.max(-1, Math.min(1, offset)) * 52;
+const z = -Math.min(abs, 3) * 130;
+const scale = 1 - Math.min(abs, 3) * 0.08;`}
+>
 
 Cover Flow doesn't animate five slides — it animates one number, `active`,
 and lets every slide read its own distance from it. Here's how that single
 signal becomes a 3D fan you can throw.
-
-## One signed distance, five slides
 
 Each slide's `offset` is just `index - active`. Everything else — position,
 rotation, depth, scale, fade — is a pure function of that one signed number.
 The center slide (`offset === 0`) sits flat and full-scale; neighbours peel
 away in perspective the farther their offset runs.
 
-<CoverFlowAnatomy />
-
 Position telescopes instead of scrolling off-screen: the first unit of
 distance moves a full pitch, everything past that compresses to 55% of a
 pitch, so far slides keep queuing toward the edge instead of vanishing.
 
-```tsx
-const near = Math.min(abs, 1);
-const far = Math.max(abs - 1, 0);
-const x = sign * (near * spacing + far * spacing * 0.55);
-const rotateY = -Math.max(-1, Math.min(1, offset)) * 52;
-const z = -Math.min(abs, 3) * 130;
-const scale = 1 - Math.min(abs, 3) * 0.08;
-```
+</LearnChapter>
 
-## Dragging rewrites the index, not the slides
+<LearnChapter
+  label="Dragging rewrites the index, not the slides"
+  scene={<CoverFlowFan />}
+  code={`const handlePan = (_e, info: PanInfo) => {
+  goTo(Math.round(dragFrom.current - info.offset.x / spacing));
+};
+const handlePanEnd = (_e, info: PanInfo) => {
+  if (Math.abs(info.velocity.x) > 600) {
+    goTo(active - Math.sign(info.velocity.x));
+  }
+};`}
+>
 
 There's no per-slide drag handler. A single `motion.div` wraps the whole
 stage and reads one pan gesture; every frame it rewrites `active` from the
@@ -37,21 +51,6 @@ drag offset, and the slides above just re-render off their new `offset`.
 Release fast enough — `|velocity.x| > 600` — and the index nudges one extra
 slide in the throw direction, so a flick keeps going past where your finger
 stopped.
-
-<CoverFlowFan />
-
-```tsx
-const handlePan = (_e, info: PanInfo) => {
-  goTo(Math.round(dragFrom.current - info.offset.x / spacing));
-};
-const handlePanEnd = (_e, info: PanInfo) => {
-  if (Math.abs(info.velocity.x) > 600) {
-    goTo(active - Math.sign(info.velocity.x));
-  }
-};
-```
-
-## One spring for every slide
 
 Every slide animates under the same spring — `stiffness: 320, damping: 32,
 mass: 0.9` — so a drag, a click, or an arrow key all resolve with the same
@@ -66,12 +65,24 @@ animate={{ x, rotateY, z, scale, opacity }}
 transition={MORPH_SPRING}
 ```
 
-## Why transform, not layout
-
 `x`, `rotateY`, `z`, `scale`, and `opacity` are the only properties that
 ever change. All five compose onto one GPU layer per slide — the browser
 never re-measures or re-paints the stage while it drags or settles, no
 matter how many slides are stacked in depth.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<CoverFlowResult />} isResult>
+
+Every piece, assembled — drag it, click a side slide, or tab in and use the
+arrow keys.
+
+One signed distance, one spring, and a drag gesture that never touches a
+slide directly — that's the whole carousel.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility
 
@@ -89,13 +100,3 @@ const z = reduce ? 0 : -Math.min(abs, 3) * 130;
 ## Motion Score
 
 <MotionScorePanel name="cover-flow" />
-
-## The result
-
-Every piece, assembled — drag it, click a side slide, or tab in and use the
-arrow keys.
-
-<CoverFlowResult />
-
-One signed distance, one spring, and a drag gesture that never touches a
-slide directly — that's the whole carousel.

--- a/apps/docs/content/docs/components/layout/gooey-stack/learn.mdx
+++ b/apps/docs/content/docs/components/layout/gooey-stack/learn.mdx
@@ -1,14 +1,29 @@
 ---
 title: Anatomy of Gooey Stack
 description: How stacked cards fuse into a liquid metaball bridge — three layers, one SVG filter, and a band-pass that only turns the goo on while surfaces are actually close.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="Three layers, same two cards"
+  scene={<GooeyStackAnatomy />}
+  code={`{/* Merge surface — full-size silhouettes fused under the goo filter */}
+<motion.div style={{ opacity: gooOpacity, filter: \`url(#\${filterId})\` }}>
+  {items.map((_, i) => <motion.div className="absolute bg-card" ... />)}
+</motion.div>
+
+{/* Native surface — real DOM cards with CSS borders */}
+<motion.div style={{ opacity: nativeOpacity }}>
+  {items.map((_, i) => <motion.div className="absolute border border-border bg-card" ... />)}
+</motion.div>`}
+>
 
 Gooey Stack never bends a border-radius or animates a `border-radius` or a
 `clip-path`. The liquid look is an SVG filter fusing rectangles, cross-faded
 against the plain crisp cards underneath — and only while it needs to be.
 Here's the whole trick.
-
-## Three layers, same two cards
 
 Every card position is drawn three times. A **merge surface** (blurred
 silhouettes, behind everything) gets pushed through the goo filter so close
@@ -17,21 +32,19 @@ borders) sits on top of it, pixel-perfect at every zoom. Your **content**
 sits on top of that, unfiltered and always sharp — it recedes and frosts
 with the cards, but text never blurs into soup.
 
-<GooeyStackAnatomy />
+</LearnChapter>
 
-```tsx
-{/* Merge surface — full-size silhouettes fused under the goo filter */}
-<motion.div style={{ opacity: gooOpacity, filter: `url(#${filterId})` }}>
-  {items.map((_, i) => <motion.div className="absolute bg-card" ... />)}
-</motion.div>
+<LearnChapter
+  label="Nearness: a band-pass, not a threshold"
+  scene={<GooeyStackNearness />}
+  code={`const nearnessAt = (g, expandedGap, collapsedGap) =>
+  clamp((expandedGap - g) / Math.max(1, expandedGap - 4), 0, 1) *
+  clamp((g - collapsedGap) / 20, 0, 1);
 
-{/* Native surface — real DOM cards with CSS borders */}
-<motion.div style={{ opacity: nativeOpacity }}>
-  {items.map((_, i) => <motion.div className="absolute border border-border bg-card" ... />)}
-</motion.div>
-```
-
-## Nearness: a band-pass, not a threshold
+const nearness = useTransform(gapSpring, (live) => nearnessAt(live, expandedGap, collapsedGap));
+const gooOpacity = useTransform(nearness, (v) => (reduce ? 0 : v));
+const nativeOpacity = useTransform(nearness, (v) => (reduce ? 1 : 1 - v));`}
+>
 
 The goo shouldn't show at rest — not fanned out, and not fully merged either
 (a receded card should leave no ghost behind the anchor). `nearness` is a
@@ -40,24 +53,24 @@ are actually necking. Watch the slow loop below — four held steps so the
 cross-fade is obvious: apart → necking (goo on) → merged (goo off) →
 necking out.
 
-<GooeyStackNearness />
-
-```tsx
-const nearnessAt = (g, expandedGap, collapsedGap) =>
-  clamp((expandedGap - g) / Math.max(1, expandedGap - 4), 0, 1) *
-  clamp((g - collapsedGap) / 20, 0, 1);
-
-const nearness = useTransform(gapSpring, (live) => nearnessAt(live, expandedGap, collapsedGap));
-const gooOpacity = useTransform(nearness, (v) => (reduce ? 0 : v));
-const nativeOpacity = useTransform(nearness, (v) => (reduce ? 1 : 1 - v));
-```
-
 It reads off a **spring following the live gap**, not the target gap
 directly — at both rest ends the target's nearness is already 0, so
 deriving the cross-fade from the target alone would mean the goo never
 appears mid-toggle at all.
 
-## The goo filter
+</LearnChapter>
+
+<LearnChapter
+  label="The goo filter"
+  scene={<GooeyStackFilter />}
+  code={`<feGaussianBlur in="SourceGraphic" stdDeviation={gooeyness} result="blur" />
+<feColorMatrix
+  in="blur"
+  mode="matrix"
+  values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 80 -40"
+  result="goo"
+/>`}
+>
 
 Two SVG primitives do the fusing: `feGaussianBlur` softens the source into
 overlapping halos, then `feColorMatrix` multiplies the alpha channel back up
@@ -66,41 +79,40 @@ blur" into "one hard-edged fused shape," almost without anti-aliasing. The
 demo crawls through the same four steps so you can see the bridge form and
 tear apart.
 
-<GooeyStackFilter />
-
-```tsx
-<feGaussianBlur in="SourceGraphic" stdDeviation={gooeyness} result="blur" />
-<feColorMatrix
-  in="blur"
-  mode="matrix"
-  values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 80 -40"
-  result="goo"
-/>
-```
-
 The real filter also regrows a thin, radially-symmetric border ring around
 the fused shape from a second small blur + threshold pass — a Gaussian
 stays round at corners and through the neck, where a box-shadow or clip-path
 approach would go square or wobble with curvature.
 
-## Why filter and opacity, not layout
+Why filter and opacity, not layout? Nothing here ever animates
+`border-radius`, `height`, or `clip-path`. Cards move on `y`/`scale`/`opacity`,
+blur is a static `filter` on a layer that itself only fades in and out —
+every frame is compositor work, whether there are two cards or a dozen
+stacked behind the anchor.
 
-Nothing here ever animates `border-radius`, `height`, or `clip-path`. Cards
-move on `y`/`scale`/`opacity`, blur is a static `filter` on a layer that
-itself only fades in and out — every frame is compositor work, whether
-there are two cards or a dozen stacked behind the anchor.
-
-## Cheap when idle
-
-A `ResizeObserver` per card keeps the stack's height and each card's bottom
-offset registered to its real content — so the layout survives text
-reflow or a resize without measuring on every animation frame. The observer
-only fires on actual size changes, not on every spring tick.
+Cheap when idle: a `ResizeObserver` per card keeps the stack's height and
+each card's bottom offset registered to its real content — so the layout
+survives text reflow or a resize without measuring on every animation frame.
+The observer only fires on actual size changes, not on every spring tick.
 
 ```tsx
 const ro = new ResizeObserver(measure);
 for (const el of contentRefs.current) if (el) ro.observe(el);
 ```
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<GooeyStackResult />} isResult>
+
+Every piece, assembled — tap the plug and watch the prompt card merge in,
+then split back out.
+
+Two silhouette layers, one band-pass, and a filter that only ever touches
+pixels that are actually close — that's the whole liquid effect.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility
 
@@ -113,13 +125,3 @@ springing through the neck.
 ## Motion Score
 
 <MotionScorePanel name="gooey-stack" />
-
-## The result
-
-Every piece, assembled — tap the plug and watch the prompt card merge in,
-then split back out.
-
-<GooeyStackResult />
-
-Two silhouette layers, one band-pass, and a filter that only ever touches
-pixels that are actually close — that's the whole liquid effect.

--- a/apps/docs/content/docs/components/layout/hero-parallax/learn.mdx
+++ b/apps/docs/content/docs/components/layout/hero-parallax/learn.mdx
@@ -1,13 +1,21 @@
 ---
 title: Anatomy of Hero Parallax
 description: How one scroll progress value drives a tilting 3D plane and three rows drifting in alternating directions, all through spring-smoothed transforms.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="Two motion values, three rows"
+  scene={<HeroParallaxAnatomy />}
+  code={`const translateX = useSpring(useTransform(scrollYProgress, [0, 1], [0, 1000]), SPRING);
+const translateXReverse = useSpring(useTransform(scrollYProgress, [0, 1], [0, -1000]), SPRING);`}
+>
 
 Hero Parallax reads exactly one number off the page — `scrollYProgress` —
 and feeds it into five `useTransform` mappings. No scroll listeners per
 row, no manual rAF loop. Here's how one number becomes a drifting 3D grid.
-
-## Two motion values, three rows
 
 Rows don't each get their own scroll math. There are only two: `translateX`
 (scroll `[0,1]` → `[0, 1000]`) and `translateXReverse` (`[0,1]` →
@@ -15,13 +23,6 @@ Rows don't each get their own scroll math. There are only two: `translateX`
 row 2 reads the second and lays out plain `flex-row` — that swap of layout
 direction against the *same-signed* motion is the entire "alternating
 drift" illusion.
-
-<HeroParallaxAnatomy />
-
-```tsx
-const translateX = useSpring(useTransform(scrollYProgress, [0, 1], [0, 1000]), SPRING);
-const translateXReverse = useSpring(useTransform(scrollYProgress, [0, 1], [0, -1000]), SPRING);
-```
 
 ```tsx
 <motion.div className="flex flex-row-reverse ...">   {/* row 1 & 3 */}
@@ -32,7 +33,16 @@ const translateXReverse = useSpring(useTransform(scrollYProgress, [0, 1], [0, -1
 </motion.div>
 ```
 
-## The plane settles fast; the rows keep drifting
+</LearnChapter>
+
+<LearnChapter
+  label="The plane settles fast; the rows keep drifting"
+  scene={<HeroParallaxScrub />}
+  code={`const rotateX = useSpring(useTransform(scrollYProgress, [0, 0.2], [15, 0]), SPRING);
+const rotateZ = useSpring(useTransform(scrollYProgress, [0, 0.2], [20, 0]), SPRING);
+const translateY = useSpring(useTransform(scrollYProgress, [0, 0.2], [-700, 200]), SPRING);
+const opacity = useSpring(useTransform(scrollYProgress, [0, 0.2], [0.2, 1]), SPRING);`}
+>
 
 The whole plane's `rotateX`, `rotateZ`, `translateY`, and `opacity` all map
 from `scrollYProgress` over just `[0, 0.2]` — the tilt is gone and the
@@ -41,21 +51,10 @@ plane is fully visible after the first fifth of the scroll. The row
 spreading the cards apart for the entire 300vh. Two different scroll
 windows on the same signal, composited together.
 
-<HeroParallaxScrub />
-
-```tsx
-const rotateX = useSpring(useTransform(scrollYProgress, [0, 0.2], [15, 0]), SPRING);
-const rotateZ = useSpring(useTransform(scrollYProgress, [0, 0.2], [20, 0]), SPRING);
-const translateY = useSpring(useTransform(scrollYProgress, [0, 0.2], [-700, 200]), SPRING);
-const opacity = useSpring(useTransform(scrollYProgress, [0, 0.2], [0.2, 1]), SPRING);
-```
-
 Every one of those runs through the same `useSpring({ stiffness: 320,
 damping: 32, mass: 0.9 })` before it reaches the DOM, so a fast scroll or a
 scrollbar drag never snaps the plane — it always eases toward wherever
 `scrollYProgress` currently points.
-
-## Why transform, not scroll offsets
 
 `rotateX`/`rotateZ`/`translateY`/`translateX`/`opacity` are the only
 properties in motion. The container's `[perspective:1000px]
@@ -67,6 +66,21 @@ per-row listeners.
 ```tsx
 className="relative flex h-[300vh] flex-col ... [perspective:1000px] [transform-style:preserve-3d]"
 ```
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<HeroParallaxResult />} isResult>
+
+Every piece, assembled — scroll inside the panel below to watch the plane
+un-tilt and the rows drift apart. It starts already mid-reveal so the cards
+are visible right away.
+
+One scroll progress value, five spring-smoothed mappings, and a layout swap
+that turns identical math into opposite drift — that's the whole hero.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility and reduced motion
 
@@ -91,14 +105,3 @@ if (reduce) {
 ## Motion Score
 
 <MotionScorePanel name="hero-parallax" />
-
-## The result
-
-Every piece, assembled — scroll inside the panel below to watch the plane
-un-tilt and the rows drift apart. It starts already mid-reveal so the cards
-are visible right away.
-
-<HeroParallaxResult />
-
-One scroll progress value, five spring-smoothed mappings, and a layout swap
-that turns identical math into opposite drift — that's the whole hero.

--- a/apps/docs/content/docs/components/layout/holographic-card/learn.mdx
+++ b/apps/docs/content/docs/components/layout/holographic-card/learn.mdx
@@ -1,15 +1,25 @@
 ---
 title: Anatomy of Holographic Card
 description: How the same spring that tilts Tilt Card also slides an iridescent foil across a dark base, and why one blend mode makes it read as light instead of paint.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="Four masks, one blend mode"
+  scene={<HolographicCardAnatomy />}
+  code={`const FOIL_LAYER =
+  "pointer-events-none absolute inset-0 mix-blend-color-dodge " +
+  "[background-size:200%_200%] [background-position:var(--holo-x)_var(--holo-y)] " +
+  "[mask-image:radial-gradient(75%_75%_at_var(--holo-x)_var(--holo-y),#000_0%,rgba(0,0,0,0.4)_55%,transparent_100%)]";`}
+>
 
 Holographic Card reuses Tilt Card's entire pointer-to-spring pipeline —
 same normalized coordinates, same spring constants — and spends its own
 complexity on one thing: making the tilt also drive a foil that looks like
 it's catching real light. Here's the layer stack and the blend mode that
 sells it.
-
-## Four masks, one blend mode
 
 The card is a dark base with three `absolute inset-0` layers stacked on top:
 a diagonal foil gradient, a glitter dot mask, and a soft radial glare —
@@ -18,25 +28,14 @@ base wherever the layer above it is bright and leaves it untouched where the
 layer is dark. That's what makes a flat gradient read as light hitting foil
 instead of a color painted over the card.
 
-<HolographicCardAnatomy />
-
-```tsx
-const FOIL_LAYER =
-  "pointer-events-none absolute inset-0 mix-blend-color-dodge " +
-  "[background-size:200%_200%] [background-position:var(--holo-x)_var(--holo-y)] " +
-  "[mask-image:radial-gradient(75%_75%_at_var(--holo-x)_var(--holo-y),#000_0%,rgba(0,0,0,0.4)_55%,transparent_100%)]";
-```
-
 The `mask-image` is the other half of the trick: the foil is masked to a
 radial gradient centered on the same pointer position, so the iridescence
 concentrates where the "light" is hitting rather than flooding the whole
 card evenly.
 
-## The tilt, borrowed wholesale
-
-`rotateX`/`rotateY` come from the identical spring pipeline as Tilt Card —
-same normalized pointer, same `{ stiffness: 170, damping: 12, mass: 0.1 }`
-spring:
+The tilt is borrowed wholesale. `rotateX`/`rotateY` come from the identical
+spring pipeline as Tilt Card — same normalized pointer, same
+`{ stiffness: 170, damping: 12, mass: 0.1 }` spring:
 
 ```tsx
 const rotateX = useTransform(sy, [-0.5, 0.5], [maxTilt, -maxTilt]);
@@ -53,7 +52,18 @@ const holoY = useTransform(sy, [-0.5, 0.5], ["0%", "100%"]);
 style={{ rotateX, rotateY, "--holo-x": holoX, "--holo-y": holoY }}
 ```
 
-## The foil that catches the light
+</LearnChapter>
+
+<LearnChapter
+  label="The foil that catches the light"
+  scene={<HolographicCardFoil />}
+  code={`const FOIL: Record<HolographicVariant, string> = {
+  rainbow: "[background-image:linear-gradient(115deg,#ff2d95,#ffd84d,#4dff9e,#4dd2ff,#a24dff,#ff2d95)]",
+  aurora:  "[background-image:linear-gradient(115deg,#22d3ee,#34d399,#a3e635,#38bdf8,#22d3ee)]",
+  galaxy:  "[background-image:linear-gradient(115deg,#a855f7,#ec4899,#3b82f6,#c026d3,#a855f7)]",
+  gold:    "[background-image:linear-gradient(115deg,#b45309,#fbbf24,#fffbeb,#fbbf24,#b45309)]",
+};`}
+>
 
 `--holo-x`/`--holo-y` land on `background-position` for the foil, the
 sparkle mask, and the glare's `radial-gradient` center all at once. One
@@ -61,26 +71,14 @@ pointer value moves the card *and* slides the foil across it in the same
 gesture — turn the card and the color visibly travels with the tilt, exactly
 like a real trading-card holo catching the light at an angle.
 
-<HolographicCardFoil />
+Each `variant` swaps the gradient stops but keeps the mechanism identical.
 
-Each `variant` swaps the gradient stops but keeps the mechanism identical:
-
-```tsx
-const FOIL: Record<HolographicVariant, string> = {
-  rainbow: "[background-image:linear-gradient(115deg,#ff2d95,#ffd84d,#4dff9e,#4dd2ff,#a24dff,#ff2d95)]",
-  aurora:  "[background-image:linear-gradient(115deg,#22d3ee,#34d399,#a3e635,#38bdf8,#22d3ee)]",
-  galaxy:  "[background-image:linear-gradient(115deg,#a855f7,#ec4899,#3b82f6,#c026d3,#a855f7)]",
-  gold:    "[background-image:linear-gradient(115deg,#b45309,#fbbf24,#fffbeb,#fbbf24,#b45309)]",
-};
-```
-
-## Optional: the gyroscope
-
-On a touch device there's no pointer to move, so `gyroscope` opts into
-reading `deviceorientation` instead — `gamma`/`beta` map onto the same
-`px`/`py` motion values the pointer would have set. iOS gates the sensor
-behind a permission prompt that must fire from a user gesture, so the
-listener requests it lazily on the first tap rather than on mount:
+Optional: the gyroscope. On a touch device there's no pointer to move, so
+`gyroscope` opts into reading `deviceorientation` instead — `gamma`/`beta`
+map onto the same `px`/`py` motion values the pointer would have set. iOS
+gates the sensor behind a permission prompt that must fire from a user
+gesture, so the listener requests it lazily on the first tap rather than on
+mount:
 
 ```tsx
 const requestOnTap = () => {
@@ -97,6 +95,20 @@ if (typeof orientationEvent.requestPermission === "function") {
 
 Because it writes into the same `px`/`py` values as the pointer handler, the
 spring, the tilt, and the foil don't need to know which input drove them.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<HolographicCardResult />} isResult>
+
+Move your pointer across each card — the foil, the glitter, and the glare
+all shift together as it tilts.
+
+Borrow the spring, add a CSS variable, mask a gradient to it — that's the
+whole holo effect.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility
 
@@ -117,13 +129,3 @@ if (reduceMotion) {
 ## Motion Score
 
 <MotionScorePanel name="holographic-card" />
-
-## The result
-
-Move your pointer across each card — the foil, the glitter, and the glare
-all shift together as it tilts.
-
-<HolographicCardResult />
-
-Borrow the spring, add a CSS variable, mask a gradient to it — that's the
-whole holo effect.

--- a/apps/docs/content/docs/components/layout/image-accordion/learn.mdx
+++ b/apps/docs/content/docs/components/layout/image-accordion/learn.mdx
@@ -1,25 +1,15 @@
 ---
 title: Anatomy of the Image Accordion
 description: How a hover-expand gallery gets away with animating flex-grow directly — a layout property — instead of chasing the usual transform-only rule, and why that's the right trade here.
+learnPlayer: true
 ---
 
-Most "grows on hover" UI fakes width with a `scale` transform, because
-animating layout properties is expensive. `ImageAccordion` doesn't bother —
-it transitions `flex-grow` on the panel itself. That's only safe because the
-whole system is small, bounded, and interaction-driven rather than
-continuous: five panels, one property, triggered once per hover.
+<LearnPlayer>
 
-## One panel, two states
-
-Every panel is a single button (or anchor) that carries all of its own
-state through `data-active`. There's no separate "expanded" component —
-the image, the scrim, the label, and the caption are always in the DOM;
-only their filters and opacity/transform swap:
-
-<ImageAccordionAnatomy />
-
-```tsx
-<Tag
+<LearnChapter
+  label="One panel, two states"
+  scene={<ImageAccordionAnatomy />}
+  code={`<Tag
   data-active={isActive}
   aria-expanded={isActive}
   style={{ flexGrow: isActive ? activeGrow : 1, flexBasis: 0 }}
@@ -31,14 +21,27 @@ only their filters and opacity/transform swap:
   />
   {/* collapsed vertical label, opacity-only */}
   {/* expanded caption: opacity + translateY, underline delayed 120ms */}
-</Tag>
-```
+</Tag>`}
+>
+
+Most "grows on hover" UI fakes width with a `scale` transform, because
+animating layout properties is expensive. `ImageAccordion` doesn't bother —
+it transitions `flex-grow` on the panel itself. That's only safe because the
+whole system is small, bounded, and interaction-driven rather than
+continuous: five panels, one property, triggered once per hover.
+
+Every panel is a single button (or anchor) that carries all of its own
+state through `data-active`. There's no separate "expanded" component —
+the image, the scrim, the label, and the caption are always in the DOM;
+only their filters and opacity/transform swap.
 
 The image gets its own timeline (700ms transform, 550ms filter) — slightly
 slower than the panel's own grow, so the zoom keeps drifting for a beat
 after the width settles instead of finishing in lockstep with it.
 
-## The grow
+</LearnChapter>
+
+<LearnChapter label="The grow" scene={<ImageAccordionGrow />}>
 
 `flexGrow` flips between `1` and `activeGrow` (default `5`) on
 `onPointerEnter` / `onClick` / `onFocus`, and the whole row redistributes
@@ -47,8 +50,6 @@ snappy-then-settling curve used across GodUI for anything that "arrives."
 `onPointerLeave` resets to `defaultIndex`, so moving off the whole strip
 always returns to a known panel rather than leaving whichever was last
 active stuck open.
-
-<ImageAccordionGrow />
 
 The diagram loops the same mutual handoff: one slot takes the `5fr`, the
 other three stay at `1fr`, so the outgoing panel visibly compresses as the
@@ -59,14 +60,24 @@ again. That's the trade that makes it fine to break the transform-only
 rule here: bounded, discrete, and it buys a change that `transform`
 genuinely can't express cleanly.
 
-## Why not just scale the active panel?
+Why not just scale the active panel? A `scale()` on the active panel would
+zoom its content without changing how much horizontal space it actually
+occupies — the neighbors wouldn't compress, and the image would need a
+matching inverse-scale correction to avoid distorting alongside the
+container. Real `flex-grow` gets both effects — growth and compression —
+from a single property, at the cost of one bounded reflow instead of zero.
 
-A `scale()` on the active panel would zoom its content without changing
-how much horizontal space it actually occupies — the neighbors wouldn't
-compress, and the image would need a matching inverse-scale correction to
-avoid distorting alongside the container. Real `flex-grow` gets both effects
-— growth and compression — from a single property, at the cost of one
-bounded reflow instead of zero.
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<ImageAccordionResult />} isResult>
+
+One state (`active`), one CSS transition, and every visual — width, image
+color, caption — reads it independently through `data-[active=true]`. Hover
+or tab across the panels above to feel the full 550ms settle.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility
 
@@ -81,11 +92,3 @@ transition to an instant switch under `prefers-reduced-motion`.
 ## Motion Score
 
 <MotionScorePanel name="image-accordion" />
-
-## The result
-
-<ImageAccordionResult />
-
-One state (`active`), one CSS transition, and every visual — width, image
-color, caption — reads it independently through `data-[active=true]`. Hover
-or tab across the panels above to feel the full 550ms settle.

--- a/apps/docs/content/docs/components/layout/image-compare/learn.mdx
+++ b/apps/docs/content/docs/components/layout/image-compare/learn.mdx
@@ -1,46 +1,49 @@
 ---
 title: Anatomy of the Image Compare
 description: How a before/after slider stays a single clip-path on the top layer, why the drag transition disappears while you're actually dragging, and what the slider role buys you for free.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="Two layers, one boundary"
+  scene={<ImageCompareAnatomy />}
+  code={`const clip = horizontal
+  ? \`inset(0 \${100 - pos}% 0 0)\`
+  : \`inset(0 0 \${100 - pos}% 0)\`;
+
+<div className="[&_img]:size-full [&_img]:object-cover">{after}</div>
+<div style={{ clipPath: clip }} className="absolute inset-0">
+  {before}
+</div>`}
+>
 
 `ImageCompare` looks like it needs two synced images and a lot of pointer
 math. It's actually one number — `pos`, 0 to 100 — read by three things: a
 `clip-path` on the top layer, the divider's `left`, and the handle's `left`.
 Nothing else in the component cares where the handle is.
 
-## Two layers, one boundary
-
 The "after" image sits underneath, full-bleed, always fully painted. The
 "before" image sits on top of it, clipped to `` inset(0 ${100 - pos}% 0 0) ``
 so only the region left of the handle is visible — everything to the right
-is still there in the DOM, just clipped away:
-
-<ImageCompareAnatomy />
-
-```tsx
-const clip = horizontal
-  ? `inset(0 ${100 - pos}% 0 0)`
-  : `inset(0 0 ${100 - pos}% 0)`;
-
-<div className="[&_img]:size-full [&_img]:object-cover">{after}</div>
-<div style={{ clipPath: clip }} className="absolute inset-0">
-  {before}
-</div>
-```
+is still there in the DOM, just clipped away.
 
 Both `<img>`s decode and paint up front — dragging never swaps sources or
 triggers a repaint of the image itself, only the clip boundary moves.
 
-## The drag has no transition — on purpose
+</LearnChapter>
+
+<LearnChapter
+  label="The drag has no transition — on purpose"
+  scene={<ImageCompareScrub />}
+  code={`const transition = dragging ? "" : "[transition:clip-path_120ms_ease-out]";`}
+>
 
 While `dragging` is true, `pos` updates with zero transition: the clip
 boundary tracks the pointer 1:1, every pixel of pointer movement becomes a
 pixel of clip movement, with no easing lag to fight. The 120ms
-`ease-out` only turns on once the pointer lets go:
-
-```tsx
-const transition = dragging ? "" : "[transition:clip-path_120ms_ease-out]";
-```
+`ease-out` only turns on once the pointer lets go.
 
 That's the opposite of most "smoothed" drag UI: smoothing here would mean
 the boundary visibly lags the cursor, which reads as latency. The eased
@@ -48,22 +51,18 @@ transition exists for the *other* way `pos` changes — keyboard steps — where
 a discrete jump benefits from a little easing to feel intentional rather
 than teleported.
 
-<ImageCompareScrub />
-
 The loop above swaps the literal `clip-path` for an opacity crossfade so it
 can run forever without a timed layout property — the real component only
 ever transitions `clip-path` for 120ms per keyboard press, never
 continuously, so this substitution doesn't change the mechanism, just how
 it's illustrated.
 
-## The handle is a slider, not a button
-
-The grabber is a `role="slider"` with `aria-valuemin`/`max`/`now`, so a
-screen reader announces it as a position control, not a generic clickable
-icon. `onKeyDown` moves it by `2` normally or `10` with <kbd>Shift</kbd>
-held, clamped to `[0, 100]` the same way the pointer handler is — one
-`clamp()` shared by both input paths, so keyboard and pointer can never
-disagree about the valid range:
+The handle is a slider, not a button. The grabber is a `role="slider"` with
+`aria-valuemin`/`max`/`now`, so a screen reader announces it as a position
+control, not a generic clickable icon. `onKeyDown` moves it by `2` normally
+or `10` with <kbd>Shift</kbd> held, clamped to `[0, 100]` the same way the
+pointer handler is — one `clamp()` shared by both input paths, so keyboard
+and pointer can never disagree about the valid range:
 
 ```tsx
 const step = e.shiftKey ? 10 : 2;
@@ -75,6 +74,17 @@ The handle itself scales on hover (`110%`) and press (`95%`) over 150ms —
 a much shorter, snappier timeline than the drag itself, so the grab
 affordance feels immediate even while the boundary it's attached to is
 still catching up.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<ImageCompareResult />} isResult>
+
+One `pos` value, one `clip-path`, one `role="slider"` — drag the handle
+above or tab to it and use the arrow keys.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility
 
@@ -89,10 +99,3 @@ it as a discrete state change rather than motion to gate.
 ## Motion Score
 
 <MotionScorePanel name="image-compare" />
-
-## The result
-
-<ImageCompareResult />
-
-One `pos` value, one `clip-path`, one `role="slider"` — drag the handle
-above or tab to it and use the arrow keys.

--- a/apps/docs/content/docs/components/layout/inertia-gallery/learn.mdx
+++ b/apps/docs/content/docs/components/layout/inertia-gallery/learn.mdx
@@ -1,23 +1,15 @@
 ---
 title: Anatomy of the Inertia Gallery
 description: How a throwable gallery gets momentum, elasticity, and distance-based scale/opacity/blur from a single motion value, and why none of it triggers a React re-render while it's moving.
+learnPlayer: true
 ---
 
-`InertiaGallery` is one draggable `motion.div` and one `MotionValue`. Every
-slide's scale, opacity, and blur are `useTransform` chains reading that
-same value — there's no per-slide state, no `onDrag` re-render loop, and no
-manual momentum math. Framer's own animation loop drives all of it.
+<LearnPlayer>
 
-## One track, one motion value
-
-The whole strip is a single flex row wrapped in a masked, `overflow-hidden`
-viewport. `x` is the one `MotionValue` everything downstream reads —
-dragging the track never touches React state:
-
-<InertiaGalleryAnatomy />
-
-```tsx
-const x = useMotionValue(-start * pitch);
+<LearnChapter
+  label="One track, one motion value"
+  scene={<InertiaGalleryAnatomy />}
+  code={`const x = useMotionValue(-start * pitch);
 
 <div className="overflow-hidden [mask-image:linear-gradient(to_right,transparent,black_8%,black_92%,transparent)]">
   <motion.div
@@ -27,65 +19,83 @@ const x = useMotionValue(-start * pitch);
     dragElastic={0.16}
     onDragEnd={handleDragEnd}
   />
-</div>
-```
+</div>`}
+>
+
+`InertiaGallery` is one draggable `motion.div` and one `MotionValue`. Every
+slide's scale, opacity, and blur are `useTransform` chains reading that
+same value — there's no per-slide state, no `onDrag` re-render loop, and no
+manual momentum math. Framer's own animation loop drives all of it.
+
+The whole strip is a single flex row wrapped in a masked, `overflow-hidden`
+viewport. `x` is the one `MotionValue` everything downstream reads —
+dragging the track never touches React state:
 
 The viewport pads each side by half the free space (measured with a
 `ResizeObserver`), which is what lets the first and last slide land dead
 center instead of pinned to an edge.
 
-## The throw
+</LearnChapter>
+
+<LearnChapter
+  label="The throw"
+  scene={<InertiaGalleryDrag />}
+  code={`const SETTLE_SPRING = { type: "spring", stiffness: 320, damping: 32, mass: 0.9 };
+
+const handleDragEnd = () => {
+  if (snap) goTo(nearest());
+  else commit(nearest());
+};`}
+>
 
 `dragElastic: 0.16` lets the track travel a little past its constraints
 while you're still holding it — a small give, not a hard wall. Release, and
 `onDragEnd` either commits the nearest slide (`commit`) or, with `snap`,
 animates `x` to it on a spring:
 
-```tsx
-const SETTLE_SPRING = { type: "spring", stiffness: 320, damping: 32, mass: 0.9 };
-
-const handleDragEnd = () => {
-  if (snap) goTo(nearest());
-  else commit(nearest());
-};
-```
-
-<InertiaGalleryDrag />
-
 Stiffness `320` with damping `32` is tuned to slightly underdamp — the
 strip overshoots the target by a few pixels before it settles, rather than
 arriving dead-on. `mass: 0.9` keeps that overshoot small; it's felt, not
 seen.
 
-## The falloff
+</LearnChapter>
+
+<LearnChapter
+  label="The falloff"
+  scene={<InertiaGalleryFalloff />}
+  code={`const nd = useTransform(x, (xv) =>
+  Math.min(Math.abs(offset + xv) / pitch, 2.4),
+);
+const scale = useTransform(nd, (d) => 1 - d * 0.14 * falloff);
+const opacity = useTransform(nd, (d) => clamp(1 - d * 0.3 * falloff, 0.4, 1));
+const blurPx = useTransform(nd, (d) => (reduce ? 0 : Math.min(d * 3.2, 5) * falloff));`}
+>
 
 Every slide runs the same three-curve chain off its own distance from
 center, computed from the shared `x` value with `useTransform` — nothing
 here is per-slide state, it's a pure function re-evaluated on every frame
 `x` changes:
 
-```tsx
-const nd = useTransform(x, (xv) =>
-  Math.min(Math.abs(offset + xv) / pitch, 2.4),
-);
-const scale = useTransform(nd, (d) => 1 - d * 0.14 * falloff);
-const opacity = useTransform(nd, (d) => clamp(1 - d * 0.3 * falloff, 0.4, 1));
-const blurPx = useTransform(nd, (d) => (reduce ? 0 : Math.min(d * 3.2, 5) * falloff));
-```
-
-<InertiaGalleryFalloff />
-
 Because `scale`, `opacity`, and `filter` are all compositor properties,
 Framer can update every slide's falloff every frame without asking the
 browser to lay anything out — the whole strip can be dragged at 60fps+
 regardless of how many slides are off-screen.
 
-## Cheap when idle
-
 Nothing here runs a `requestAnimationFrame` loop of its own. `useTransform`
 only recomputes when its input `MotionValue` changes, and `x` only changes
 while a drag or a settle animation is in flight — a gallery sitting still
 costs nothing beyond the one `ResizeObserver` watching the viewport.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<InertiaGalleryResult />} isResult>
+
+One motion value, three distance curves, one settle spring — throw the
+strip above, or use the buttons.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility
 
@@ -100,10 +110,3 @@ feel switched off.
 ## Motion Score
 
 <MotionScorePanel name="inertia-gallery" />
-
-## The result
-
-<InertiaGalleryResult />
-
-One motion value, three distance curves, one settle spring — throw the
-strip above, or use the buttons.

--- a/apps/docs/content/docs/components/layout/morph-gallery/learn.mdx
+++ b/apps/docs/content/docs/components/layout/morph-gallery/learn.mdx
@@ -1,13 +1,34 @@
 ---
 title: Anatomy of Morph Gallery
 description: How one shared layoutId, a spring, and an independent backdrop tween combine so a grid tile morphs into a fullscreen detail view with no cross-fade seam.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="One layoutId, two measured boxes"
+  scene={<MorphGalleryAnatomy />}
+  code={`<motion.img
+  layoutId={reduce ? undefined : \`\${uid}-\${i}\`}
+  src={item.src}
+  alt={item.alt}
+  transition={MORPH_SPRING}
+  className="size-full object-cover"
+/>
+
+<motion.img
+  layoutId={reduce ? undefined : \`\${uid}-\${open}\`}
+  src={current.src}
+  alt={current.alt}
+  transition={MORPH_SPRING}
+  className="max-h-[70vh] w-auto max-w-full rounded-2xl object-contain"
+/>`}
+>
 
 Morph Gallery doesn't cross-fade between a thumbnail and a lightbox — it
 morphs the *same* image element between two boxes. Here's the identity that
 makes that work, and the two independent timelines riding on top of it.
-
-## One layoutId, two measured boxes
 
 Every tile's `motion.img` and the detail view's `motion.img` share a single
 Framer Motion `layoutId`, generated once per gallery with `React.useId()` so
@@ -16,33 +37,26 @@ mounted before the transition and whichever one mounts after, then
 interpolates the image's box between them every frame. There's no "morph"
 animation to write by hand — mounting the detail view *is* the animation.
 
-<MorphGalleryAnatomy />
-
-```tsx
-<motion.img
-  layoutId={reduce ? undefined : `${uid}-${i}`}
-  src={item.src}
-  alt={item.alt}
-  transition={MORPH_SPRING}
-  className="size-full object-cover"
-/>
-```
-
-```tsx
-<motion.img
-  layoutId={reduce ? undefined : `${uid}-${open}`}
-  src={current.src}
-  alt={current.alt}
-  transition={MORPH_SPRING}
-  className="max-h-[70vh] w-auto max-w-full rounded-2xl object-contain"
-/>
-```
-
 Nothing else carries the `layoutId`. The prev/next/close buttons, the
 caption, and the backdrop are ordinary markup layered around the one element
 that actually moves.
 
-## The morph: one spring, one tween
+</LearnChapter>
+
+<LearnChapter
+  label="The morph: one spring, one tween"
+  scene={<MorphGalleryMorph />}
+  code={`// SPRING.smooth — shared-layout morph.
+const MORPH_SPRING = { type: "spring", stiffness: 320, damping: 32, mass: 0.9 } as const;
+
+<motion.div
+  className="fixed inset-0 z-modal grid place-items-center bg-background/80 backdrop-blur-sm"
+  initial={{ opacity: 0 }}
+  animate={{ opacity: 1 }}
+  exit={{ opacity: 0 }}
+  transition={{ duration: 0.2 }}
+/>`}
+>
 
 `MORPH_SPRING` — `{ stiffness: 320, damping: 32, mass: 0.9 }` — is the only
 transition on the image itself. The backdrop that dims the page behind it is
@@ -52,38 +66,31 @@ tween finishes well before the spring has fully settled the image into the
 detail box, and on close the backdrop is already gone before the image
 finishes travelling back to its grid slot.
 
-<MorphGalleryMorph />
+Why a shared layoutId instead of a manual tween? Framer's layout animation
+doesn't tween `width`/`height` directly — under the hood it applies a
+`scale` + `translate` correction on the compositor each frame, then un-scales
+the content so it doesn't stretch. That's exactly why this technique is
+cheap: the browser never re-lays-out the image mid-morph, it just repaints a
+transformed layer. Writing the equivalent by hand would mean measuring both
+boxes with `getBoundingClientRect` and driving your own FLIP animation —
+`layoutId` gets you the same result for one line per image.
 
-```tsx
-// SPRING.smooth — shared-layout morph.
-const MORPH_SPRING = { type: "spring", stiffness: 320, damping: 32, mass: 0.9 } as const;
-```
+Cheap when closed: when `open` is `null`, the `AnimatePresence` around the
+backdrop renders nothing — no dialog markup, no image clone, no listeners
+beyond the grid's own `onClick` handlers. The gallery's idle cost is just
+the grid of buttons.
 
-```tsx
-<motion.div
-  className="fixed inset-0 z-modal grid place-items-center bg-background/80 backdrop-blur-sm"
-  initial={{ opacity: 0 }}
-  animate={{ opacity: 1 }}
-  exit={{ opacity: 0 }}
-  transition={{ duration: 0.2 }}
-/>
-```
+</LearnChapter>
 
-## Why a shared layoutId instead of a manual tween
+<LearnChapter label="The result" scene={<MorphGalleryResult />} isResult>
 
-Framer's layout animation doesn't tween `width`/`height` directly — under the
-hood it applies a `scale` + `translate` correction on the compositor each
-frame, then un-scales the content so it doesn't stretch. That's exactly why
-this technique is cheap: the browser never re-lays-out the image mid-morph,
-it just repaints a transformed layer. Writing the equivalent by hand would
-mean measuring both boxes with `getBoundingClientRect` and driving your own
-FLIP animation — `layoutId` gets you the same result for one line per image.
+One `layoutId`, one spring, one independent backdrop tween — that's the whole
+illusion. The browser never measures a manual FLIP; it just morphs a
+transformed layer and dims the page underneath it.
 
-## Cheap when closed
+</LearnChapter>
 
-When `open` is `null`, the `AnimatePresence` around the backdrop renders
-nothing — no dialog markup, no image clone, no listeners beyond the grid's
-own `onClick` handlers. The gallery's idle cost is just the grid of buttons.
+</LearnPlayer>
 
 ## Accessibility and reduced motion
 
@@ -109,11 +116,3 @@ with a plain opacity tween instead of morphing across the screen.
 ## Motion Score
 
 <MotionScorePanel name="morph-gallery" />
-
-## The result
-
-<MorphGalleryResult />
-
-One `layoutId`, one spring, one independent backdrop tween — that's the whole
-illusion. The browser never measures a manual FLIP; it just morphs a
-transformed layer and dims the page underneath it.

--- a/apps/docs/content/docs/components/layout/orbit-carousel/learn.mdx
+++ b/apps/docs/content/docs/components/layout/orbit-carousel/learn.mdx
@@ -1,30 +1,31 @@
 ---
 title: Anatomy of Orbit Carousel
 description: How one signed offset drives position, tilt, scale, and opacity for every slide on the arc, and how a drag rewrites that offset live before a spring settles it.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="One offset, five properties"
+  scene={<OrbitCarouselAnatomy />}
+  code={`const a = offset * angleStep;
+const rad = (a * Math.PI) / 180;
+const x = radius * Math.sin(rad);
+const y = radius * (1 - Math.cos(rad));
+const scale = 1 - Math.min(Math.abs(a) / 70, 1) * 0.42;
+const opacity = Math.max(0, 1 - Math.min(Math.abs(a) / 82, 1) * 0.85);`}
+>
 
 Orbit Carousel doesn't animate five slides independently — it derives all
 five from a single number per slide (`offset = i - active`) fed through one
 arc formula. Here's that formula, and the drag that keeps rewriting it in
 real time.
 
-## One offset, five properties
-
 Each slide reads its own `offset` and turns it into `angle = offset *
 angleStep`. Everything else — `x`, `y`, `scale`, `opacity`, `rotate` — is a
 function of that one angle. The front slide (`offset = 0`) sits full-size and
 upright; every step away curves along the arc, shrinks, dims, and tilts.
-
-<OrbitCarouselAnatomy />
-
-```tsx
-const a = offset * angleStep;
-const rad = (a * Math.PI) / 180;
-const x = radius * Math.sin(rad);
-const y = radius * (1 - Math.cos(rad));
-const scale = 1 - Math.min(Math.abs(a) / 70, 1) * 0.42;
-const opacity = Math.max(0, 1 - Math.min(Math.abs(a) / 82, 1) * 0.85);
-```
 
 ```tsx
 <motion.div
@@ -38,7 +39,20 @@ const opacity = Math.max(0, 1 - Math.min(Math.abs(a) / 82, 1) * 0.85);
 slide is visibly smaller before it's visibly faded. That's a deliberate
 two-stage falloff, not one number reused twice.
 
-## The motion: pan rewrites `active`, a spring settles it
+</LearnChapter>
+
+<LearnChapter
+  label="The motion: pan rewrites active, a spring settles it"
+  scene={<OrbitCarouselOrbit />}
+  code={`const handlePan = (_e: unknown, info: PanInfo) => {
+  goTo(Math.round(dragFrom.current - info.offset.x / 120));
+};
+const handlePanEnd = (_e: unknown, info: PanInfo) => {
+  if (Math.abs(info.velocity.x) > 500) {
+    goTo(active - Math.sign(info.velocity.x));
+  }
+};`}
+>
 
 Dragging doesn't move any slide directly. `onPan` recomputes `active` on
 every pointer move — `goTo(dragFrom - offset.x / 120)` — and every slide's
@@ -47,25 +61,10 @@ moves the DOM; the pointer just keeps changing where the spring is chasing.
 Release past the fling threshold and `active` gets one more nudge before the
 spring even starts settling toward it.
 
-<OrbitCarouselOrbit />
-
-```tsx
-const handlePan = (_e: unknown, info: PanInfo) => {
-  goTo(Math.round(dragFrom.current - info.offset.x / 120));
-};
-const handlePanEnd = (_e: unknown, info: PanInfo) => {
-  if (Math.abs(info.velocity.x) > 500) {
-    goTo(active - Math.sign(info.velocity.x));
-  }
-};
-```
-
 Because `active` is a plain rounded integer even mid-drag, every slide is
 already animating toward its next resting angle as soon as the pointer
 crosses the halfway point to the next slot — there's no separate "commit"
 step; the drag handler and the settle spring share the exact same state.
-
-## Why transform, not layout
 
 Every property `OrbitItem` animates — `x`, `y`, `rotate`, `scale`, `opacity`
 — is a `transform`/`opacity` pair, set directly in the `style` object as
@@ -82,6 +81,17 @@ recalculation; the browser only repaints transformed layers.
 />
 ```
 
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<OrbitCarouselResult />} isResult>
+
+One offset, one formula, one spring chasing whatever `active` the drag or
+the keyboard last set — that's the entire wheel.
+
+</LearnChapter>
+
+</LearnPlayer>
+
 ## Accessibility and reduced motion
 
 The stage is `role="group"` with `aria-roledescription="carousel"`, and the
@@ -97,10 +107,3 @@ animate={{ x, y, rotate: reduce ? 0 : a * 0.5, scale, opacity }}
 ## Motion Score
 
 <MotionScorePanel name="orbit-carousel" />
-
-## The result
-
-<OrbitCarouselResult />
-
-One offset, one formula, one spring chasing whatever `active` the drag or
-the keyboard last set — that's the entire wheel.

--- a/apps/docs/content/docs/components/layout/progressive-card-reveal/learn.mdx
+++ b/apps/docs/content/docs/components/layout/progressive-card-reveal/learn.mdx
@@ -1,7 +1,18 @@
 ---
 title: Anatomy of Progressive Card Reveal
 description: How one activeIndex, a distance-based funnel, and a layout-driven width morph combine so exactly one card in a stack ever expands at a time.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="One activeIndex, five cards react"
+  scene={<ProgressiveCardRevealAnatomy />}
+  code={`const expanded = index === reveal.activeIndex;
+const distance = Math.abs(index - reveal.activeIndex);
+const depth = reveal.maxDepth != null ? Math.min(distance, reveal.maxDepth) : distance;`}
+>
 
 Progressive Card Reveal never toggles a card's own "am I open" flag — every
 card compares its position to one shared `activeIndex` and funnels its width
@@ -9,20 +20,10 @@ accordingly. Here's how five cards asking the same question produces a
 symmetric funnel, and the one place this component chooses a real layout
 animation over a transform trick.
 
-## One activeIndex, five cards react
-
 The root is fully controlled: it holds `activeIndex` and hands it down
 through context. Each `Card` reads its own position from a second context
 (assigned automatically by `React.Children.map`, so you never pass an index
 by hand), then derives `expanded` and `distance` itself.
-
-<ProgressiveCardRevealAnatomy />
-
-```tsx
-const expanded = index === reveal.activeIndex;
-const distance = Math.abs(index - reveal.activeIndex);
-const depth = reveal.maxDepth != null ? Math.min(distance, reveal.maxDepth) : distance;
-```
 
 ```tsx
 function collapsedWidth(distance: number) {
@@ -35,7 +36,20 @@ No card knows about its siblings. The funnel — wider near the active card,
 narrower toward the edges — is an emergent property of five independent
 `distance` calculations, not a hand-authored gradient.
 
-## The funnel morph
+</LearnChapter>
+
+<LearnChapter
+  label="The funnel morph"
+  scene={<ProgressiveCardRevealFunnel />}
+  code={`<motion.div
+  layout={!reducedMotion}
+  transition={reducedMotion ? { duration: 0 } : LAYOUT_TRANSITION}
+  style={{
+    width: expanded ? EXPANDED_WIDTH : collapsedWidth(depth),
+    borderRadius: expanded ? EXPANDED_RADIUS : COLLAPSED_RADIUS,
+  }}
+/>`}
+>
 
 `width` and `borderRadius` are the only two properties that change when a
 card expands or collapses, and both ride on `motion.div`'s `layout` prop —
@@ -46,19 +60,6 @@ the row's real width, and its neighbours actually need to give some up — a
 `scale` transform can't redistribute space between siblings, only a layout
 animation can.
 
-<ProgressiveCardRevealFunnel />
-
-```tsx
-<motion.div
-  layout={!reducedMotion}
-  transition={reducedMotion ? { duration: 0 } : LAYOUT_TRANSITION}
-  style={{
-    width: expanded ? EXPANDED_WIDTH : collapsedWidth(depth),
-    borderRadius: expanded ? EXPANDED_RADIUS : COLLAPSED_RADIUS,
-  }}
-/>
-```
-
 `LAYOUT_TRANSITION` is `{ stiffness: 320, damping: 32, mass: 0.9 }` — kept
 close to critically damped (critical ≈ 2·√stiffness ≈ 35.8) on purpose.
 Underdamping here would make the moving edges wobble as the width settles,
@@ -68,8 +69,6 @@ which reads as a flick rather than a resize.
 inverse-scale correction to radius when it's a style value — animating it
 through `animate` instead would let the layout scale-correction warp the
 corners as the box resizes.
-
-## Content doesn't reflow mid-morph
 
 The collapsed and expanded content are two different subtrees, swapped by
 `AnimatePresence mode="popLayout"`. `popLayout` pulls the exiting view out of
@@ -93,14 +92,24 @@ The collapsed pill's `exit` has `duration: 0` — on click it vanishes
 instantly instead of fading out, so the expanded view never crossfades over
 a lingering ghost of the pill it replaced.
 
-## The hover lift is a transform, deliberately
-
 Hovering a collapsed card scales it to `1.03` via `whileHover` — a transform,
 not a width change. Reusing `width` for the hover lift would re-lay-out the
 card's right-aligned content on every spring frame, which reads as a
 flicker. `scale` and `width` are independent animated values on the same
 element, so a later `activeIndex` change still updates width correctly even
 mid-hover.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<ProgressiveCardRevealResult />} isResult>
+
+One shared index, a distance formula five cards each run for themselves, and
+one deliberate layout animation for the width handoff a transform can't
+fake — that's the whole funnel.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility and reduced motion
 
@@ -113,11 +122,3 @@ their target width instead of morphing.
 ## Motion Score
 
 <MotionScorePanel name="progressive-card-reveal" />
-
-## The result
-
-<ProgressiveCardRevealResult />
-
-One shared index, a distance formula five cards each run for themselves, and
-one deliberate layout animation for the width handoff a transform can't
-fake — that's the whole funnel.

--- a/apps/docs/content/docs/components/layout/reorder-list/learn.mdx
+++ b/apps/docs/content/docs/components/layout/reorder-list/learn.mdx
@@ -1,7 +1,23 @@
 ---
 title: Anatomy of Reorder List
 description: How a data attribute (not whileDrag) drives the grab lift, and how one spring resolves the dragged item and every displaced neighbor together.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="Group, item, and a data-driven lift"
+  scene={<ReorderListAnatomy />}
+  code={`<Reorder.Item
+  value={value}
+  data-dragging={dragging || undefined}
+  transition={REORDER_SPRING}
+  onDragStart={() => setDragging(true)}
+  onDragEnd={() => setDragging(false)}
+  className="... [transition:scale_150ms_ease] data-[dragging]:scale-[1.03]"
+>`}
+>
 
 Reorder List leans almost entirely on Motion's built-in drag-to-reorder
 primitives — `Reorder.Group` and `Reorder.Item` already know how to swap
@@ -9,26 +25,11 @@ values and animate the rest of the list around a drag. The interesting
 decisions here are in what this component deliberately does *not* let
 Framer drive: the lift.
 
-## Group, item, and a data-driven lift
-
 Each row is a `Reorder.Item` with a `value` inside one `Reorder.Group`
 holding the ordered array and the `onReorder` callback. The grab lift —
 `scale-[1.03]` and a shadow — isn't a Framer `whileDrag` animation. It's a
 plain `data-dragging` attribute flipped by `onDragStart`/`onDragEnd`, read by
 a Tailwind `data-[dragging]:scale-[1.03]` and a CSS `transition`.
-
-<ReorderListAnatomy />
-
-```tsx
-<Reorder.Item
-  value={value}
-  data-dragging={dragging || undefined}
-  transition={REORDER_SPRING}
-  onDragStart={() => setDragging(true)}
-  onDragEnd={() => setDragging(false)}
-  className="... [transition:scale_150ms_ease] data-[dragging]:scale-[1.03]"
->
-```
 
 `whileDrag` was the first approach, and it has a real failure mode: a
 `scale`/`boxShadow` animation driven that way can get stranded as an inline
@@ -48,20 +49,20 @@ main-thread paint property; `opacity` is compositor-only.
 />
 ```
 
-## Neighbor flow
+</LearnChapter>
+
+<LearnChapter
+  label="Neighbor flow"
+  scene={<ReorderListFlow />}
+  code={`// Snappy enough that neighbours flow out of the way instantly, but with a
+// little spring so items settle rather than snap.
+const REORDER_SPRING = { type: "spring" as const, stiffness: 520, damping: 32 };`}
+>
 
 What Framer *does* own is the reordering itself. The moment a dragged
 item's center crosses a neighbour's, `Reorder.Group` swaps them in the
 `values` array and calls `onReorder` — every item, dragged or not, then
 animates to its new slot under the same `REORDER_SPRING`.
-
-<ReorderListFlow />
-
-```tsx
-// Snappy enough that neighbours flow out of the way instantly, but with a
-// little spring so items settle rather than snap.
-const REORDER_SPRING = { type: "spring" as const, stiffness: 520, damping: 32 };
-```
 
 ```tsx
 <Reorder.Item value={value} transition={REORDER_SPRING}>
@@ -71,8 +72,6 @@ Stiffness 520 with damping 32 is snappier than the 320/32 spring used
 elsewhere in the library — a list reorder needs to feel instantaneous, not
 smoothed, or the displaced rows read as sluggish while a hand is still
 holding the dragged one.
-
-## Why the position lives in `values`, not local state
 
 `ReorderList` never keeps its own copy of the order. `values` and
 `onReorder` are both owned by the caller — the component is a rendering and
@@ -88,6 +87,18 @@ list (persistence, undo, syncing to a server) just reacts to the same
 </ReorderList>
 ```
 
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<ReorderListResult />} isResult>
+
+One built-in reorder primitive for the list, one intentionally CSS-driven
+lift so a stray drop can never strand an inline style — that's the whole
+mechanism.
+
+</LearnChapter>
+
+</LearnPlayer>
+
 ## Accessibility and reduced motion
 
 Rows are real `<li>` elements inside a `<ul>` (`Reorder.Group`'s `as="ul"`
@@ -101,11 +112,3 @@ gesture itself still works.
 ## Motion Score
 
 <MotionScorePanel name="reorder-list" />
-
-## The result
-
-<ReorderListResult />
-
-One built-in reorder primitive for the list, one intentionally CSS-driven
-lift so a stray drop can never strand an inline style — that's the whole
-mechanism.

--- a/apps/docs/content/docs/components/layout/scroll-stack/learn.mdx
+++ b/apps/docs/content/docs/components/layout/scroll-stack/learn.mdx
@@ -1,14 +1,25 @@
 ---
 title: Anatomy of Scroll Stack
 description: How one scroll progress value turns plain sticky elements into a stack of cards that pin, bury, and scale — with no scroll-jacking and no per-card listeners.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="One pinTop, three sticky cards"
+  scene={<ScrollStackAnatomy />}
+  code={`<div className={\`sticky flex items-center justify-center \${trackClass}\`} style={{ top: pinTop }}>
+  <motion.div style={{ scale, filter, translateY: index * peek, transformOrigin: "center top" }}>
+    {children}
+  </motion.div>
+</div>`}
+>
 
 `ScrollStack` doesn't move anything to make cards "stack." Every card is a
 plain `position: sticky` element pinned to the same offset; the stacking
 illusion comes entirely from one shared scroll progress value driving each
 card's own scale, brightness, and blur as it gets buried.
-
-## One pinTop, three sticky cards
 
 Every card sits inside its own track — `h-screen` when the stack tracks the
 page, or `h-full` when it's self-contained — and pins to the same `top:
@@ -17,20 +28,25 @@ later cards render after earlier ones in the DOM, a later card's sticky
 box visually covers the one before it; the only thing keeping the buried
 card visible at all is a small `translateY` offset.
 
-<ScrollStackAnatomy />
-
-```tsx
-<div className={`sticky flex items-center justify-center ${trackClass}`} style={{ top: pinTop }}>
-  <motion.div style={{ scale, filter, translateY: index * peek, transformOrigin: "center top" }}>
-    {children}
-  </motion.div>
-</div>
-```
-
 `peek` (default `16`) is that offset — just enough of the buried card's
 edge to read as depth without the stack looking like a random pile.
 
-## The bury
+</LearnChapter>
+
+<LearnChapter
+  label="The bury"
+  scene={<ScrollStackBury />}
+  code={`const finalScale = Math.max(baseScale, 1 - depth * (1 - baseScale) * 0.5);
+const buriedBrightness = Math.max(0.6, 1 - depth * 0.08);
+const buriedBlur = depth * (blur ? 2 : 0);
+
+const scale = useTransform(progress, [0, segmentEnd, 1], [1, 1, finalScale]);
+const filter = useTransform(progress, [0, segmentEnd, 1], [
+  "brightness(1) blur(0px)",
+  "brightness(1) blur(0px)",
+  \`brightness(\${buriedBrightness}) blur(\${buriedBlur}px)\`,
+]);`}
+>
 
 `depth` is how many cards end up stacked on top of a given one
 (`total - 1 - index`), and it's the only input to that card's `scale` and
@@ -39,26 +55,9 @@ edge to read as depth without the stack looking like a random pile.
 and `filter` ease from resting values toward the buried ones over the rest
 of the scroll:
 
-<ScrollStackBury />
-
-```tsx
-const finalScale = Math.max(baseScale, 1 - depth * (1 - baseScale) * 0.5);
-const buriedBrightness = Math.max(0.6, 1 - depth * 0.08);
-const buriedBlur = depth * (blur ? 2 : 0);
-
-const scale = useTransform(progress, [0, segmentEnd, 1], [1, 1, finalScale]);
-const filter = useTransform(progress, [0, segmentEnd, 1], [
-  "brightness(1) blur(0px)",
-  "brightness(1) blur(0px)",
-  `brightness(${buriedBrightness}) blur(${buriedBlur}px)`,
-]);
-```
-
 The `Math.max(baseScale, …)` clamp means a two-card stack never buries its
 back card past `baseScale` even though the formula alone would ask for
 more — depth stays readable instead of shrinking to a speck.
-
-## Page track vs. self-contained scroller
 
 `ScrollStack` reads exactly one `useScroll` call, and which mode it uses
 flips on a single check:
@@ -78,6 +77,18 @@ stack's total height is `total` viewports of scroll distance. Pass
 `height` and it becomes its own scroll viewport instead, useful anywhere
 you don't want to dedicate that much page scroll to it — inside a bounded
 panel, a modal, or (as below) a docs preview.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<ScrollStackResult />} isResult>
+
+One `scrollYProgress`, one `depth`-driven transform per card, and a resting
+list for anyone who'd rather not watch things scale and blur as they
+scroll.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility
 
@@ -99,11 +110,3 @@ if (reduce) {
 ## Motion Score
 
 <MotionScorePanel name="scroll-stack" />
-
-## The result
-
-<ScrollStackResult />
-
-One `scrollYProgress`, one `depth`-driven transform per card, and a resting
-list for anyone who'd rather not watch things scale and blur as they
-scroll.

--- a/apps/docs/content/docs/components/layout/spin-viewer/learn.mdx
+++ b/apps/docs/content/docs/components/layout/spin-viewer/learn.mdx
@@ -1,56 +1,55 @@
 ---
 title: Anatomy of Spin Viewer
 description: How dragging a 360° product shot down to a rounded division and an array index — no 3D, no Framer Motion, just a discrete frame swap.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="An array and an index"
+  scene={<SpinViewerAnatomy />}
+  code={`for (const src of frames) {
+  const img = new Image();
+  img.onload = done;
+  img.onerror = done;
+  img.src = src;
+}`}
+>
 
 `SpinViewer` doesn't simulate a 3D object at all. It's an ordered array of
 photos and a `<img src={frames[index]} />` — "rotating" the object is
 nothing but changing `index`. Every mechanism in the component exists to
 make that one `src` swap feel physical.
 
-## An array and an index
-
 On mount, every frame preloads with a plain `new Image()` before the
 viewer marks itself `ready` — that's what makes the first drag instant
 instead of a flash of broken/loading images:
-
-<SpinViewerAnatomy />
-
-```tsx
-for (const src of frames) {
-  const img = new Image();
-  img.onload = done;
-  img.onerror = done;
-  img.src = src;
-}
-```
 
 Once ready, the whole visible surface is one `<img>` whose `src` swaps —
 never a tween, never an opacity cross-fade between two frames. That's why
 the scene above steps discretely instead of easing: a real frame swap has
 no in-between state to animate through.
 
-## The drag
+</LearnChapter>
+
+<LearnChapter
+  label="The drag"
+  scene={<SpinViewerDrag />}
+  code={`const dx = e.clientX - drag.current.x;
+const stepped = Math.round(dx / sensitivity) * (reverse ? -1 : 1);
+setIndex(mod(drag.current.i + stepped, count));`}
+>
 
 `onPointerDown` snapshots the pointer's `clientX` and the current `index`.
 `onPointerMove` does the only math in the whole gesture — how many
 `sensitivity`-px ticks the pointer has crossed since then, rounded to a
 whole step:
 
-<SpinViewerDrag />
-
-```tsx
-const dx = e.clientX - drag.current.x;
-const stepped = Math.round(dx / sensitivity) * (reverse ? -1 : 1);
-setIndex(mod(drag.current.i + stepped, count));
-```
-
 With the default `sensitivity={6}`, a 60px drag steps through 10 frames —
 drag slower and nothing moves until you cross the next 6px tick, which is
 exactly why a slow, deliberate drag feels more "mechanical" than a fast
 flick: the fast flick blurs past ticks the eye never resolves.
-
-## Idle auto-rotate, until grabbed
 
 `autoRotate` runs its own tiny `requestAnimationFrame` loop, independent
 of the drag math — it accumulates `(dt / 1000) * autoRotateSpeed` frames
@@ -69,6 +68,16 @@ The loop bails out the moment `dragging`, `reduced`, or `!ready` is true —
 grabbing the viewer or preferring reduced motion stops it outright, it
 never fights the user's drag.
 
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<SpinViewerResult />} isResult>
+
+One array, one index, one preload pass — drag above, or watch it idle.
+
+</LearnChapter>
+
+</LearnPlayer>
+
 ## Accessibility
 
 The root is `role="img"` with a descriptive `aria-label`, so screen
@@ -81,9 +90,3 @@ since it's a deliberate user action rather than motion the page imposed.
 ## Motion Score
 
 <MotionScorePanel name="spin-viewer" />
-
-## The result
-
-<SpinViewerResult />
-
-One array, one index, one preload pass — drag above, or watch it idle.

--- a/apps/docs/content/docs/components/layout/stack-badge/learn.mdx
+++ b/apps/docs/content/docs/components/layout/stack-badge/learn.mdx
@@ -1,24 +1,15 @@
 ---
 title: Anatomy of the Stack Badge
 description: A tech-stack wall built from one flex row, a lookup table that normalizes built-in and custom logos to the same shape, and two independent springs — one that enters once, one that only ever plays on hover.
+learnPlayer: true
 ---
 
-A tech-stack wall usually means dropping in a row of brand SVGs and calling it
-done. `StackBadge` treats that row as two problems: normalizing whatever you
-hand it (a built-in name or a custom `{ name, icon, color }`) into one uniform
-chip shape, and layering exactly two motions onto that chip — an entrance that
-fires once, and a hover that fires forever.
+<LearnPlayer>
 
-## One pill, two tokens
-
-Every chip is the same `inline-flex items-center rounded-full` row — an icon,
-then a label — regardless of whether it came from the built-in registry or a
-custom object:
-
-<StackBadgeAnatomy />
-
-```tsx
-function resolveItem(item: StackBadgeItem, size: number): ResolvedItem {
+<LearnChapter
+  label="One pill, two tokens"
+  scene={<StackBadgeAnatomy />}
+  code={`function resolveItem(item: StackBadgeItem, size: number): ResolvedItem {
   if (typeof item === "string") {
     const entry: TechEntry = TECH[item];
     return {
@@ -27,7 +18,7 @@ function resolveItem(item: StackBadgeItem, size: number): ResolvedItem {
       color: entry.color,
       glow: entry.mono
         ? "color-mix(in oklch, var(--foreground) 16%, transparent)"
-        : `${entry.color}3d`,
+        : \`\${entry.color}3d\`,
       icon: <TechIcon path={entry.path} label={entry.label} size={size} />,
     };
   }
@@ -36,12 +27,22 @@ function resolveItem(item: StackBadgeItem, size: number): ResolvedItem {
     label: item.name,
     color: item.color,
     glow: item.color.startsWith("#")
-      ? `${item.color}3d`
+      ? \`\${item.color}3d\`
       : "color-mix(in oklch, var(--foreground) 16%, transparent)",
     icon: item.icon,
   };
-}
-```
+}`}
+>
+
+A tech-stack wall usually means dropping in a row of brand SVGs and calling it
+done. `StackBadge` treats that row as two problems: normalizing whatever you
+hand it (a built-in name or a custom `{ name, icon, color }`) into one uniform
+chip shape, and layering exactly two motions onto that chip — an entrance that
+fires once, and a hover that fires forever.
+
+Every chip is the same `inline-flex items-center rounded-full` row — an icon,
+then a label — regardless of whether it came from the built-in registry or a
+custom object.
 
 `resolveItem` is the whole trick: it runs before render and returns the same
 `{ key, label, color, glow, icon }` shape either way. The chip component below
@@ -51,12 +52,12 @@ with no color of their own) get a neutral `color-mix` glow instead of a hex
 suffix, so they still warm up on hover without inventing a brand color that
 doesn't exist.
 
-## Enter once, hover forever
+</LearnChapter>
 
-<StackBadgeStagger />
-
-```tsx
-<motion.div
+<LearnChapter
+  label="Enter once, hover forever"
+  scene={<StackBadgeStagger />}
+  code={`<motion.div
   initial={reduce || !animateIn ? false : { opacity: 0, y: 8 }}
   whileInView={reduce || !animateIn ? undefined : { opacity: 1, y: 0 }}
   viewport={{ once: true, margin: "0px 0px -10% 0px" }}
@@ -70,8 +71,8 @@ doesn't exist.
       ? undefined
       : { y: -3, transition: { type: "spring", stiffness: 520, damping: 32 } }
   }
+>`}
 >
-```
 
 `viewport={{ once: true }}` means the stagger spring is a one-shot: it plays
 the moment the row is 10% into view and Framer detaches the observer —
@@ -80,7 +81,12 @@ separate animation living on the same node; it has no `viewport`, no `once`,
 so it fires every time the pointer enters, indefinitely, for the lifetime of
 the chip. Two `transition` objects, two lifespans, one element.
 
-## The glow is a shadow, not a background swap
+The glow is a shadow, not a background swap. The halo is a `box-shadow`
+that's *already painted* at `opacity-0` — hovering only flips its opacity to
+1 over 240ms, so the glow itself never repaints or resizes, just fades in.
+`--glow` is set once per chip in inline `style` (the `3d` hex suffix or the
+`color-mix` fallback from `resolveItem`), so the shadow's color is fixed
+per-item and the transition only ever touches `opacity`.
 
 ```tsx
 {glow ? (
@@ -91,12 +97,18 @@ the chip. Two `transition` objects, two lifespans, one element.
 ) : null}
 ```
 
-The halo is a `box-shadow` that's *already painted* at `opacity-0` — hovering
-only flips its opacity to 1 over 240ms, so the glow itself never repaints or
-resizes, just fades in. `--glow` is set once per chip in inline `style` (the
-`3d` hex suffix or the `color-mix` fallback from `resolveItem`), so the
-shadow's color is fixed per-item and the transition only ever touches
-`opacity`.
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<StackBadgeResult />} isResult>
+
+A lookup table that normalizes every item to one shape, one spring that plays
+once on scroll-in, and one independent spring that plays forever on hover —
+scroll past this wall and nothing happens twice, but you can hover the same
+chip a hundred times.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Reduced motion turns off the trigger, not the transition
 
@@ -114,12 +126,3 @@ two springs are removed.
 ## Motion Score
 
 <MotionScorePanel name="stack-badge" />
-
-## The result
-
-<StackBadgeResult />
-
-A lookup table that normalizes every item to one shape, one spring that plays
-once on scroll-in, and one independent spring that plays forever on hover —
-scroll past this wall and nothing happens twice, but you can hover the same
-chip a hundred times.

--- a/apps/docs/content/docs/components/layout/stepper/learn.mdx
+++ b/apps/docs/content/docs/components/layout/stepper/learn.mdx
@@ -1,37 +1,33 @@
 ---
 title: Anatomy of Stepper
 description: How Stepper mixes three different motion techniques — a CSS color transition, a spring-filled connector, and an SVG pathLength draw — into one clean step-forward beat.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="One stateFor(i), three tones"
+  scene={<StepperAnatomy />}
+  code={`const stateFor = (i: number): StepState =>
+  i < active ? "complete" : i === active ? "active" : "upcoming";`}
+>
 
 `Stepper` looks like one animation when a step completes, but it's three
 independent techniques layered together, each picked for what it's
 animating rather than for consistency's sake.
 
-## One `stateFor(i)`, three tones
-
 Every circle's tone comes from a single comparison against `active` — no
-per-step config, no variants map:
+per-step config, no variants map. Connectors follow the same logic: the one
+between step `i` and `i + 1` fills only once `active > i` — the step before
+it is actually done, not just reached.
 
-<StepperAnatomy />
+</LearnChapter>
 
-```tsx
-const stateFor = (i: number): StepState =>
-  i < active ? "complete" : i === active ? "active" : "upcoming";
-```
-
-Connectors follow the same logic: the one between step `i` and `i + 1`
-fills only once `active > i` — the step before it is actually done, not
-just reached.
-
-## The motion
-
-Advancing a step fires three different animations at once, and each one
-is deliberately the "wrong" technique for the other two jobs:
-
-<StepperProgress />
-
-```tsx
-// the circle's border/background/text color — a plain CSS transition
+<LearnChapter
+  label="The motion"
+  scene={<StepperProgress />}
+  code={`// the circle's border/background/text color — a plain CSS transition
 className="[transition:background-color_250ms_ease,border-color_250ms_ease,color_250ms_ease,box-shadow_250ms_ease]"
 
 // the connector fill — a spring, so it can overshoot slightly
@@ -46,24 +42,23 @@ className="[transition:background-color_250ms_ease,border-color_250ms_ease,color
   initial={{ pathLength: 0 }}
   animate={{ pathLength: 1 }}
   transition={{ duration: 0.3, ease: "easeOut" }}
-/>
-```
+/>`}
+>
 
-## Why three techniques, not one
+Advancing a step fires three different animations at once, and each one
+is deliberately the "wrong" technique for the other two jobs.
 
-A color swap has no meaningful "motion" to it — a `transition` is cheaper
-than mounting a `motion` component for a property that's either on or off.
-The connector *is* motion — it's a line growing across visible space — so
-it gets the spring that gives every other GodUI surface transition its
-felt weight. The checkmark isn't a fade or a scale at all; `pathLength`
-draws the stroke the way a pen would, which a spring or an opacity fade
-can't reproduce. Each animation type is chosen for the shape of the change,
-not applied uniformly across the component.
+Why three techniques, not one? A color swap has no meaningful "motion" to
+it — a `transition` is cheaper than mounting a `motion` component for a
+property that's either on or off. The connector *is* motion — it's a line
+growing across visible space — so it gets the spring that gives every other
+GodUI surface transition its felt weight. The checkmark isn't a fade or a
+scale at all; `pathLength` draws the stroke the way a pen would, which a
+spring or an opacity fade can't reproduce. Each animation type is chosen for
+the shape of the change, not applied uniformly across the component.
 
-## Horizontal vs. vertical
-
-The same `Connector` component renders either orientation from one prop —
-only the animated axis and its origin flip:
+Horizontal vs. vertical: the same `Connector` component renders either
+orientation from one prop — only the animated axis and its origin flip.
 
 ```tsx
 animate={horizontal ? { scaleX: filled ? 1 : 0 } : { scaleY: filled ? 1 : 0 }}
@@ -73,6 +68,17 @@ className={horizontal ? "mt-[17px] h-0.5 flex-1" : "my-1 w-0.5 flex-1 self-cente
 `scaleX` from `origin-left` reads as "filling left to right"; `scaleY`
 from `origin-top` reads as "filling downward" — the same spring, aimed
 along whichever axis the layout actually flows.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<StepperResult />} isResult>
+
+One state comparison, three purpose-built animations, and a stepper that
+never feels like it's animating for animation's sake.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility
 
@@ -86,10 +92,3 @@ animating in.
 ## Motion Score
 
 <MotionScorePanel name="stepper" />
-
-## The result
-
-<StepperResult />
-
-One state comparison, three purpose-built animations, and a stepper that
-never feels like it's animating for animation's sake.

--- a/apps/docs/content/docs/components/layout/sticky-scroll/learn.mdx
+++ b/apps/docs/content/docs/components/layout/sticky-scroll/learn.mdx
@@ -1,40 +1,37 @@
 ---
 title: Anatomy of Sticky Scroll
 description: How one IntersectionObserver line and one active index drive a dimming list on the left and a crossfading sticky panel on the right — no scroll math, no per-item listeners.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="One active index, two columns"
+  scene={<StickyScrollAnatomy />}
+  code={`<div className="grid gap-x-10 md:grid-cols-2">
+  <div>{items.map((item, i) => <Section key={item.title} isActive={i === active} {...item} />)}</div>
+  <div className="hidden md:block">
+    <div className="sticky top-0 h-[30rem]">{items[active]?.content}</div>
+  </div>
+</div>`}
+>
 
 `StickyScroll` never reads a scroll offset. It watches for one thing —
 which item's element is crossing the container's vertical center — and
 every visual response, on both sides of the layout, follows from that
 single `active` index.
 
-## One active index, two columns
-
 The left column is a plain scrolling list; the right column is a
 `position: sticky` panel that always renders `items[active].content`.
-Neither column knows the other exists — they only share the index:
+Neither column knows the other exists — they only share the index.
 
-<StickyScrollAnatomy />
+</LearnChapter>
 
-```tsx
-<div className="grid gap-x-10 md:grid-cols-2">
-  <div>{items.map((item, i) => <Section key={item.title} isActive={i === active} {...item} />)}</div>
-  <div className="hidden md:block">
-    <div className="sticky top-0 h-[30rem]">{items[active]?.content}</div>
-  </div>
-</div>
-```
-
-## The trigger
-
-The detection is one `IntersectionObserver`, scoped to the component's own
-scroll container, with a `rootMargin` that collapses the entire viewport
-down to a single horizontal line at its center:
-
-<StickyScrollIo />
-
-```tsx
-const observer = new IntersectionObserver(
+<LearnChapter
+  label="The trigger"
+  scene={<StickyScrollIo />}
+  code={`const observer = new IntersectionObserver(
   (entries) => {
     for (const entry of entries) {
       if (entry.isIntersecting) {
@@ -44,20 +41,22 @@ const observer = new IntersectionObserver(
     }
   },
   { root: containerRef.current, rootMargin: "-50% 0px -50% 0px", threshold: 0 },
-);
-```
+);`}
+>
+
+The detection is one `IntersectionObserver`, scoped to the component's own
+scroll container, with a `rootMargin` that collapses the entire viewport
+down to a single horizontal line at its center.
 
 `-50%` off both the top and bottom of the root leaves nothing but a
 zero-height strip in the middle — an item only ever reports "intersecting"
 for the instant it's crossing that strip, so `active` always tracks
 whichever section is nearest the panel's vertical center.
 
-## Two springs, one state
-
-Once `active` changes, the left column and the right panel both react to
-it, on the same tuning, but through different Motion primitives — the
-list dims/brightens in place, while the panel replaces its content
-outright:
+Two springs, one state: once `active` changes, the left column and the right
+panel both react to it, on the same tuning, but through different Motion
+primitives — the list dims/brightens in place, while the panel replaces its
+content outright:
 
 ```tsx
 // left column — same element stays mounted, values animate
@@ -74,13 +73,22 @@ Both read the same `SPRING` constant (`stiffness: 320, damping: 32, mass:
 enter/exit swap, they resolve on the same beat and never feel like two
 separate systems.
 
-## Mobile falls back to inline
-
-Below the `md` breakpoint the sticky panel is simply `hidden` — there
-isn't room for a pinned column next to a scrolling one on a narrow
-screen. Each list item instead renders its own `content` inline,
-directly beneath its copy, so nothing is lost — it's just laid out
+Mobile falls back to inline: below the `md` breakpoint the sticky panel is
+simply `hidden` — there isn't room for a pinned column next to a scrolling
+one on a narrow screen. Each list item instead renders its own `content`
+inline, directly beneath its copy, so nothing is lost — it's just laid out
 top-to-bottom instead of side-by-side.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<StickyScrollResult />} isResult>
+
+One observer line, one active index, two independent renderers reading
+the same spring — scroll inside the panel above to watch it work.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility
 
@@ -92,10 +100,3 @@ any motion.
 ## Motion Score
 
 <MotionScorePanel name="sticky-scroll" />
-
-## The result
-
-<StickyScrollResult />
-
-One observer line, one active index, two independent renderers reading
-the same spring — scroll inside the panel above to watch it work.

--- a/apps/docs/content/docs/components/layout/store-badge/learn.mdx
+++ b/apps/docs/content/docs/components/layout/store-badge/learn.mdx
@@ -1,55 +1,56 @@
 ---
 title: Anatomy of the Store Badge
 description: An inline-SVG lockup that scales off one height prop, a sheen that crosses once instead of looping, and a QR popover that only exists for fine pointers.
+learnPlayer: true
 ---
 
-Download badges are usually a `<img src="app-store-badge.svg">` — a fixed
-bitmap you can't restyle or resize cleanly. `StoreBadge` draws the lockup
-itself: one `height` prop drives the icon, the two lines of text, and the
-padding, so the badge scales like a font instead of an image.
+<LearnPlayer>
 
-## The lockup, not a logo image
-
-<StoreBadgeAnatomy />
-
-```tsx
-const iconSize = Math.round(height * 0.52);
+<LearnChapter
+  label="The lockup, not a logo image"
+  scene={<StoreBadgeAnatomy />}
+  code={`const iconSize = Math.round(height * 0.52);
 const topSize = Math.max(9, Math.round(height * 0.17));
 const nameSize = Math.max(13, Math.round(height * 0.3));
 
 <a
   className="group/badge relative isolate inline-flex select-none items-center overflow-hidden ..."
   style={{
-    height: `${height}px`,
-    gap: `${Math.round(height * 0.17)}px`,
-    paddingInline: `${Math.round(height * 0.3)}px`,
-    borderRadius: `${Math.round(height * 0.18)}px`,
+    height: \`\${height}px\`,
+    gap: \`\${Math.round(height * 0.17)}px\`,
+    paddingInline: \`\${Math.round(height * 0.3)}px\`,
+    borderRadius: \`\${Math.round(height * 0.18)}px\`,
   }}
 >
   {store === "app-store" ? <AppleLogo size={iconSize} /> : <GooglePlayLogo size={iconSize} />}
   <span className="flex flex-col items-start leading-none">
-    <span style={{ fontSize: `${topSize}px` }}>{copy.top}</span>
-    <span style={{ fontSize: `${nameSize}px` }}>{copy.name}</span>
+    <span style={{ fontSize: \`\${topSize}px\` }}>{copy.top}</span>
+    <span style={{ fontSize: \`\${nameSize}px\` }}>{copy.name}</span>
   </span>
-</a>
-```
+</a>`}
+>
+
+Download badges are usually a `<img src="app-store-badge.svg">` — a fixed
+bitmap you can't restyle or resize cleanly. `StoreBadge` draws the lockup
+itself: one `height` prop drives the icon, the two lines of text, and the
+padding, so the badge scales like a font instead of an image.
 
 Every dimension — icon, gap, padding, corner radius, both text sizes — is a
 ratio of `height`, floored with `Math.max` so the caption never drops below a
 legible 9px. Hand it `height={72}` for a hero and `height={40}` for a footer;
 nothing else changes, because nothing else is a hardcoded pixel value.
 
-## The sheen, once per hover
+</LearnChapter>
 
-<StoreBadgeSheen />
-
-```tsx
-<span
+<LearnChapter
+  label="The sheen, once per hover"
+  scene={<StoreBadgeSheen />}
+  code={`<span
   aria-hidden
   className="pointer-events-none absolute inset-0 -translate-x-[130%] skew-x-[-12deg] transition-transform duration-700 ease-out group-hover/badge:translate-x-[130%] motion-reduce:hidden"
   style={{ background: "linear-gradient(105deg, transparent 20%, rgba(255,255,255,0.28) 50%, transparent 80%)" }}
-/>
-```
+/>`}
+>
 
 This isn't a shimmer that loops on an interval — it's a single `translate-x`
 transition parked off-screen left (`-130%`) that eases to off-screen right
@@ -59,7 +60,14 @@ instantly, ready for the next hover). The `-12deg` skew is what makes it read
 as a light streak crossing a curved badge edge instead of a rectangular bar
 sliding across a rectangular one.
 
-## The QR is a popover, not a modal
+The QR is a popover, not a modal. `matchMedia("(pointer: coarse)")` gates the
+whole feature: on touch, `show` is a no-op and the badge just links normally —
+there's no tap-to-reveal state to get stuck in on a phone. On a fine pointer,
+hover *or* focus (so keyboard users get it too) mounts the `AnimatePresence`
+child, which pops in on the same `{ stiffness: 520, damping: 32 }` spring used
+everywhere else in the library for menus and popovers. The QR itself is
+generated client-side from the badge's `href` (or an explicit `qrUrl`) — no
+image asset, no server round trip.
 
 ```tsx
 const mq = window.matchMedia("(pointer: coarse)");
@@ -84,14 +92,17 @@ const show = () => !coarse && setOpen(true);
 </span>
 ```
 
-`matchMedia("(pointer: coarse)")` gates the whole feature: on touch, `show`
-is a no-op and the badge just links normally — there's no tap-to-reveal state
-to get stuck in on a phone. On a fine pointer, hover *or* focus (so keyboard
-users get it too) mounts the `AnimatePresence` child, which pops in on the
-same `{ stiffness: 520, damping: 32 }` spring used everywhere else in the
-library for menus and popovers. The QR itself is generated client-side from
-the badge's `href` (or an explicit `qrUrl`) — no image asset, no server round
-trip.
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<StoreBadgeResult />} isResult>
+
+One `height` prop drives an entire scalable lockup, a sheen that crosses once
+per hover instead of looping, and a QR popover that only exists where a phone
+camera could actually use it — hover either badge below to see all three.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility
 
@@ -105,11 +116,3 @@ hover would.
 ## Motion Score
 
 <MotionScorePanel name="store-badge" />
-
-## The result
-
-<StoreBadgeResult />
-
-One `height` prop drives an entire scalable lockup, a sheen that crosses once
-per hover instead of looping, and a QR popover that only exists where a phone
-camera could actually use it — hover either badge below to see all three.

--- a/apps/docs/content/docs/components/layout/swipe-deck/learn.mdx
+++ b/apps/docs/content/docs/components/layout/swipe-deck/learn.mdx
@@ -1,19 +1,15 @@
 ---
 title: Anatomy of the Swipe Deck
 description: A card stack built from a rank formula instead of absolute layout, a drag gesture that maps distance straight to rotation, and a release that keeps the throw's own momentum through the exit spring.
+learnPlayer: true
 ---
 
-Swipeable decks are often built by absolutely positioning every card and
-recomputing offsets on each swipe. `SwipeDeck` keeps the stack as one
-formula applied to whatever rank a card currently holds, so "the next card
-moves up" is a spring on a number, not a layout recalculation.
+<LearnPlayer>
 
-## A stack is a formula, not a deck of positioned cards
-
-<SwipeDeckAnatomy />
-
-```tsx
-const BehindCard: React.FC<{ rank: number; children: React.ReactNode }> = ({ rank, children }) => (
+<LearnChapter
+  label="A stack is a formula, not a deck of positioned cards"
+  scene={<SwipeDeckAnatomy />}
+  code={`const BehindCard: React.FC<{ rank: number; children: React.ReactNode }> = ({ rank, children }) => (
   <motion.div
     style={{ zIndex: 30 - rank, transformOrigin: "top center" }}
     animate={{
@@ -25,8 +21,13 @@ const BehindCard: React.FC<{ rank: number; children: React.ReactNode }> = ({ ran
   >
     {children}
   </motion.div>
-);
-```
+);`}
+>
+
+Swipeable decks are often built by absolutely positioning every card and
+recomputing offsets on each swipe. `SwipeDeck` keeps the stack as one
+formula applied to whatever rank a card currently holds, so "the next card
+moves up" is a spring on a number, not a layout recalculation.
 
 Only the front card (`rank === 0`) is a `FrontCard` with drag handlers;
 everything behind it is a `BehindCard` whose entire visual state — scale,
@@ -37,12 +38,12 @@ animates each card from its old slot to its new one. There's no separate
 "promote" animation — it's the identical `STACK_SPRING` the deck already uses
 for steady state.
 
-## Drag maps to rotation, release keeps the throw
+</LearnChapter>
 
-<SwipeDeckFling />
-
-```tsx
-const rotate = useTransform(x, [-320, 0, 320], [-18, 0, 18], { clamp: true });
+<LearnChapter
+  label="Drag maps to rotation, release keeps the throw"
+  scene={<SwipeDeckFling />}
+  code={`const rotate = useTransform(x, [-320, 0, 320], [-18, 0, 18], { clamp: true });
 
 const handleDragEnd = (_e, info: PanInfo) => {
   const power = info.offset.x + info.velocity.x * 0.2;
@@ -53,8 +54,8 @@ const handleDragEnd = (_e, info: PanInfo) => {
   } else {
     animate(x, 0, { type: "spring", stiffness: 520, damping: 32, velocity: info.velocity.x });
   }
-};
-```
+};`}
+>
 
 `rotate` is a live `useTransform` of the drag's `x` motion value, so the tilt
 tracks the finger in real time with zero extra state. On release, `power`
@@ -63,7 +64,14 @@ a swipe even if it never crossed the raw `threshold` (110px), and a slow drag
 that overshoots the threshold but is decelerating still counts as a real
 commit rather than requiring a minimum speed.
 
-## The exit continues the gesture, it doesn't restart it
+The exit continues the gesture, it doesn't restart it. The exit spring's
+`velocity` is seeded with the *release* velocity from the drag, not zero. A
+fast flick flies off fast; a slow drag past threshold drifts off slowly —
+the card's exit speed is a direct continuation of how it was moving the
+instant you let go, which is why `{ stiffness: 60, damping: 16 }` reads as
+"thrown" rather than "faded out." A snapped-back drag (one that didn't clear
+the threshold) uses a different, snappier spring (`520 / 32`) seeded the same
+way, so even an aborted swipe still feels like it remembers your hand.
 
 ```tsx
 const controls = animate(x, sign * (width * 0.9 + 360), {
@@ -76,16 +84,10 @@ const controls = animate(x, sign * (width * 0.9 + 360), {
 });
 ```
 
-The exit spring's `velocity` is seeded with the *release* velocity from the
-drag, not zero. A fast flick flies off fast; a slow drag past threshold
-drifts off slowly — the card's exit speed is a direct continuation of how it
-was moving the instant you let go, which is why `{ stiffness: 60, damping:
-16 }` reads as "thrown" rather than "faded out." A snapped-back drag (one
-that didn't clear the threshold) uses a different, snappier spring (`520 /
-32`) seeded the same way, so even an aborted swipe still feels like it
-remembers your hand.
-
-## Keyboard parity
+Keyboard parity: arrow keys call the exact same `beginLeave` a completed drag
+would, just with a hardcoded velocity (±1200) standing in for a fast flick —
+so a keyboard user gets the same momentum-driven exit spring a mouse or touch
+gesture would produce, not a instant cut or a separate fade transition.
 
 ```tsx
 const handleKey = (e: React.KeyboardEvent) => {
@@ -94,20 +96,19 @@ const handleKey = (e: React.KeyboardEvent) => {
 };
 ```
 
-Arrow keys call the exact same `beginLeave` a completed drag would, just with
-a hardcoded velocity (±1200) standing in for a fast flick — so a keyboard
-user gets the same momentum-driven exit spring a mouse or touch gesture
-would produce, not a instant cut or a separate fade transition.
+</LearnChapter>
 
-## Motion Score
-
-<MotionScorePanel name="swipe-deck" />
-
-## The result
-
-<SwipeDeckResult />
+<LearnChapter label="The result" scene={<SwipeDeckResult />} isResult>
 
 One rank formula drives the whole stack, one `useTransform` maps drag to
 rotation, and one seeded spring makes the exit feel like it's still being
 thrown after you've let go — drag the front card, or use the buttons or arrow
 keys below.
+
+</LearnChapter>
+
+</LearnPlayer>
+
+## Motion Score
+
+<MotionScorePanel name="swipe-deck" />

--- a/apps/docs/content/docs/components/layout/three-d-marquee/learn.mdx
+++ b/apps/docs/content/docs/components/layout/three-d-marquee/learn.mdx
@@ -1,19 +1,15 @@
 ---
 title: Anatomy of the 3D Marquee
 description: A wall of flat images that reads as a tilted 3D plane from two CSS transforms, with per-column drift durations tuned so the grid never repeats in visible sync.
+learnPlayer: true
 ---
 
-`ThreeDMarquee` looks like it needs a 3D scene graph — a tilted grid of
-images drifting at different speeds with real depth. It's actually two CSS
-transforms on a flat grid of `<img>` tags, and a duration offset per column
-that keeps the drift from ever looking mechanical.
+<LearnPlayer>
 
-## Two rotations fake a 3D wall
-
-<ThreeDMarqueeAnatomy />
-
-```tsx
-<div className="relative ... [perspective:1200px]">
+<LearnChapter
+  label="Two rotations fake a 3D wall"
+  scene={<ThreeDMarqueeAnatomy />}
+  code={`<div className="relative ... [perspective:1200px]">
   <div className="w-[140%] scale-110">
     <div
       className="grid size-full origin-center gap-4 [transform:rotateX(55deg)_rotateZ(-45deg)]"
@@ -22,8 +18,13 @@ that keeps the drift from ever looking mechanical.
       {/* columns of <img> */}
     </div>
   </div>
-</div>
-```
+</div>`}
+>
+
+`ThreeDMarquee` looks like it needs a 3D scene graph — a tilted grid of
+images drifting at different speeds with real depth. It's actually two CSS
+transforms on a flat grid of `<img>` tags, and a duration offset per column
+that keeps the drift from ever looking mechanical.
 
 `perspective: 1200px` on the outer container is what gives the child's
 rotation any depth at all — without it, `rotateX`/`rotateZ` would just
@@ -36,20 +37,20 @@ corners project outside its own bounding box, so the grid is rendered oversize
 and re-scaled down to guarantee it still covers every corner of the visible
 container after rotation.
 
-## Per-column drift, never in sync
+</LearnChapter>
 
-<ThreeDMarqueeBob />
-
-```tsx
-<motion.div
+<LearnChapter
+  label="Per-column drift, never in sync"
+  scene={<ThreeDMarqueeBob />}
+  code={`<motion.div
   animate={{ y: colIndex % 2 === 0 ? [0, -40, 0] : [0, 40, 0] }}
   transition={{
     duration: 10 + colIndex,
     ease: [0.65, 0, 0.35, 1],
     repeat: Number.POSITIVE_INFINITY,
   }}
+>`}
 >
-```
 
 Every column loops the identical shape — up-and-back or down-and-back — but
 `duration: 10 + colIndex` gives column 0 a 10s cycle, column 1 an 11s cycle,
@@ -61,7 +62,11 @@ same shape decelerating into the turnaround as accelerating out of it — which
 is what keeps a `repeat: Infinity` bob from having a visible seam at the loop
 point.
 
-## `toColumns()` splits by position, not by image
+`images` is just a flat array — the component doesn't know or care what's in
+it. `toColumns` chunks it into `columns` sequential groups of
+`Math.ceil(length / columns)` each, and the `Math.min` clamp is what
+absorbs the remainder into the last column instead of ever producing a
+`columns + 1`'th bucket when the count doesn't divide evenly.
 
 ```tsx
 function toColumns<T>(items: T[], count: number): T[][] {
@@ -74,11 +79,17 @@ function toColumns<T>(items: T[], count: number): T[][] {
 }
 ```
 
-`images` is just a flat array — the component doesn't know or care what's in
-it. `toColumns` chunks it into `columns` sequential groups of
-`Math.ceil(length / columns)` each, and the `Math.min` clamp is what
-absorbs the remainder into the last column instead of ever producing a
-`columns + 1`'th bucket when the count doesn't divide evenly.
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<ThreeDMarqueeResult />} isResult>
+
+Two transforms and one overscan wrapper turn a flat grid into a tilted plane,
+and a duration offset per column is the entire trick behind a drift that
+never looks like it's repeating.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility
 
@@ -97,11 +108,3 @@ affordance from fighting the tilted layout.
 ## Motion Score
 
 <MotionScorePanel name="three-d-marquee" />
-
-## The result
-
-<ThreeDMarqueeResult />
-
-Two transforms and one overscan wrapper turn a flat grid into a tilted plane,
-and a duration offset per column is the entire trick behind a drift that
-never looks like it's repeating.

--- a/apps/docs/content/docs/components/layout/tilt-card/learn.mdx
+++ b/apps/docs/content/docs/components/layout/tilt-card/learn.mdx
@@ -1,14 +1,28 @@
 ---
 title: Anatomy of Tilt Card
 description: How one spring-smoothed pointer value drives a card's rotation, its floating content, and a glare that chases the cursor.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="The three layers"
+  scene={<TiltCardAnatomy />}
+  code={`<div className="[perspective:1000px]">
+  <motion.div style={{ rotateX, rotateY }} className="[transform-style:preserve-3d]">
+    <div style={{ transform: \`translateZ(\${depth}px)\`, transformStyle: "preserve-3d" }}>
+      {children}
+    </div>
+    <motion.div style={{ "--gx": glareX, "--gy": glareY }} />
+  </motion.div>
+</div>`}
+>
 
 Tilt Card doesn't animate a rotation and a glare separately — it reads the
 pointer once, smooths it through a single spring, and lets both the tilt and
 the glare's position fall out of that one signal. Here's how a `pointermove`
 handler becomes a card that feels like it's made of glass.
-
-## The three layers
 
 Everything lives inside one `[perspective:1000px]` wrapper. The card itself
 carries `rotateX`/`rotateY` in a `preserve-3d` box; a content layer floats
@@ -16,34 +30,23 @@ toward the viewer on `translateZ(depth)` so children read as physically
 closer; and a glare layer sits on top, its radial gradient centered wherever
 the pointer is.
 
-<TiltCardAnatomy />
+</LearnChapter>
 
-```tsx
-<div className="[perspective:1000px]">
-  <motion.div style={{ rotateX, rotateY }} className="[transform-style:preserve-3d]">
-    <div style={{ transform: `translateZ(${depth}px)`, transformStyle: "preserve-3d" }}>
-      {children}
-    </div>
-    <motion.div style={{ "--gx": glareX, "--gy": glareY }} />
-  </motion.div>
-</div>
-```
-
-## One pointer, one spring, two mappings
-
-`onPointerMove` normalizes the cursor to `[-0.5, 0.5]` on each axis relative
-to the card's bounding rect, and writes that straight into two motion
-values — no rotation math happens here yet:
-
-```tsx
-const px = useMotionValue(0);
+<LearnChapter
+  label="One pointer, one spring, two mappings"
+  scene={<TiltCardSpring />}
+  code={`const px = useMotionValue(0);
 const py = useMotionValue(0);
 const sx = useSpring(px, SPRING);
 const sy = useSpring(py, SPRING);
 
 px.set((e.clientX - rect.left) / rect.width - 0.5);
-py.set((e.clientY - rect.top) / rect.height - 0.5);
-```
+py.set((e.clientY - rect.top) / rect.height - 0.5);`}
+>
+
+`onPointerMove` normalizes the cursor to `[-0.5, 0.5]` on each axis relative
+to the card's bounding rect, and writes that straight into two motion
+values — no rotation math happens here yet:
 
 `sx`/`sy` are the spring-smoothed versions of those raw values, and
 `SPRING` — `{ stiffness: 170, damping: 12, mass: 0.1 }` — is deliberately
@@ -63,19 +66,29 @@ Because the tilt and the glare read the same two springs, they can never
 drift out of sync — move the pointer and the highlight always sits on the
 side of the card that's tilted toward it.
 
-<TiltCardSpring />
-
 Leaving the card resets `px`/`py` to `0`, and the same spring eases the tilt
 and glare back to flat rather than snapping — `onPointerLeave` never touches
 `rotateX`/`rotateY` directly, it just gives the spring a new target.
-
-## Why transform, not layout
 
 `rotateX`, `rotateY`, `scale` (on `whileHover`), and the glare's CSS-variable
 position are the only things that change per frame. All of it composes onto
 the transform/paint layers the GPU already owns — the browser never
 re-measures the card while the spring is settling, no matter how fast the
 pointer moves across it.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<TiltCardResult />} isResult>
+
+Move your pointer across each card — the rotation, the depth, and the glare
+all come from the same spring.
+
+One pointer position, one spring, four `useTransform` calls — that's the
+whole card.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility
 
@@ -96,13 +109,3 @@ if (reduceMotion) {
 ## Motion Score
 
 <MotionScorePanel name="tilt-card" />
-
-## The result
-
-Move your pointer across each card — the rotation, the depth, and the glare
-all come from the same spring.
-
-<TiltCardResult />
-
-One pointer position, one spring, four `useTransform` calls — that's the
-whole card.

--- a/apps/docs/content/docs/components/navigation/breadcrumbs/learn.mdx
+++ b/apps/docs/content/docs/components/navigation/breadcrumbs/learn.mdx
@@ -1,26 +1,15 @@
 ---
 title: Anatomy of Breadcrumbs
 description: How a flat items array becomes a trail of pills with one shared hover highlight, a spring-loaded overflow popover, and a mobile collapse that never touches JavaScript.
+learnPlayer: true
 ---
 
-A breadcrumb trail looks like the simplest nav in the system — links, a
-separator, done. The interesting part shows up at the edges: what happens
-when the pointer moves along the row, and what happens when the trail is
-longer than the screen. Breadcrumbs answers both without adding a single
-extra DOM node per crumb.
+<LearnPlayer>
 
-## The trail is pills and chevrons
-
-Every crumb but the last is an `<a>` tinted `text-muted-foreground`; the
-last is a plain `<span>` filled `bg-muted` and marked `aria-current="page"`.
-An `aria-hidden` chevron sits between each pair. The whole row is a
-`motion.ol` so `AnimatePresence` can cross-fade crumbs in and out when the
-`items` array changes:
-
-<BreadcrumbsAnatomy />
-
-```tsx
-<motion.li
+<LearnChapter
+  label="Pills and chevrons"
+  scene={<BreadcrumbsAnatomy />}
+  code={`<motion.li
   layout
   initial={reduceMotion ? false : { opacity: 0, x: -6 }}
   animate={{ opacity: 1, x: 0 }}
@@ -36,28 +25,40 @@ An `aria-hidden` chevron sits between each pair. The whole row is a
       {item.label}
     </a>
   )}
-</motion.li>
-```
+</motion.li>`}
+>
 
-## One hover pill, not N highlights
+A breadcrumb trail looks like the simplest nav in the system — links, a
+separator, done. The interesting part shows up at the edges: what happens
+when the pointer moves along the row, and what happens when the trail is
+longer than the screen. Breadcrumbs answers both without adding a single
+extra DOM node per crumb.
 
-Hovering a crumb doesn't toggle that crumb's own background — every link
-shares a single `motion.span` bound by one `layoutId`. It only renders
-under whichever crumb is currently hovered, so moving the pointer along the
-trail springs that one element from box to box:
+Every crumb but the last is an `<a>` tinted `text-muted-foreground`; the
+last is a plain `<span>` filled `bg-muted` and marked `aria-current="page"`.
+An `aria-hidden` chevron sits between each pair. The whole row is a
+`motion.ol` so `AnimatePresence` can cross-fade crumbs in and out when the
+`items` array changes:
 
-<BreadcrumbsPill />
+</LearnChapter>
 
-```tsx
-const HoverPill = ({ active }: { active: boolean }) =>
+<LearnChapter
+  label="One hover pill"
+  scene={<BreadcrumbsPill />}
+  code={`const HoverPill = ({ active }: { active: boolean }) =>
   active ? (
     <motion.span
       layoutId={hoverId}
       transition={{ type: "spring", stiffness: 520, damping: 32 }}
       className="absolute inset-0 rounded-lg bg-accent"
     />
-  ) : null;
-```
+  ) : null;`}
+>
+
+Hovering a crumb doesn't toggle that crumb's own background — every link
+shares a single `motion.span` bound by one `layoutId`. It only renders
+under whichever crumb is currently hovered, so moving the pointer along the
+trail springs that one element from box to box:
 
 `stiffness: 520, damping: 32` is the same snap used across GodUI's small
 UI springs — fast enough that it never lags a fast mouse sweep, damped
@@ -65,22 +66,22 @@ enough that it doesn't wobble on arrival. `onMouseEnter` sets `hovered` to
 the crumb's key; leaving the `<nav>` entirely clears it in one
 `onMouseLeave` at the root instead of per-crumb listeners.
 
-## Collapsing the middle
+</LearnChapter>
+
+<LearnChapter
+  label="Collapsing the middle"
+  scene={<BreadcrumbsCollapse />}
+  code={`const tailCount = maxItems - 1;
+const head = items.slice(0, 1).map(toEntry);
+const hidden = items.slice(1, items.length - tailCount);
+const tail = items.slice(items.length - tailCount).map(toEntry);
+return [...head, { kind: "ellipsis", hidden }, ...tail];`}
+>
 
 Pass `maxItems`, and once `items.length` exceeds it the middle crumbs fold
 into a single ellipsis button — head crumb, `…`, then the last
 `maxItems − 1` crumbs. Clicking the ellipsis doesn't navigate; it opens a
 popover listing the crumbs it swallowed:
-
-<BreadcrumbsCollapse />
-
-```tsx
-const tailCount = maxItems - 1;
-const head = items.slice(0, 1).map(toEntry);
-const hidden = items.slice(1, items.length - tailCount);
-const tail = items.slice(items.length - tailCount).map(toEntry);
-return [...head, { kind: "ellipsis", hidden }, ...tail];
-```
 
 The popover springs in on `scale: 0.92 → 1, y: -4 → 0` — the same overlay
 entrance used by every other panel in the system — and a `mousedown`
@@ -91,7 +92,19 @@ collapse kicks in on narrow viewports: crumbs past the first hide under
 a portaled iframe but at the parent's JS realm, so only a media query
 actually sees the iframe's width.
 
-## `aria-current` carries the "you are here"
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<BreadcrumbsResult />} isResult>
+
+One `items` array, one shared hover pill, and a collapse that degrades
+gracefully from `maxItems` down to a CSS ellipsis on narrow screens — the
+trail never needs more markup than the pieces above.
+
+</LearnChapter>
+
+</LearnPlayer>
+
+## Accessibility
 
 There's no extra label announcing the current page — the last crumb's
 `aria-current="page"` is the whole signal, exactly like a native breadcrumb
@@ -103,11 +116,3 @@ are just anchors.
 ## Motion Score
 
 <MotionScorePanel name="breadcrumbs" />
-
-## The result
-
-<BreadcrumbsResult />
-
-One `items` array, one shared hover pill, and a collapse that degrades
-gracefully from `maxItems` down to a CSS ellipsis on narrow screens — the
-trail never needs more markup than the pieces above.

--- a/apps/docs/content/docs/components/navigation/combobox/learn.mdx
+++ b/apps/docs/content/docs/components/navigation/combobox/learn.mdx
@@ -1,26 +1,15 @@
 ---
 title: Anatomy of the Combobox
 description: How one input and a floating listbox turn a flat option list into a searchable field — with staggered rows, a spliced highlight, and a race-guarded async resolver.
+learnPlayer: true
 ---
 
-A combobox looks like a `<select>` that learned to type. Underneath it's much
-simpler than that suggests: one real `<input role="combobox">`, and — mounted
-through `AnimatePresence` the moment it's focused — a `role="listbox"`
-popover sitting on top. No portal, no virtualized list, no hidden `<select>`
-shadowing the input. The input owns the value; the listbox is just its
-reflection.
+<LearnPlayer>
 
-## One input, a floating listbox
-
-The popover isn't a separate stateful component — it's the same `open`
-boolean that gates the input's dropdown affordance, rendered as an absolutely
-positioned sibling with `origin-top` so it visually grows out of the field's
-bottom edge:
-
-<ComboboxAnatomy />
-
-```tsx
-<input
+<LearnChapter
+  label="Input and listbox"
+  scene={<ComboboxAnatomy />}
+  code={`<input
   role="combobox"
   aria-expanded={open}
   aria-controls={listboxId}
@@ -31,24 +20,31 @@ bottom edge:
 
 <AnimatePresence>
   {open && <motion.ul id={listboxId} role="listbox" className="absolute top-full ... origin-top" />}
-</AnimatePresence>
-```
+</AnimatePresence>`}
+>
+
+A combobox looks like a `<select>` that learned to type. Underneath it's much
+simpler than that suggests: one real `<input role="combobox">`, and — mounted
+through `AnimatePresence` the moment it's focused — a `role="listbox"`
+popover sitting on top. No portal, no virtualized list, no hidden `<select>`
+shadowing the input. The input owns the value; the listbox is just its
+reflection.
+
+The popover isn't a separate stateful component — it's the same `open`
+boolean that gates the input's dropdown affordance, rendered as an absolutely
+positioned sibling with `origin-top` so it visually grows out of the field's
+bottom edge:
 
 Notice the input's own `value`: while closed it shows the *selected label*;
 the instant you type, it switches to showing your raw `query`. One field,
 two readings, no second input to keep in sync.
 
-## The listbox springs, the rows cascade behind it
+</LearnChapter>
 
-Opening isn't a fade — the whole `<ul>` springs in from `scale: 0.97, y: -4`
-to `1, 0` on a `stiffness: 520 / damping: 32` spring, stiff enough to feel
-instant. But the rows inside don't wait for the popover to finish; each
-`<motion.li>` runs its own entrance the moment it mounts, staggered by index:
-
-<ComboboxStagger />
-
-```tsx
-const spring = { type: "spring", stiffness: 520, damping: 32 } as const;
+<LearnChapter
+  label="Spring + row stagger"
+  scene={<ComboboxStagger />}
+  code={`const spring = { type: "spring", stiffness: 520, damping: 32 } as const;
 
 <motion.ul
   initial={{ opacity: 0, scale: 0.97, y: -4 }}
@@ -63,24 +59,25 @@ const spring = { type: "spring", stiffness: 520, damping: 32 } as const;
       transition={{ delay: i * 0.02 }}
     />
   ))}
-</motion.ul>
-```
+</motion.ul>`}
+>
+
+Opening isn't a fade — the whole `<ul>` springs in from `scale: 0.97, y: -4`
+to `1, 0` on a `stiffness: 520 / damping: 32` spring, stiff enough to feel
+instant. But the rows inside don't wait for the popover to finish; each
+`<motion.li>` runs its own entrance the moment it mounts, staggered by index:
 
 `delay: i * 0.02` is a 20ms stagger — barely perceptible row-to-row, but
 across ten rows it reads as the list *filling in* rather than appearing all
 at once. Both animations key off the same `open` state, so they always start
 together; the popover just has a head start because it's the outer element.
 
-## The match is spliced, not restyled
+</LearnChapter>
 
-`highlight()` doesn't wrap the whole label in a different style and hope the
-match stands out — it finds the query with a case-insensitive `indexOf` and
-cuts the string into three literal pieces, wrapping only the middle one:
-
-<ComboboxHighlight />
-
-```tsx
-function highlight(label: string, query: string) {
+<LearnChapter
+  label="Spliced highlight"
+  scene={<ComboboxHighlight />}
+  code={`function highlight(label: string, query: string) {
   if (!query) return label;
   const idx = label.toLowerCase().indexOf(query.toLowerCase());
   if (idx === -1) return label;
@@ -93,25 +90,24 @@ function highlight(label: string, query: string) {
       {label.slice(idx + query.length)}
     </>
   );
-}
-```
+}`}
+>
+
+`highlight()` doesn't wrap the whole label in a different style and hope the
+match stands out — it finds the query with a case-insensitive `indexOf` and
+cuts the string into three literal pieces, wrapping only the middle one:
 
 The `<mark>` carries no background — just weight and full-opacity color — so
 it reads as emphasis inside the row's muted text, not as a search-engine
 yellow smear. Because it's `indexOf`, the match can land anywhere in the
 label; there's no assumption it starts at index 0.
 
-## Async search races itself
+</LearnChapter>
 
-Pass `onSearch` instead of `options` and every keystroke becomes a network
-request. Two things keep that safe: a **debounce** so you don't fire on
-every character, and a **request-id guard** so a slow response can never
-clobber a newer one:
-
-<ComboboxRace />
-
-```tsx
-const reqId = React.useRef(0);
+<LearnChapter
+  label="Async race guard"
+  scene={<ComboboxRace />}
+  code={`const reqId = React.useRef(0);
 
 React.useEffect(() => {
   if (!onSearch || !open) return;
@@ -127,8 +123,13 @@ React.useEffect(() => {
     });
   }, 180);
   return () => clearTimeout(t);
-}, [query, onSearch, open]);
-```
+}, [query, onSearch, open]);`}
+>
+
+Pass `onSearch` instead of `options` and every keystroke becomes a network
+request. Two things keep that safe: a **debounce** so you don't fire on
+every character, and a **request-id guard** so a slow response can never
+clobber a newer one:
 
 Every render that changes `query` bumps `reqId.current` and captures its own
 `id` in the closure. If a request from three keystrokes ago finally resolves
@@ -136,7 +137,20 @@ after a newer one already landed, `id === reqId.current` is false and the
 stale result is silently dropped — no cancellation token, no AbortController,
 just a number that only ever goes up.
 
-## Keys, active index, and cleanup
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<ComboboxResult />} isResult>
+
+One input, one listbox, one `highlight()` splice, and a request id that only
+counts up — that's the whole searchable field. Swap `options` for `onSearch`
+and every mechanism above — the debounce, the race guard, the stagger — keeps
+working without a single prop changing shape.
+
+</LearnChapter>
+
+</LearnPlayer>
+
+## Accessibility
 
 `ArrowDown`/`ArrowUp` walk a plain `active` index clamped to the results
 array; `Enter` commits whatever row is active; `Escape` closes without
@@ -160,12 +174,3 @@ or slide to get there.
 ## Motion Score
 
 <MotionScorePanel name="combobox" />
-
-## The result
-
-<ComboboxResult />
-
-One input, one listbox, one `highlight()` splice, and a request id that only
-counts up — that's the whole searchable field. Swap `options` for `onSearch`
-and every mechanism above — the debounce, the race guard, the stagger — keeps
-working without a single prop changing shape.

--- a/apps/docs/content/docs/components/navigation/context-menu/learn.mdx
+++ b/apps/docs/content/docs/components/navigation/context-menu/learn.mdx
@@ -1,25 +1,17 @@
 ---
 title: Anatomy of the Context Menu
 description: How a flat items array becomes a spring-loaded menu that grows from the exact cursor point and flips itself to stay inside the viewport.
+learnPlayer: true
 ---
 
-A native right-click menu is invisible plumbing: capture `contextmenu`, place a
-panel at the pointer, catch focus, and clean up on the first click outside. The
-hard parts aren't the rows — they're *where* the panel lands and *how* it gets
-out of its own way at a screen edge. Context Menu is one component that takes a
-flat array and does all of it.
+<LearnPlayer>
 
-## The shape of the array is the shape of the menu
-
-There's no nested config and no compound `<Menu.Item>` children. You pass one
-flat `items` array, and the component walks it in order, switching on `type`:
-
-<ContextMenuAnatomy />
-
-```tsx
-{items.map((item, index) => {
-  if (item.type === "separator") return <hr key={`sep-${index}`} />;
-  if (item.type === "label") return <div key={`label-${index}`}>{item.label}</div>;
+<LearnChapter
+  label="Flat items array"
+  scene={<ContextMenuAnatomy />}
+  code={`{items.map((item, index) => {
+  if (item.type === "separator") return <hr key={\`sep-\${index}\`} />;
+  if (item.type === "label") return <div key={\`label-\${index}\`}>{item.label}</div>;
   return (
     <button role="menuitem" data-menu-item onClick={() => { item.onSelect?.(); setCoords(null); }}>
       {item.icon && <span className="opacity-70">{item.icon}</span>}
@@ -27,26 +19,29 @@ flat `items` array, and the component walks it in order, switching on `type`:
       {item.shortcut && <span className="ml-auto">{item.shortcut}</span>}
     </button>
   );
-})}
-```
+})}`}
+>
+
+A native right-click menu is invisible plumbing: capture `contextmenu`, place a
+panel at the pointer, catch focus, and clean up on the first click outside. The
+hard parts aren't the rows — they're *where* the panel lands and *how* it gets
+out of its own way at a screen edge. Context Menu is one component that takes a
+flat array and does all of it.
+
+There's no nested config and no compound `<Menu.Item>` children. You pass one
+flat `items` array, and the component walks it in order, switching on `type`:
 
 A `label` is a muted, non-focusable header; a `separator` is a hairline `<hr>`;
 everything else is a `menuitem` button laying out icon · label · shortcut. A
 `destructive: true` item is the same row tinted with `text-destructive` and a
 red hover — no separate variant to render.
 
-## It springs from the cursor point
+</LearnChapter>
 
-The menu doesn't fade into the middle of the screen; it appears to grow out of
-where you clicked. On `contextMenu` the component stores the raw
-`clientX/clientY`, mounts the panel at `position: fixed` with `left`/`top` set to
-exactly those coordinates, and pins `transformOrigin` to the corner nearest the
-pointer:
-
-<ContextMenuSpring />
-
-```tsx
-const spring = reduceMotion
+<LearnChapter
+  label="Spring from the cursor"
+  scene={<ContextMenuSpring />}
+  code={`const spring = reduceMotion
   ? { duration: 0 }
   : ({ type: "spring", stiffness: 520, damping: 32 } as const);
 
@@ -56,39 +51,57 @@ const spring = reduceMotion
   exit={reduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.9 }}
   transition={spring}
   style={{ position: "fixed", left: coords.x, top: coords.y, transformOrigin: "left top" }}
-/>
-```
+/>`}
+>
+
+The menu doesn't fade into the middle of the screen; it appears to grow out of
+where you clicked. On `contextMenu` the component stores the raw
+`clientX/clientY`, mounts the panel at `position: fixed` with `left`/`top` set to
+exactly those coordinates, and pins `transformOrigin` to the corner nearest the
+pointer:
 
 `scale: 0.9 → 1` with the origin at the click corner is what sells the "grew from
 the pointer" read — a centered scale would look like it inflated from the middle.
 The `stiffness 520 / damping 32` spring is stiff enough to feel instant but still
 lands with a hair of overshoot.
 
-## It flips to stay inside the viewport
+</LearnChapter>
+
+<LearnChapter
+  label="Viewport flip"
+  scene={<ContextMenuFlip />}
+  code={`const openAt = (clientX, clientY) => {
+  const menuW = 220;
+  const menuH = Math.min(items.length * 40 + 12, 360);
+  const flipX = clientX + menuW > window.innerWidth;
+  const flipY = clientY + menuH > window.innerHeight;
+  setCoords({ x: clientX, y: clientY, flipX, flipY });
+};`}
+>
 
 Anchoring at the cursor breaks the moment you right-click near the bottom-right
 corner — a naive panel would overflow the screen. So `openAt` measures first. It
 estimates the panel box from the item count and compares it against the viewport
 before the menu ever mounts:
 
-<ContextMenuFlip />
-
-```tsx
-const openAt = (clientX, clientY) => {
-  const menuW = 220;
-  const menuH = Math.min(items.length * 40 + 12, 360);
-  const flipX = clientX + menuW > window.innerWidth;
-  const flipY = clientY + menuH > window.innerHeight;
-  setCoords({ x: clientX, y: clientY, flipX, flipY });
-};
-```
-
 When a flag trips, the anchor switches from `left/top` to `right/bottom`
 (`right: innerWidth − x`) and `transformOrigin` swaps to the opposite corner. The
 panel opens *away* from the edge instead of through it — and because the origin
 moves with it, it still springs out of the pointer, just in the other direction.
 
-## Focus, keys, and cleanup
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<ContextMenuResult />} isResult>
+
+One flat array in, a `role="menu"` of buttons out — placed at the cursor,
+sprung from its corner, flipped off the edges, and dismissed the instant you
+look away. The rows are just paint; the component is the placement.
+
+</LearnChapter>
+
+</LearnPlayer>
+
+## Accessibility
 
 Opening the menu immediately moves focus to the first `data-menu-item`, so the
 keyboard is live without a click. `ArrowDown`/`ArrowUp` walk the items with a
@@ -111,11 +124,3 @@ leaving a plain opacity fade with `duration: 0` on the spring.
 ## Motion Score
 
 <MotionScorePanel name="context-menu" />
-
-## The result
-
-<ContextMenuResult />
-
-One flat array in, a `role="menu"` of buttons out — placed at the cursor,
-sprung from its corner, flipped off the edges, and dismissed the instant you
-look away. The rows are just paint; the component is the placement.

--- a/apps/docs/content/docs/components/navigation/dock/learn.mdx
+++ b/apps/docs/content/docs/components/navigation/dock/learn.mdx
@@ -1,24 +1,15 @@
 ---
 title: Anatomy of the Dock
 description: How a magnifying dock runs on one shared pointer signal instead of per-item mouse handlers, with each item's size chasing a distance-derived target on its own spring.
+learnPlayer: true
 ---
 
-A macOS-style dock looks like it needs a lot of coordination — every icon
-has to know how far the pointer is and how big its neighbors have grown. It
-doesn't. `Dock` publishes exactly one number, and every `DockItem` reads it
-independently. There's no loop that measures all items and repaints them;
-each one is its own small reactive system.
+<LearnPlayer>
 
-## One signal, many listeners
-
-`Dock` holds a single `mouseX` `MotionValue`, updated on every `mousemove`
-and reset to `+Infinity` on `mouseleave`. It hands that value down through
-context — nothing else about pointer position is shared:
-
-<DockAnatomy />
-
-```tsx
-const mouseX = useMotionValue(Number.POSITIVE_INFINITY);
+<LearnChapter
+  label="One signal, many listeners"
+  scene={<DockAnatomy />}
+  code={`const mouseX = useMotionValue(Number.POSITIVE_INFINITY);
 
 <div
   onMouseMove={(e) => mouseX.set(e.clientX)}
@@ -27,26 +18,30 @@ const mouseX = useMotionValue(Number.POSITIVE_INFINITY);
   <DockContext.Provider value={{ mouseX, baseSize, magnification, distance }}>
     {children}
   </DockContext.Provider>
-</div>
-```
+</div>`}
+>
+
+A macOS-style dock looks like it needs a lot of coordination — every icon
+has to know how far the pointer is and how big its neighbors have grown. It
+doesn't. `Dock` publishes exactly one number, and every `DockItem` reads it
+independently. There's no loop that measures all items and repaints them;
+each one is its own small reactive system.
+
+`Dock` holds a single `mouseX` `MotionValue`, updated on every `mousemove`
+and reset to `+Infinity` on `mouseleave`. It hands that value down through
+context — nothing else about pointer position is shared:
 
 Resetting to `Infinity` rather than some off-screen coordinate matters:
 every item's distance-from-pointer calculation ends up huge and clamps to
 `baseSize`, so leaving the dock relaxes every icon back to rest in one
 write, with no separate "pointer left" branch to maintain.
 
-## Distance in, size out, on a spring
+</LearnChapter>
 
-Each `DockItem` measures its own bounding box and subtracts the shared
-`mouseX` from its center to get a signed distance. `useTransform` maps that
-distance through a triangular curve — far away is `baseSize`, dead center is
-`magnification`, and it falls off linearly on either side — and a
-`useSpring` chases whatever that target becomes, frame by frame:
-
-<DockMagnify />
-
-```tsx
-const distanceFromMouse = useTransform(mouseX, (val) => {
+<LearnChapter
+  label="Distance to size spring"
+  scene={<DockMagnify />}
+  code={`const distanceFromMouse = useTransform(mouseX, (val) => {
   const bounds = ref.current?.getBoundingClientRect();
   if (!bounds) return distance + 1;
   return val - bounds.x - bounds.width / 2;
@@ -59,8 +54,14 @@ const sizeTarget = useTransform(
 );
 const size = useSpring(sizeTarget, { mass: 0.1, stiffness: 170, damping: 12 });
 
-<motion.div style={{ width: size, height: size }} />
-```
+<motion.div style={{ width: size, height: size }} />`}
+>
+
+Each `DockItem` measures its own bounding box and subtracts the shared
+`mouseX` from its center to get a signed distance. `useTransform` maps that
+distance through a triangular curve — far away is `baseSize`, dead center is
+`magnification`, and it falls off linearly on either side — and a
+`useSpring` chases whatever that target becomes, frame by frame:
 
 Defaults are `baseSize: 44`, `magnification: 72`, `distance: 140` — an item
 144px away from the pointer sits fully at rest; directly under it, it's 64%
@@ -70,8 +71,6 @@ frame (not from React state), moving the pointer never triggers a re-render
 The low `mass: 0.1` and `damping: 12` spring is what gives the size a slight
 overshoot as it chases a fast-moving target, instead of snapping rigidly to
 it.
-
-## Labels ride the same hover, no coordination needed
 
 The tooltip above each item is a plain `AnimatePresence` child gated by CSS
 `group-hover:block` — it doesn't read `mouseX` at all. Framer only handles
@@ -93,6 +92,18 @@ that item's own DOM node:
 </AnimatePresence>
 ```
 
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<DockResult />} isResult>
+
+One `mouseX` value published on `mousemove`, one distance-to-size transform
+per item, one spring chasing that target — sweep the row and watch the
+ripple move with zero shared layout code between icons.
+
+</LearnChapter>
+
+</LearnPlayer>
+
 ## No `useReducedMotion` — worth knowing
 
 Unlike most GodUI components, `Dock` doesn't check `useReducedMotion`
@@ -105,11 +116,3 @@ entirely) yourself at the call site — the component won't do it for you.
 ## Motion Score
 
 <MotionScorePanel name="dock" />
-
-## The result
-
-<DockResult />
-
-One `mouseX` value published on `mousemove`, one distance-to-size transform
-per item, one spring chasing that target — sweep the row and watch the
-ripple move with zero shared layout code between icons.

--- a/apps/docs/content/docs/components/navigation/dropdown-menu/learn.mdx
+++ b/apps/docs/content/docs/components/navigation/dropdown-menu/learn.mdx
@@ -1,23 +1,15 @@
 ---
 title: Anatomy of the Dropdown Menu
 description: How one recursive panel component turns a flat items array into a menu that springs from the trigger's corner and nests submenus to the side, at any depth.
+learnPlayer: true
 ---
 
-A dropdown menu and its submenus look like two different pieces of UI. In
-the source they're the same component called twice. `MenuPanel` doesn't know
-whether it's the root menu or nested three levels deep — it just renders an
-`items` array, and if one of those items has its own `submenu`, it renders
-another `MenuPanel` inside itself.
+<LearnPlayer>
 
-## One array, four row kinds
-
-There's no compound `<Menu.Item>` / `<Menu.Label>` API. `DropdownMenuItem` is
-a union, and the panel switches on `type` (or the absence of one) as it maps:
-
-<DropdownMenuAnatomy />
-
-```tsx
-export type DropdownMenuItem =
+<LearnChapter
+  label="Four row kinds"
+  scene={<DropdownMenuAnatomy />}
+  code={`export type DropdownMenuItem =
   | { type: "separator" }
   | { type: "label"; label: React.ReactNode }
   | {
@@ -26,26 +18,29 @@ export type DropdownMenuItem =
       icon?: React.ReactNode;
       shortcut?: string;
       submenu?: DropdownMenuItem[];
-    };
-```
+    };`}
+>
+
+A dropdown menu and its submenus look like two different pieces of UI. In
+the source they're the same component called twice. `MenuPanel` doesn't know
+whether it's the root menu or nested three levels deep — it just renders an
+`items` array, and if one of those items has its own `submenu`, it renders
+another `MenuPanel` inside itself.
+
+There's no compound `<Menu.Item>` / `<Menu.Label>` API. `DropdownMenuItem` is
+a union, and the panel switches on `type` (or the absence of one) as it maps:
 
 A `label` is a muted, non-interactive heading; a `separator` is a hairline
 `<hr>`; a plain item lays out icon · label · shortcut; and an item with a
 non-empty `submenu` gets the same row plus a trailing chevron. Four visual
 kinds, one loop, no branching component tree.
 
-## It springs from the corner nearest the trigger
+</LearnChapter>
 
-Opening isn't a fade toward the center — the panel scales `0.94 → 1` while
-fading in, on the same `stiffness: 520 / damping: 32` spring used across
-GodUI's popovers. What makes it read as "growing off the trigger" is
-`transform-origin`: not a fixed corner, but whichever one sits closest to
-where the trigger is, computed from `side` and `align`:
-
-<DropdownMenuSpring />
-
-```tsx
-const originClasses: Record<DropdownSide, Record<DropdownAlign, string>> = {
+<LearnChapter
+  label="Spring from the corner"
+  scene={<DropdownMenuSpring />}
+  code={`const originClasses: Record<DropdownSide, Record<DropdownAlign, string>> = {
   bottom: { start: "origin-top-left", center: "origin-top", end: "origin-top-right" },
   top:    { start: "origin-bottom-left", center: "origin-bottom", end: "origin-bottom-right" },
   // …right, left…
@@ -55,27 +50,27 @@ const originClasses: Record<DropdownSide, Record<DropdownAlign, string>> = {
   initial={{ opacity: 0, scale: 0.94 }}
   animate={{ opacity: 1, scale: 1 }}
   transition={{ type: "spring", stiffness: 520, damping: 32 }}
-  className={`... ${originClasses[side][align]}`}
-/>
-```
+  className={\`... \${originClasses[side][align]}\`}
+/>`}
+>
+
+Opening isn't a fade toward the center — the panel scales `0.94 → 1` while
+fading in, on the same `stiffness: 520 / damping: 32` spring used across
+GodUI's popovers. What makes it read as "growing off the trigger" is
+`transform-origin`: not a fixed corner, but whichever one sits closest to
+where the trigger is, computed from `side` and `align`:
 
 An `align="end"` menu below a right-aligned trigger gets `origin-top-right`
 — the panel visibly unfolds from its own top-right corner, which is exactly
 where the trigger's edge is. Flip `align` to `start` and the origin flips
 with it; the component never hardcodes "top left."
 
-## Submenus are the same panel, recursed
+</LearnChapter>
 
-A submenu isn't a second, simpler component — `MenuPanel` calls itself.
-Hovering (or pressing `ArrowRight` on) a row with a `submenu` sets a local
-`openSub` index; the child `MenuPanel` mounts absolutely positioned off that
-row's right edge, with `side="right"` and `align="start"` so its own origin
-resolves to `origin-top-left`:
-
-<DropdownMenuSubmenu />
-
-```tsx
-{hasSub && (
+<LearnChapter
+  label="Recursive submenus"
+  scene={<DropdownMenuSubmenu />}
+  code={`{hasSub && (
   <div onMouseEnter={() => setOpenSub(index)} onMouseLeave={() => setOpenSub(null)}>
     <button
       onKeyDown={(e) => {
@@ -91,8 +86,14 @@ resolves to `origin-top-left`:
       </div>
     )}
   </div>
-)}
-```
+)}`}
+>
+
+A submenu isn't a second, simpler component — `MenuPanel` calls itself.
+Hovering (or pressing `ArrowRight` on) a row with a `submenu` sets a local
+`openSub` index; the child `MenuPanel` mounts absolutely positioned off that
+row's right edge, with `side="right"` and `align="start"` so its own origin
+resolves to `origin-top-left`:
 
 Because it's the *same* `MenuPanel`, a submenu gets every mechanism the root
 menu gets for free — its own spring-in, its own focus trap, its own
@@ -100,7 +101,19 @@ menu gets for free — its own spring-in, its own focus trap, its own
 submenu of a submenu would just work, though the current row kinds only
 nest one level deep in practice.
 
-## Focus and keys, scoped to each panel
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<DropdownMenuResult />} isResult>
+
+One `items` array, one recursive `MenuPanel`, and a `transform-origin` that
+follows the trigger instead of being fixed — that's a menu and every nested
+submenu it can grow, built from a single component calling itself.
+
+</LearnChapter>
+
+</LearnPlayer>
+
+## Accessibility
 
 Each `MenuPanel` focuses its own first `[data-menu-item]` on mount and owns
 its own `ArrowDown`/`ArrowUp` wrap-around walk — scoped to *that* panel's
@@ -124,11 +137,3 @@ panel, root and submenu alike, leaving a plain opacity fade.
 ## Motion Score
 
 <MotionScorePanel name="dropdown-menu" />
-
-## The result
-
-<DropdownMenuResult />
-
-One `items` array, one recursive `MenuPanel`, and a `transform-origin` that
-follows the trigger instead of being fixed — that's a menu and every nested
-submenu it can grow, built from a single component calling itself.

--- a/apps/docs/content/docs/components/navigation/filter-bar/learn.mdx
+++ b/apps/docs/content/docs/components/navigation/filter-bar/learn.mdx
@@ -1,7 +1,23 @@
 ---
 title: Anatomy of the Filter Bar
 description: How a row of facet pills stays a set of plain buttons and a popover — with a compositor-only summary slide-in, and a spring-in clear button.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="Two pill states"
+  scene={<FilterBarAnatomy />}
+  code={`<div className={hasSelection ? "border-foreground/15 bg-accent" : "border-dashed border-border"}>
+  <button onClick={() => setOpen(isOpen ? null : facet.id)}>
+    {!hasSelection && <motion.span>{PlusIcon}</motion.span>}
+    <span>{facet.label}</span>
+    {hasSelection && <motion.span>{summarize(facet, selected)}</motion.span>}
+  </button>
+  {hasSelection && <motion.button onClick={() => clearFacet(facet.id)}>{CloseIcon}</motion.button>}
+</div>`}
+>
 
 A filter bar reads like a form — checkboxes, a submit, a results count — but
 there's no `<select multiple>` and no schema anywhere in it. `FilterBar`
@@ -9,40 +25,21 @@ takes a `facets` array and renders each one as a pill: a button that opens a
 popover of options, and, once you've picked something, an inline summary of
 what's selected. That's the entire vocabulary.
 
-## One flex row, two pill states
-
 Every facet pill is the same markup wearing one of two looks. Empty, it's a
 dashed ring with a plus glyph and a muted label — an obvious "add a filter"
 affordance. Active, the ring solidifies, a summary of the selection appears
 inline, and a clear button shows up on its trailing edge:
 
-<FilterBarAnatomy />
-
-```tsx
-<div className={hasSelection ? "border-foreground/15 bg-accent" : "border-dashed border-border"}>
-  <button onClick={() => setOpen(isOpen ? null : facet.id)}>
-    {!hasSelection && <motion.span>{PlusIcon}</motion.span>}
-    <span>{facet.label}</span>
-    {hasSelection && <motion.span>{summarize(facet, selected)}</motion.span>}
-  </button>
-  {hasSelection && <motion.button onClick={() => clearFacet(facet.id)}>{CloseIcon}</motion.button>}
-</div>
-```
-
 `summarize()` collapses a multi-select down to `"<first label> +<n-1>"`, so
 the pill never grows unbounded — pick five options in one facet and the
 label still reads as one short phrase.
 
-## Presence, not a width morph
+</LearnChapter>
 
-The pill's width still changes when a selection appears — content is
-content — but that reflow is a single layout pass, not a tween. The motion
-that sells the change stays on the compositor: the plus scales out, the
-summary slides in on `x` + opacity, and the clear button pops on scale, all
-on the same spring (`stiffness: 520 / damping: 32`):
-
-```tsx
-<motion.span
+<LearnChapter
+  label="Presence, not width"
+  scene={<FilterBarSpring />}
+  code={`<motion.span
   initial={{ opacity: 0, x: -6 }}
   animate={{ opacity: 1, x: 0 }}
   exit={{ opacity: 0, x: -6 }}
@@ -50,16 +47,18 @@ on the same spring (`stiffness: 520 / damping: 32`):
 >
   <span className="h-3.5 w-px bg-border" />
   <span>{summarize(facet, selected)}</span>
-</motion.span>
-```
+</motion.span>`}
+>
+
+The pill's width still changes when a selection appears — content is
+content — but that reflow is a single layout pass, not a tween. The motion
+that sells the change stays on the compositor: the plus scales out, the
+summary slides in on `x` + opacity, and the clear button pops on scale, all
+on the same spring (`stiffness: 520 / damping: 32`):
 
 There's no `width: 0 → "auto"` and no Framer `layout` on the row. Animating
 width to fit unknown text reflows every sibling every frame; snapping the
 pill and animating only presence reads cleaner and stays GPU-composited.
-
-<FilterBarSpring />
-
-## The popover and its checkbox list
 
 Clicking a pill opens a `role="listbox"` popover — spring-scaled in from
 `0.96, y: -4`, same spring again — with an optional search input and a list
@@ -82,7 +81,19 @@ leaving `{ status: [] }` around — is what makes `activeCount` and "Clear all"
 visibility a simple `Object.values(value).length` check downstream, with no
 empty-array edge case to filter out first.
 
-## Accessibility and cleanup
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<FilterBarResult />} isResult>
+
+A `facets` array in, a `FilterValue` record out — every pill is a button and
+a popover, the summary slides in on the compositor, and "Clear all" is
+nothing more than a count check away from disappearing again.
+
+</LearnChapter>
+
+</LearnPlayer>
+
+## Accessibility
 
 Each pill button carries `aria-haspopup="listbox"` and `aria-expanded`; each
 option row is `role="option"` with `aria-selected` mirroring the checkbox
@@ -111,11 +122,3 @@ still appears, it just doesn't slide or scale into place.
 ## Motion Score
 
 <MotionScorePanel name="filter-bar" />
-
-## The result
-
-<FilterBarResult />
-
-A `facets` array in, a `FilterValue` record out — every pill is a button and
-a popover, the summary slides in on the compositor, and "Clear all" is
-nothing more than a count check away from disappearing again.

--- a/apps/docs/content/docs/components/navigation/magic-tab/learn.mdx
+++ b/apps/docs/content/docs/components/navigation/magic-tab/learn.mdx
@@ -1,7 +1,20 @@
 ---
 title: Anatomy of the Magic Tab
 description: How a segmented control borrows Magic Button's three-layer stack, but only the selected tab ever pays for it.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="Three layers, one tab"
+  scene={<MagicTabAnatomy />}
+  code={`const shadowOpacity = selected ? (rainbow ? "opacity-70" : "opacity-100") : "opacity-0";
+const edgeFill = selected ? \`opacity-100 \${...}\` : "opacity-0";
+const frontState = selected
+  ? \`-translate-y-[4px] \${frontVariantSelected[variant]} ...\`
+  : \`bg-transparent text-muted-foreground \${frontVariantPreview[variant]}\`;`}
+>
 
 Magic Tab is Magic Button's sibling: same three-layer illusion of a
 pushed-up surface, same springy bezier — but wearing a `role="tablist"`
@@ -9,43 +22,31 @@ instead of a lone button. The twist is selection. A button is always
 "pressed or not"; a tab has to hold a rest state for every item it isn't,
 and only spend the 3D budget on the one it is.
 
-## Three layers, but one tab wears them
-
 Every tab is a `<button>` with the same absolutely-stacked shadow, edge,
 and front-face spans as Magic Button. The difference: on an unselected tab
 the shadow and edge sit at `opacity-0` and the front is flat
 (`bg-transparent`, no lift). Only the selected tab's stack actually
 materializes — shown below as flat → the three spans → assembled lift:
 
-<MagicTabAnatomy />
-
-```tsx
-const shadowOpacity = selected ? (rainbow ? "opacity-70" : "opacity-100") : "opacity-0";
-const edgeFill = selected ? `opacity-100 ${...}` : "opacity-0";
-const frontState = selected
-  ? `-translate-y-[4px] ${frontVariantSelected[variant]} ...`
-  : `bg-transparent text-muted-foreground ${frontVariantPreview[variant]}`;
-```
-
 Unselected tabs still preview the selected color flat on hover/focus
 (`frontVariantPreview`) — a hint of what clicking does — but never lift.
 Lifting is reserved for the tab that's actually selected.
 
-## The lift has three stops, not two
+</LearnChapter>
+
+<LearnChapter
+  label="Three lift stops"
+  scene={<MagicTabLift />}
+  code={`// front face
+"-translate-y-[4px] group-focus-visible:-translate-y-[6px]
+ [transition:translate_600ms_cubic-bezier(0.3,0.7,0.4,1)]
+ group-focus-visible:[transition:translate_250ms_cubic-bezier(0.3,0.7,0.4,1.5)]"`}
+>
 
 A selected tab doesn't just sit at `-4px` — it goes one step further on
 `focus-visible`, to `-6px`, the same way Magic Button's hover lift previews
 what a press would feel like. Rest → selected uses the slower settle
 bezier; selected → focus overshoots on the snappier one:
-
-<MagicTabLift />
-
-```tsx
-// front face
-"-translate-y-[4px] group-focus-visible:-translate-y-[6px]
- [transition:translate_600ms_cubic-bezier(0.3,0.7,0.4,1)]
- group-focus-visible:[transition:translate_250ms_cubic-bezier(0.3,0.7,0.4,1.5)]"
-```
 
 `600ms` at rest→selected is deliberately unhurried; `250ms` with a `1.5`
 overshoot control point on selected→focus is the snap that says "this is
@@ -53,7 +54,19 @@ now interactive." Both offsets animate `translate`, never `top` — the same
 compositor-only rule Magic Button enforces, for the same reason: a moved
 layer is free, a re-laid-out one isn't.
 
-## The rainbow, paused when nobody's looking
+</LearnChapter>
+
+<LearnChapter
+  label="Rainbow, paused offscreen"
+  scene={<MagicTabRainbow />}
+  code={`const io = new IntersectionObserver(
+  ([entry]) => {
+    for (const layer of root.querySelectorAll<HTMLElement>(".animate-magic-rainbow"))
+      layer.style.animationPlayState = entry.isIntersecting ? "" : "paused";
+  },
+  { rootMargin: "128px" },
+);`}
+>
 
 The selected tab's edge and shadow can run the same sliding rainbow
 gradient as Magic Button — `background-size: 200% 100%` with a
@@ -61,23 +74,22 @@ gradient as Magic Button — `background-size: 200% 100%` with a
 `IntersectionObserver` on the tablist root pauses every
 `.animate-magic-rainbow` layer the instant it scrolls out of view:
 
-<MagicTabRainbow />
-
-```tsx
-const io = new IntersectionObserver(
-  ([entry]) => {
-    for (const layer of root.querySelectorAll<HTMLElement>(".animate-magic-rainbow"))
-      layer.style.animationPlayState = entry.isIntersecting ? "" : "paused";
-  },
-  { rootMargin: "128px" },
-);
-```
-
 `rootMargin: "128px"` resumes the sweep just before the tablist re-enters
 the viewport, so scrolling back to it never catches a frozen mid-cycle
 frame snapping back to life.
 
-## A tablist, not a button row
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<MagicTabResult />} isResult>
+
+Same three spans, same bezier as Magic Button — Magic Tab just decides,
+per render, which single tab is allowed to spend them.
+
+</LearnChapter>
+
+</LearnPlayer>
+
+## Accessibility
 
 The container is `role="tablist"` with `aria-orientation="horizontal"`;
 each button is `role="tab"` with `aria-selected`. Focus and selection are
@@ -103,10 +115,3 @@ whatever's actually selected.
 ## Motion Score
 
 <MotionScorePanel name="magic-tab" />
-
-## The result
-
-<MagicTabResult />
-
-Same three spans, same bezier as Magic Button — Magic Tab just decides,
-per render, which single tab is allowed to spend them.

--- a/apps/docs/content/docs/components/navigation/mega-menu/learn.mdx
+++ b/apps/docs/content/docs/components/navigation/mega-menu/learn.mdx
@@ -1,7 +1,23 @@
 ---
 title: Anatomy of the Mega Menu
 description: How a trigger row shares one sliding highlight, measures its own panel content, and morphs its footprint from a one-column list to a two-column spread.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="Triggers, pill, and panel"
+  scene={<MegaMenuAnatomy />}
+  code={`{isHot && (
+  <motion.span
+    layoutId={highlightId}
+    transition={spring}
+    className="absolute inset-0 rounded-lg bg-accent"
+  />
+)}
+<span className="relative">{item.label}</span>`}
+>
 
 A mega menu is really two small components stapled together: a trigger row
 that behaves like a segmented control, and a panel that has to resize
@@ -9,62 +25,41 @@ itself for whatever content the hot trigger happens to carry. Neither part
 is hard alone — the trick is making them agree on timing so hovering
 across triggers never feels like it's fighting the panel underneath it.
 
-## Triggers, one shared pill, one panel
-
 The trigger row is plain buttons and links — no wrapper markup per item.
 A single highlight `motion.span` renders only under whichever trigger is
 "hot" (`hovered ?? active`), and triggers that carry a `sections` array
 open a panel of link columns below them:
 
-<MegaMenuAnatomy />
-
-```tsx
-{isHot && (
-  <motion.span
-    layoutId={highlightId}
-    transition={spring}
-    className="absolute inset-0 rounded-lg bg-accent"
-  />
-)}
-<span className="relative">{item.label}</span>
-```
-
 `hasPanel` triggers get `aria-haspopup="true"` and `aria-expanded`; plain
 links skip both — a mega menu isn't obligated to make every top-level item
 a dropdown.
 
-## One highlight slides between triggers
+</LearnChapter>
+
+<LearnChapter
+  label="One sliding highlight"
+  scene={<MegaMenuHighlight />}
+  code={`const spring = reduceMotion
+  ? { duration: 0 }
+  : ({ type: "spring", stiffness: 320, damping: 32, mass: 0.9 } as const);`}
+>
 
 Because the pill is one `motion.span` with a shared `layoutId`, moving the
 pointer from trigger to trigger doesn't cross-fade two separate
 backgrounds — framer diffs the old box against the new one and springs a
 single element between them, direction-aware for free:
 
-<MegaMenuHighlight />
-
-```tsx
-const spring = reduceMotion
-  ? { duration: 0 }
-  : ({ type: "spring", stiffness: 320, damping: 32, mass: 0.9 } as const);
-```
-
 The extra `mass: 0.9` (versus the `520/32` pill used elsewhere in the
 system) is deliberate — a mega menu's trigger row is wider and the highlight
 travels further per hop, so a touch more inertia keeps the slide from
 feeling twitchy over that distance.
 
-## The panel flows with the hot trigger
+</LearnChapter>
 
-This is the one place in GodUI navigation that intentionally animates a
-layout property. Hover from Product (two columns) to Resources (one) and
-the open panel doesn't unmount — it keeps the shell, measures the incoming
-content, and morphs `width`/`height` so the footprint flows around it while
-the links cross-fade:
-
-<MegaMenuMorph />
-
-```tsx
-useIsoLayoutEffect(() => {
+<LearnChapter
+  label="Panel footprint morph"
+  scene={<MegaMenuMorph />}
+  code={`useIsoLayoutEffect(() => {
   if (active === null) return;
   const el = contentRef.current;
   if (el) setBounds({ width: el.offsetWidth, height: el.offsetHeight });
@@ -74,8 +69,14 @@ useIsoLayoutEffect(() => {
   animate={{ width: bounds?.width ?? "auto", height: bounds?.height ?? "auto" }}
   transition={{ duration: 0.3, ease: [0.22, 1, 0.36, 1] }}
   className="relative overflow-hidden"
-/>
-```
+/>`}
+>
+
+This is the one place in GodUI navigation that intentionally animates a
+layout property. Hover from Product (two columns) to Resources (one) and
+the open panel doesn't unmount — it keeps the shell, measures the incoming
+content, and morphs `width`/`height` so the footprint flows around it while
+the links cross-fade:
 
 Faking that with `scale` would distort the text inside the panel. Reading
 `offsetWidth`/`offsetHeight` and animating layout is the honest trade: the
@@ -85,8 +86,6 @@ mode="popLayout"` keyed on `active`, so the outgoing column set never
 overlaps the incoming one mid-morph. In the Result below, hover Product
 then Resources to feel both the sliding highlight and the panel flow at
 once.
-
-## Open and close run on different clocks
 
 Hovering a trigger doesn't open its panel instantly — `scheduleOpen` waits
 `openDelay` (default `80ms`) before committing, so a fast sweep across
@@ -111,14 +110,18 @@ scheduleOpen(index)}`, and on touch, hover panels don't work at all, so
 `md:hidden` swaps the whole thing for an accordion drawer instead of trying
 to simulate hover.
 
-## Motion Score
+</LearnChapter>
 
-<MotionScorePanel name="mega-menu" />
-
-## The result
-
-<MegaMenuResult />
+<LearnChapter label="The result" scene={<MegaMenuResult />} isResult>
 
 One shared highlight, one measured panel, two independently-tuned timers —
 that's the whole mega menu, whether it's showing a single link or a
 two-column spread.
+
+</LearnChapter>
+
+</LearnPlayer>
+
+## Motion Score
+
+<MotionScorePanel name="mega-menu" />

--- a/apps/docs/content/docs/components/navigation/resizable-header/learn.mdx
+++ b/apps/docs/content/docs/components/navigation/resizable-header/learn.mdx
@@ -1,35 +1,47 @@
 ---
 title: Anatomy of the Resizable Header
 description: How one nav bar morphs from a wide rounded surface into a floating pill on scroll, and carries two independent layoutId tracks for hover and active state.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="One nav: logo, links, CTA"
+  scene={<ResizableHeaderAnatomy />}
+  code={`<motion.nav
+  layout
+  transition={spring}
+  className={\`... border border-border bg-background/70 backdrop-blur-xl \${
+    shrunk
+      ? "w-full max-w-2xl rounded-full px-3 py-2 shadow-lg"
+      : "w-full max-w-5xl rounded-2xl px-4 py-3 shadow-sm"
+  }\`}
+/>`}
+>
 
 Most "shrinking header" implementations swap two separate DOM trees at a
 breakpoint. Resizable Header is one `motion.nav` the whole time — a single
 element whose class names change and whose box framer FLIPs between them,
 so the shrink reads as one continuous move instead of a cut.
 
-## One nav: logo, links, CTA
-
 Structurally it's a `<header>` wrapping a single `motion.nav` — a
 shrink-0 logo on the left, a link row in the middle with room for a hover
 pill and an active underline, and a shrink-0 CTA plus mobile toggle on the
 right:
 
-<ResizableHeaderAnatomy />
+</LearnChapter>
 
-```tsx
-<motion.nav
-  layout
-  transition={spring}
-  className={`... border border-border bg-background/70 backdrop-blur-xl ${
-    shrunk
-      ? "w-full max-w-2xl rounded-full px-3 py-2 shadow-lg"
-      : "w-full max-w-5xl rounded-2xl px-4 py-3 shadow-sm"
-  }`}
-/>
-```
+<LearnChapter
+  label="Scroll threshold morph"
+  scene={<ResizableHeaderMorph />}
+  code={`const { scrollY } = useScroll(scrollRef ? { container: scrollRef } : undefined);
+useMotionValueEvent(scrollY, "change", (latest) => {
+  setShrunk(latest > scrollThreshold);
+});
 
-## Scroll crosses a threshold, the box morphs
+const spring = { type: "spring", stiffness: 320, damping: 32, mass: 0.9 };`}
+>
 
 `useScroll` tracks `scrollY`; a `useMotionValueEvent` listener flips a
 single boolean the instant it passes `scrollThreshold` (default `24px`).
@@ -38,41 +50,28 @@ That boolean is the only thing driving the two class strings above — the
 `max-w-5xl`/`rounded-2xl` to `max-w-2xl`/`rounded-full` on a spring instead
 of snapping:
 
-<ResizableHeaderMorph />
-
-```tsx
-const { scrollY } = useScroll(scrollRef ? { container: scrollRef } : undefined);
-useMotionValueEvent(scrollY, "change", (latest) => {
-  setShrunk(latest > scrollThreshold);
-});
-
-const spring = { type: "spring", stiffness: 320, damping: 32, mass: 0.9 };
-```
-
 The same `320/32/mass 0.9` spring as Mega Menu's panel morph — both are
 "resize a real box" animations, and both want that extra mass so a wide
 surface doesn't overshoot visibly on the way to its new width.
 
-## Two layoutId tracks on one link row
+</LearnChapter>
+
+<LearnChapter
+  label="Two layoutId tracks"
+  scene={<ResizableHeaderPills />}
+  code={`{hovered === link.href && (
+  <motion.span layoutId={\`\${ids.pill}-hover\`} transition={spring} className="... bg-accent" />
+)}
+{isActive && (
+  <motion.span layoutId={ids.pill} transition={spring} className="... bg-foreground" />
+)}`}
+>
 
 The link row carries two independent `motion.span`s, each bound to its own
 `layoutId`: a hover pill that fills whatever link the pointer is over, and
 a thin active underline that only follows a click. They don't know about
 each other — the hover pill can sweep past three links while the
 underline sits still on the one that's actually active:
-
-<ResizableHeaderPills />
-
-```tsx
-{hovered === link.href && (
-  <motion.span layoutId={`${ids.pill}-hover`} transition={spring} className="... bg-accent" />
-)}
-{isActive && (
-  <motion.span layoutId={ids.pill} transition={spring} className="... bg-foreground" />
-)}
-```
-
-## Sticky by default, container-aware, mobile-safe
 
 `sticky` (default `true`) pins the header with `sticky top-0 z-sticky`;
 set it `false` for a header that scrolls away normally. For layouts where
@@ -81,6 +80,17 @@ panel — pass `scrollRef` and `useScroll` tracks that container's scroll
 position instead of the window's. Below `md`, the link row and CTA hide
 entirely behind a hamburger button that opens an `AnimatePresence` dropdown
 sharing the header's border radius and shadow language.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<ResizableHeaderResult />} isResult>
+
+Scroll it: one nav, one threshold, one spring — the bar becomes a pill and
+the two highlight tracks keep riding along underneath it.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility
 
@@ -93,10 +103,3 @@ morph alone.
 ## Motion Score
 
 <MotionScorePanel name="resizable-header" />
-
-## The result
-
-<ResizableHeaderResult />
-
-Scroll it: one nav, one threshold, one spring — the bar becomes a pill and
-the two highlight tracks keep riding along underneath it.

--- a/apps/docs/content/docs/components/navigation/segmented-control/learn.mdx
+++ b/apps/docs/content/docs/components/navigation/segmented-control/learn.mdx
@@ -1,25 +1,15 @@
 ---
 title: Anatomy of the Segmented Control
 description: How a tab-like control renders one pill that lives inside whichever tab is active, and lets Framer's layoutId spring it between segments instead of cross-fading.
+learnPlayer: true
 ---
 
-A segmented control could be built as N buttons each tracking their own
-"am I selected" background. GodUI builds it as N buttons and exactly **one**
-pill, which is only ever rendered inside the currently active tab. Switching
-segments doesn't toggle a background on the old and new button — it moves
-the same element.
+<LearnPlayer>
 
-## One track, N tabs, one pill
-
-The track is a `role="tablist"` with `bg-muted`, rounded corners, and a
-little padding; each option is a `role="tab"` button. The pill itself is
-`absolute inset-0` of whichever button is active — conditionally rendered,
-so it only ever exists in one place in the DOM at a time:
-
-<SegmentedControlAnatomy />
-
-```tsx
-<div role="tablist" className="inline-flex items-center rounded-lg border bg-muted p-1">
+<LearnChapter
+  label="One track, one pill"
+  scene={<SegmentedControlAnatomy />}
+  code={`<div role="tablist" className="inline-flex items-center rounded-lg border bg-muted p-1">
   {options.map((opt) => {
     const active = opt.value === value;
     return (
@@ -34,14 +24,38 @@ so it only ever exists in one place in the DOM at a time:
       </button>
     );
   })}
-</div>
-```
+</div>`}
+>
+
+A segmented control could be built as N buttons each tracking their own
+"am I selected" background. GodUI builds it as N buttons and exactly **one**
+pill, which is only ever rendered inside the currently active tab. Switching
+segments doesn't toggle a background on the old and new button — it moves
+the same element.
+
+The track is a `role="tablist"` with `bg-muted`, rounded corners, and a
+little padding; each option is a `role="tab"` button. The pill itself is
+`absolute inset-0` of whichever button is active — conditionally rendered,
+so it only ever exists in one place in the DOM at a time:
 
 Because the pill is a child of the *button*, not the track, it's positioned
 with plain `inset-0` — no coordinate math to find "which tab am I under."
 The tab's own layout does that for free.
 
-## `layoutId` turns a remount into a slide
+</LearnChapter>
+
+<LearnChapter
+  label="layoutId slide"
+  scene={<SegmentedControlSlide />}
+  code={`let pillSeed = 0;
+const layoutId = React.useMemo(() => \`segmented-pill-\${pillSeed++}\`, []);
+
+<motion.span
+  layoutId={layoutId}
+  transition={{ type: "spring", stiffness: 520, damping: 32 }}
+  className="absolute inset-0 rounded-md bg-background shadow-sm"
+/>`}
+>
 
 When `value` changes, the pill unmounts from the old button and mounts in
 the new one — normally that would be two separate elements popping in and
@@ -49,26 +63,11 @@ out. `layoutId` tells Framer Motion these two mounts are "the same" element:
 it measures the old box, measures the new box, and animates a `transform`
 between them instead of letting either one just appear:
 
-<SegmentedControlSlide />
-
-```tsx
-let pillSeed = 0;
-const layoutId = React.useMemo(() => `segmented-pill-${pillSeed++}`, []);
-
-<motion.span
-  layoutId={layoutId}
-  transition={{ type: "spring", stiffness: 520, damping: 32 }}
-  className="absolute inset-0 rounded-md bg-background shadow-sm"
-/>
-```
-
 The per-instance `pillSeed` counter matters more than it looks: `layoutId`
 is matched globally across the page, so two `SegmentedControl`s rendered at
 once must never share an id, or Framer would try to slide a pill *between
 them*. Incrementing a module-level counter on every mount guarantees each
 instance gets its own namespace without a prop the consumer has to supply.
-
-## Press feedback, no extra state
 
 There's no separate "pressed" boolean to track. Every tab button carries
 `active:scale-[0.97]` — a plain CSS active-state utility, not a Framer
@@ -78,6 +77,19 @@ nothing while the control is idle:
 ```tsx
 className="... active:scale-[0.97] disabled:pointer-events-none disabled:opacity-40"
 ```
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<SegmentedControlResult />} isResult>
+
+Two lines of state (`value`, and a `layoutId` that only exists to keep
+instances apart) plus one conditionally-rendered pill — the slide is Framer
+measuring two boxes and animating between them, not a control tracking
+motion on its own.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility
 
@@ -93,12 +105,3 @@ pill still jumps to the new tab, it just doesn't slide.
 ## Motion Score
 
 <MotionScorePanel name="segmented-control" />
-
-## The result
-
-<SegmentedControlResult />
-
-Two lines of state (`value`, and a `layoutId` that only exists to keep
-instances apart) plus one conditionally-rendered pill — the slide is Framer
-measuring two boxes and animating between them, not a control tracking
-motion on its own.

--- a/apps/docs/content/docs/components/navigation/tab-bar/learn.mdx
+++ b/apps/docs/content/docs/components/navigation/tab-bar/learn.mdx
@@ -1,14 +1,27 @@
 ---
 title: Anatomy of the Tab Bar
 description: How a bottom nav's active indicator is one sliding blob, one popping icon, and a label that only exists on the tab that's currently active.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="Pill, blob, icon, label"
+  scene={<TabBarAnatomy />}
+  code={`{active && (
+  <motion.span
+    layoutId={blobId}
+    transition={spring}
+    className="absolute inset-0 rounded-full bg-primary shadow-sm"
+  />
+)}`}
+>
 
 A mobile tab bar has one job most desktop nav doesn't: it has to say "you
 are here" in a strip barely tall enough for an icon. Tab Bar answers with
 motion instead of more chrome — a blob that travels, an icon that pops,
 and a label that only shows up where it's needed.
-
-## One pill, one blob, icons plus a label
 
 The bar is a single rounded `<nav>` holding N `<button>` tabs. Every tab
 always shows its icon; only the active one renders the blob underneath it
@@ -16,49 +29,31 @@ and reveals its label — `labelsOnActiveOnly` (default `true`) is what
 keeps the inactive tabs icon-only so the row stays tight enough for four or
 five destinations:
 
-<TabBarAnatomy />
+</LearnChapter>
 
-```tsx
-{active && (
-  <motion.span
-    layoutId={blobId}
-    transition={spring}
-    className="absolute inset-0 rounded-full bg-primary shadow-sm"
-  />
-)}
-```
-
-## The blob is a spring, not four backgrounds
+<LearnChapter
+  label="One springing blob"
+  scene={<TabBarBlob />}
+  code={`const spring = reduceMotion
+  ? { duration: 0 }
+  : ({ type: "spring", stiffness: 520, damping: 32 } as const);`}
+>
 
 Like every other shared-highlight pattern in the system, there's exactly
 one blob element, bound by a `layoutId`. Switching the active tab doesn't
 swap a class on the old and new tab — framer sees the same `layoutId`
 land in a new box and springs it there:
 
-<TabBarBlob />
-
-```tsx
-const spring = reduceMotion
-  ? { duration: 0 }
-  : ({ type: "spring", stiffness: 520, damping: 32 } as const);
-```
-
 `520/32` is the fast, barely-overshooting spring — a bottom nav gets tapped
 in quick succession, so the blob needs to keep up without ever feeling like
 it's still catching up from the last tap.
 
-## Becoming active: a pop, then a label
+</LearnChapter>
 
-The instant a tab becomes active, its icon runs a `scale: [1, 1.18, 1]`
-keyframe — a tap-confirmation pop, not a hover effect, since bottom navs
-are touch surfaces first. The label reveal is honestly a layout animation:
-`motion.span` with `layout` animates `width: 0 → auto` so the text doesn't
-just snap into existence:
-
-<TabBarPop />
-
-```tsx
-<motion.span
+<LearnChapter
+  label="Pop, then label"
+  scene={<TabBarPop />}
+  code={`<motion.span
   animate={reduceMotion || !active ? { scale: 1 } : { scale: [1, 1.18, 1] }}
   transition={{ duration: 0.3, ease: "easeOut" }}
 >
@@ -68,8 +63,14 @@ just snap into existence:
   <motion.span layout initial={{ opacity: 0, width: 0 }} animate={{ opacity: 1, width: "auto" }} transition={spring}>
     {tab.label}
   </motion.span>
-)}
-```
+)}`}
+>
+
+The instant a tab becomes active, its icon runs a `scale: [1, 1.18, 1]`
+keyframe — a tap-confirmation pop, not a hover effect, since bottom navs
+are touch surfaces first. The label reveal is honestly a layout animation:
+`motion.span` with `layout` animates `width: 0 → auto` so the text doesn't
+just snap into existence:
 
 Animating `width` breaks the compositor-only rule the rest of GodUI's
 motion holds to — but it's the one place that trade is worth making: it
@@ -77,13 +78,22 @@ happens on at most one tab at a time, only on an explicit tap, and `layout`
 lets framer FLIP the width change into a transform under the hood rather
 than thrashing layout every frame.
 
-## Safe area, for real devices
-
 `safeArea` adds `pb-[max(0.375rem,env(safe-area-inset-bottom))]` — enough
 bottom padding to clear a home indicator on notched phones without adding
 dead space on devices that don't have one. It's opt-in because a tab bar
 docked inside a larger shell (a card, a modal) usually shouldn't reserve
 that space at all.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<TabBarResult />} isResult>
+
+One blob, one pop, one label that shows up exactly where it's active — the
+whole bar fits in the space of four icons and still tells you where you are.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility
 
@@ -97,10 +107,3 @@ decorative to assistive tech beyond what the label already conveys.
 ## Motion Score
 
 <MotionScorePanel name="tab-bar" />
-
-## The result
-
-<TabBarResult />
-
-One blob, one pop, one label that shows up exactly where it's active — the
-whole bar fits in the space of four icons and still tells you where you are.

--- a/apps/docs/content/docs/components/overlays/animated-tooltip/learn.mdx
+++ b/apps/docs/content/docs/components/overlays/animated-tooltip/learn.mdx
@@ -1,24 +1,15 @@
 ---
 title: Anatomy of the Animated Tooltip
 description: How one motion.span becomes a bouncy, pointer-tracking tooltip — the mount spring, the 3D tilt math, and why both share one spring config.
+learnPlayer: true
 ---
 
-Most tooltips are a `display` toggle with a CSS transition bolted on. Animated
-Tooltip is one `<span>` wrapper, an `AnimatePresence`, and two coupled springs
-— one for the mount, one for the pointer — built from the exact same
-`{ stiffness: 170, damping: 12, mass: 0.1 }` config so the whole thing feels
-like a single physical object.
+<LearnPlayer>
 
-## Anatomy
-
-The wrapper never unmounts. `open` — flipped by `onMouseEnter`/`onMouseLeave`
-and `onFocus`/`onBlur` — controls whether the panel and its caret exist at
-all:
-
-<AnimatedTooltipAnatomy />
-
-```tsx
-<span
+<LearnChapter
+  label="Anatomy"
+  scene={<AnimatedTooltipAnatomy />}
+  code={`<span
   onMouseEnter={() => setOpen(true)}
   onMouseLeave={() => setOpen(false)}
   onFocus={() => setOpen(true)}
@@ -29,24 +20,29 @@ all:
     {open ? <motion.span role="tooltip">{content}</motion.span> : null}
   </AnimatePresence>
   {children}
-</span>
-```
+</span>`}
+>
+
+Most tooltips are a `display` toggle with a CSS transition bolted on. Animated
+Tooltip is one `<span>` wrapper, an `AnimatePresence`, and two coupled springs
+— one for the mount, one for the pointer — built from the exact same
+`{ stiffness: 170, damping: 12, mass: 0.1 }` config so the whole thing feels
+like a single physical object.
+
+The wrapper never unmounts. `open` — flipped by `onMouseEnter`/`onMouseLeave`
+and `onFocus`/`onBlur` — controls whether the panel and its caret exist at
+all.
 
 The caret isn't a triangle or an SVG — it's a 2px square, `rotate-45`, tucked
 half-behind the panel's edge. Cheaper than a clip-path, and it inherits the
 panel's own background so there's nothing to keep in sync.
 
-## The motion
+</LearnChapter>
 
-The panel's `initial`/`animate` pair isn't a fade with a duration; it's a
-spring, and a deliberately underdamped one. `damping: 12` against
-`stiffness: 170` with a featherweight `mass: 0.1` means it doesn't ease up to
-`scale: 1` — it flies past it and springs back:
-
-<AnimatedTooltipSpring />
-
-```tsx
-<motion.span
+<LearnChapter
+  label="The motion"
+  scene={<AnimatedTooltipSpring />}
+  code={`<motion.span
   initial={{ opacity: 0, y: isTop ? 8 : -8, scale: 0.85 }}
   animate={{
     opacity: 1,
@@ -55,33 +51,38 @@ spring, and a deliberately underdamped one. `damping: 12` against
     transition: { type: "spring", stiffness: 170, damping: 12, mass: 0.1 },
   }}
   exit={{ opacity: 0, y: isTop ? 6 : -6, scale: 0.9 }}
-/>
-```
+/>`}
+>
+
+The panel's `initial`/`animate` pair isn't a fade with a duration; it's a
+spring, and a deliberately underdamped one. `damping: 12` against
+`stiffness: 170` with a featherweight `mass: 0.1` means it doesn't ease up to
+`scale: 1` — it flies past it and springs back.
 
 Notice the exit isn't a spring at all — no `transition` is specified, so it
 falls back to Framer's default tween. The bounce is a *hello*, not a
 *goodbye*: reserved for the moment the tooltip earns your attention, skipped
 on the way out because nobody's watching it leave.
 
-## Pointer tilt
+</LearnChapter>
 
-The 3D read comes from a second spring riding the same config, driven by the
-cursor instead of a mount/unmount. `onMouseMove` measures the pointer against
-the trigger's own center — not the page — so the math is symmetric around
-zero regardless of where the trigger sits:
-
-<AnimatedTooltipTilt />
-
-```tsx
-const x = useMotionValue(0);
+<LearnChapter
+  label="Pointer tilt"
+  scene={<AnimatedTooltipTilt />}
+  code={`const x = useMotionValue(0);
 const rotate = useSpring(useTransform(x, [-60, 60], [-14, 14]), SPRING);
 const translateX = useSpring(useTransform(x, [-60, 60], [-12, 12]), SPRING);
 
 const handleMouseMove = (e: React.MouseEvent<HTMLSpanElement>) => {
   const rect = e.currentTarget.getBoundingClientRect();
   x.set(e.clientX - rect.left - rect.width / 2);
-};
-```
+};`}
+>
+
+The 3D read comes from a second spring riding the same config, driven by the
+cursor instead of a mount/unmount. `onMouseMove` measures the pointer against
+the trigger's own center — not the page — so the math is symmetric around
+zero regardless of where the trigger sits.
 
 `useTransform` is the instant, unanimated remap — pure interpolation, no
 easing. `useSpring` is what wraps around it, turning that instantaneous
@@ -95,6 +96,18 @@ off the motion values directly — no re-render per pixel of mouse movement.
 caret's own `rotate-45` compositing correctly together instead of one
 flattening the other.
 
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<AnimatedTooltipResult />} isResult>
+
+One spring config, two jobs: the panel springs into existence, and once it
+exists, the same numbers govern how it leans toward wherever you're
+pointing.
+
+</LearnChapter>
+
+</LearnPlayer>
+
 ## Accessibility
 
 `role="tooltip"` is on the panel itself, and it opens on `onFocus` exactly
@@ -106,11 +119,3 @@ routed through the identical `AnimatePresence`.
 ## Motion Score
 
 <MotionScorePanel name="animated-tooltip" />
-
-## The result
-
-<AnimatedTooltipResult />
-
-One spring config, two jobs: the panel springs into existence, and once it
-exists, the same numbers govern how it leans toward wherever you're
-pointing.

--- a/apps/docs/content/docs/components/overlays/command-palette/learn.mdx
+++ b/apps/docs/content/docs/components/overlays/command-palette/learn.mdx
@@ -1,27 +1,15 @@
 ---
 title: Anatomy of the Command Palette
 description: How a flat groups array becomes a spring-loaded ⌘K menu, with a single highlight that springs between rows instead of restyling them.
+learnPlayer: true
 ---
 
-A command palette is three unglamorous jobs wearing one glossy interaction:
-mount an overlay, filter a list as you type, and keep a keyboard cursor in
-sync with the mouse. None of that is hard on its own — what makes it feel
-fast is that the filtering, the keyboard, and the ⌘K shortcut all share one
-piece of state, and the "active" row is one animated element, not a
-re-render of every row.
+<LearnPlayer>
 
-## Backdrop, panel, rows
-
-`CommandPalette` portals a fixed-position layer into `document.body` and
-renders it only while `open` is true, via `AnimatePresence`. Behind the
-panel sits a click-to-close backdrop; inside it, a search input drives a
-`useMemo`'d filter over `groups`, and the surviving items render flat, one
-`<button role="menuitem">` per row:
-
-<CommandPaletteAnatomy />
-
-```tsx
-const filteredGroups = groups
+<LearnChapter
+  label="Backdrop, panel, rows"
+  scene={<CommandPaletteAnatomy />}
+  code={`const filteredGroups = groups
   .map((g) => ({ ...g, items: g.items.filter((i) => matches(i, query)) }))
   .filter((g) => g.items.length > 0);
 
@@ -32,29 +20,42 @@ function matches(item: CommandItem, query: string) {
     item.label.toLowerCase().includes(q) ||
     item.keywords?.some((k) => k.toLowerCase().includes(q)) === true
   );
-}
-```
+}`}
+>
+
+A command palette is three unglamorous jobs wearing one glossy interaction:
+mount an overlay, filter a list as you type, and keep a keyboard cursor in
+sync with the mouse. None of that is hard on its own — what makes it feel
+fast is that the filtering, the keyboard, and the ⌘K shortcut all share one
+piece of state, and the "active" row is one animated element, not a
+re-render of every row.
+
+`CommandPalette` portals a fixed-position layer into `document.body` and
+renders it only while `open` is true, via `AnimatePresence`. Behind the
+panel sits a click-to-close backdrop; inside it, a search input drives a
+`useMemo`'d filter over `groups`, and the surviving items render flat, one
+`<button role="menuitem">` per row.
 
 `matches` checks the label *and* an optional `keywords` array, so an item
 titled "Toggle Theme" can still surface on "dark" or "light" — the palette
 searches intent, not just the string on screen.
 
-## Enter and exit share one spring
+</LearnChapter>
 
-The panel doesn't fade in from nowhere — it resolves out of a blur, like a
-lens racking into focus. `initial`/`animate`/`exit` move four properties at
-once (`opacity`, `scale`, `y`, `filter: blur()`), all on the same spring:
-
-<CommandPaletteEnter />
-
-```tsx
-<motion.div
+<LearnChapter
+  label="Enter and exit spring"
+  scene={<CommandPaletteEnter />}
+  code={`<motion.div
   initial={{ opacity: 0, scale: 0.96, y: -8, filter: "blur(8px)" }}
   animate={{ opacity: 1, scale: 1, y: 0, filter: "blur(0px)" }}
   exit={{ opacity: 0, scale: 0.97, y: -6, filter: "blur(6px)" }}
   transition={{ type: "spring", stiffness: 320, damping: 32, mass: 0.9 }}
-/>
-```
+/>`}
+>
+
+The panel doesn't fade in from nowhere — it resolves out of a blur, like a
+lens racking into focus. `initial`/`animate`/`exit` move four properties at
+once (`opacity`, `scale`, `y`, `filter: blur()`), all on the same spring.
 
 The exit isn't a mirror of the entrance — `scale 0.97` and `y -6` are a
 shorter throw than `0.96`/`-8`, and the blur is 6px instead of 8. Dismissing
@@ -62,23 +63,23 @@ reads as a quick settle rather than the entrance played backward, which
 matters because exits happen far more often than opens (every `Escape`,
 every selection, every backdrop click).
 
-## One highlight, not one per row
+</LearnChapter>
 
-The active-row indicator isn't a class toggled on whichever row is hot —
-it's a single `motion.span` that only ever exists inside one row at a time,
-bound by a shared `layoutId`:
-
-<CommandPaletteHighlight />
-
-```tsx
-{isActive ? (
+<LearnChapter
+  label="One highlight"
+  scene={<CommandPaletteHighlight />}
+  code={`{isActive ? (
   <motion.span
     layoutId="command-active"
     transition={{ type: "spring", stiffness: 500, damping: 35 }}
     className="absolute inset-0 rounded-lg bg-accent"
   />
-) : null}
-```
+) : null}`}
+>
+
+The active-row indicator isn't a class toggled on whichever row is hot —
+it's a single `motion.span` that only ever exists inside one row at a time,
+bound by a shared `layoutId`.
 
 When `activeIndex` changes — `ArrowDown`/`ArrowUp`, or `onMouseMove`
 re-targeting the row under the cursor — the span it was rendered inside
@@ -87,6 +88,18 @@ unmounts and a new one mounts in the new row. Framer notices they share
 transform instead of cross-fading two static rects. The spring is stiffer
 than the panel's own enter (`500/35` vs `320/32`) because it has to keep up
 with a held-down arrow key without lagging behind it.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<CommandPaletteResult />} isResult>
+
+One `groups` array, filtered in place, walked flat, with a single animated
+highlight riding on top of it. The panel is a spring; the rows are just
+data.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Keyboard, ⌘K, and cleanup
 
@@ -117,11 +130,3 @@ palette, and it never leaks the lock if the component unmounts mid-session.
 ## Motion Score
 
 <MotionScorePanel name="command-palette" />
-
-## The result
-
-<CommandPaletteResult />
-
-One `groups` array, filtered in place, walked flat, with a single animated
-highlight riding on top of it. The panel is a spring; the rows are just
-data.

--- a/apps/docs/content/docs/components/overlays/drawer/learn.mdx
+++ b/apps/docs/content/docs/components/overlays/drawer/learn.mdx
@@ -1,7 +1,19 @@
 ---
 title: Anatomy of the Drawer
 description: How a sheet pinned to one edge slides purely on transform, and why its drag gesture only stretches in the direction that dismisses it.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="Pinned to an edge"
+  scene={<DrawerAnatomy />}
+  code={`const PANEL_BY_SIDE: Record<DrawerSide, string> = {
+  bottom: "inset-x-0 bottom-0 max-h-[90vh] rounded-t-2xl border-t border-border",
+  right:  "inset-y-0 right-0 w-full max-w-md rounded-l-2xl border-l border-border",
+};`}
+>
 
 A drawer is a modal that refuses to feel like one. It's still a portalled
 overlay with a backdrop and a `role="dialog"`, but it lives on an edge
@@ -11,37 +23,21 @@ in. Every one of those differences comes down to one idea: the panel is
 never really "positioned," it's always at its resting `top`/`right`, and
 everything you see is a `transform` on top of that.
 
-## One panel, pinned to an edge
-
 `side="bottom"` and `side="right"` render the same `motion.div`, just with
 different resting classes and a different drag axis. The bottom sheet gets
 `inset-x-0 bottom-0` plus a grab handle; the side panel gets `inset-y-0
-right-0` and no handle:
-
-<DrawerAnatomy />
-
-```tsx
-const PANEL_BY_SIDE: Record<DrawerSide, string> = {
-  bottom: "inset-x-0 bottom-0 max-h-[90vh] rounded-t-2xl border-t border-border",
-  right:  "inset-y-0 right-0 w-full max-w-md rounded-l-2xl border-l border-border",
-};
-```
+right-0` and no handle.
 
 Because those classes never change while the drawer is open, the browser
 never has to reflow the panel's box — everything that moves after mount is
 a `transform`, which brings us to the actual animation.
 
-## It slides, it never repositions
+</LearnChapter>
 
-Hidden and shown are two `transform` values, nothing else. For the bottom
-sheet that's `y: "100%"` (pushed one full panel-height below its own edge)
-to `y: 0`; for the right panel it's the same idea on `x`. One spring drives
-both directions:
-
-<DrawerSpring />
-
-```tsx
-const hidden = isBottom ? { y: "100%" } : { x: "100%" };
+<LearnChapter
+  label="It slides, never repositions"
+  scene={<DrawerSpring />}
+  code={`const hidden = isBottom ? { y: "100%" } : { x: "100%" };
 const shown = isBottom ? { y: 0 } : { x: 0 };
 
 <motion.div
@@ -50,23 +46,24 @@ const shown = isBottom ? { y: 0 } : { x: 0 };
   exit={hidden}
   transition={{ type: "spring", damping: 32, stiffness: 320, mass: 0.9 }}
   drag={isBottom ? "y" : "x"}
-/>
-```
+/>`}
+>
+
+Hidden and shown are two `transform` values, nothing else. For the bottom
+sheet that's `y: "100%"` (pushed one full panel-height below its own edge)
+to `y: 0`; for the right panel it's the same idea on `x`. One spring drives
+both directions.
 
 Because the resting layout never moves, `%`-based transforms stay correct
 at every viewport size without a resize listener — `100%` is always exactly
 one panel-length, on any screen.
 
-## The drag only stretches one way
+</LearnChapter>
 
-The same axis the panel slides on is also the axis you can drag it on, but
-`dragElastic` is asymmetric — it only gives in the direction that dismisses
-the drawer, and stiffens the harder you pull:
-
-<DrawerDismiss />
-
-```tsx
-const CLOSE_OFFSET = 120;
+<LearnChapter
+  label="Drag only one way"
+  scene={<DrawerDismiss />}
+  code={`const CLOSE_OFFSET = 120;
 const CLOSE_VELOCITY = 600;
 
 <motion.div
@@ -74,8 +71,12 @@ const CLOSE_VELOCITY = 600;
   dragConstraints={{ top: 0, bottom: 0, left: 0, right: 0 }}
   dragElastic={isBottom ? { top: 0, bottom: 0.6 } : { left: 0, right: 0.6 }}
   onDragEnd={handleDragEnd}
-/>
-```
+/>`}
+>
+
+The same axis the panel slides on is also the axis you can drag it on, but
+`dragElastic` is asymmetric — it only gives in the direction that dismisses
+the drawer, and stiffens the harder you pull.
 
 `dragConstraints` is zero on every side — there's no real travel budget —
 so all of the give comes from `dragElastic`'s rubber-band math on the
@@ -98,6 +99,19 @@ enough (`> 600px/s`) even from a short drag. Anything short of both and the
 panel has no memory of the gesture — it just springs back to `y: 0` on the
 same transition the open used, because dropping the drag doesn't change
 `animate`.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<DrawerResult />} isResult>
+
+Same component, two edges: a cart on the right you drag away horizontally,
+a share sheet on the bottom you drag away vertically — one spring, one
+elastic drag axis, and a threshold that decides when a gesture becomes a
+dismissal.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Escape, scrim, and scroll lock
 
@@ -131,12 +145,3 @@ that's visually the drawer.
 ## Motion Score
 
 <MotionScorePanel name="drawer" />
-
-## The result
-
-<DrawerResult />
-
-Same component, two edges: a cart on the right you drag away horizontally,
-a share sheet on the bottom you drag away vertically — one spring, one
-elastic drag axis, and a threshold that decides when a gesture becomes a
-dismissal.

--- a/apps/docs/content/docs/components/overlays/dynamic-island/learn.mdx
+++ b/apps/docs/content/docs/components/overlays/dynamic-island/learn.mdx
@@ -1,23 +1,15 @@
 ---
 title: Anatomy of the Dynamic Island
 description: How five fixed size presets, one stiff spring, and a separate crossfade combine into Apple's signature pill.
+learnPlayer: true
 ---
 
-The Dynamic Island's shell and its content are animated by two entirely
-different systems that happen to sit inside the same element: the shell's
-box model is driven by `layout` + explicit `animate`, and the content inside
-it is a nested `AnimatePresence` that doesn't know or care what shape it's
-sitting in.
+<LearnPlayer>
 
-## Five presets, nothing computed
-
-There's no formula deriving a size from content — `SIZES` is a lookup table,
-and every shape the shell can take is one of exactly five entries:
-
-<DynamicIslandAnatomy />
-
-```tsx
-const SIZES: Record<
+<LearnChapter
+  label="Five presets"
+  scene={<DynamicIslandAnatomy />}
+  code={`const SIZES: Record<
   DynamicIslandSize,
   { width: number; height: number; radius: number }
 > = {
@@ -26,22 +18,28 @@ const SIZES: Record<
   long: { width: 360, height: 52, radius: 26 },
   tall: { width: 260, height: 120, radius: 28 },
   large: { width: 360, height: 200, radius: 36 },
-};
-```
+};`}
+>
+
+The Dynamic Island's shell and its content are animated by two entirely
+different systems that happen to sit inside the same element: the shell's
+box model is driven by `layout` + explicit `animate`, and the content inside
+it is a nested `AnimatePresence` that doesn't know or care what shape it's
+sitting in.
+
+There's no formula deriving a size from content — `SIZES` is a lookup table,
+and every shape the shell can take is one of exactly five entries.
 
 Passing a size you haven't defined isn't possible — `DynamicIslandSize` is a
 union of these five keys, so the shell only ever animates between known,
 designed states, never an arbitrary in-between.
 
-## The shell spring
+</LearnChapter>
 
-Changing `size` triggers one `animate` call across all three box properties
-at once:
-
-<DynamicIslandShell />
-
-```tsx
-// Underdamped so the shell settles with the signature rubbery overshoot.
+<LearnChapter
+  label="The shell spring"
+  scene={<DynamicIslandShell />}
+  code={`// Underdamped so the shell settles with the signature rubbery overshoot.
 const SHELL_SPRING = {
   type: "spring" as const,
   stiffness: 520,
@@ -58,8 +56,11 @@ const SHELL_SPRING = {
   }}
   transition={reduceMotion ? { duration: 0 } : SHELL_SPRING}
   className="relative flex items-center justify-center overflow-hidden bg-black text-white shadow-xl"
-/>
-```
+/>`}
+>
+
+Changing `size` triggers one `animate` call across all three box properties
+at once.
 
 `stiffness: 520` is considerably stiffer than the morph dialog's `320` —
 the island snaps toward its target almost immediately and only overshoots by
@@ -70,15 +71,12 @@ capsules anymore — their radius is much smaller than half the height — so th
 scene above springs the same three box properties the component does, rather
 than faking the morph with `scale` (which would warp the corners).
 
-## The content crossfade
+</LearnChapter>
 
-The shell's `animate` only touches the box. What's inside crossfades through
-its own, independent `AnimatePresence`:
-
-<DynamicIslandCrossfade />
-
-```tsx
-const key = presenceKey ?? size;
+<LearnChapter
+  label="The content crossfade"
+  scene={<DynamicIslandCrossfade />}
+  code={`const key = presenceKey ?? size;
 
 <AnimatePresence mode="popLayout" initial={false}>
   <motion.div
@@ -90,8 +88,11 @@ const key = presenceKey ?? size;
   >
     {children}
   </motion.div>
-</AnimatePresence>
-```
+</AnimatePresence>`}
+>
+
+The shell's `animate` only touches the box. What's inside crossfades through
+its own, independent `AnimatePresence`.
 
 `presenceKey` defaults to `size`, so simply switching shapes is enough to
 trigger a crossfade — but it's a separate prop precisely so you can keep the
@@ -100,6 +101,17 @@ trigger a crossfade — but it's a separate prop precisely so you can keep the
 means the exiting and entering views animate concurrently rather than
 waiting their turn, which is what makes it read as one view dissolving into
 the next instead of two sequential fades.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<DynamicIslandResult />} isResult>
+
+Two systems, cleanly separated: a five-preset shell spring for the box, and
+an independent crossfade for whatever you put inside it.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Cheap when idle
 
@@ -121,10 +133,3 @@ content — motion is what's skipped, not state.
 ## Motion Score
 
 <MotionScorePanel name="dynamic-island" />
-
-## The result
-
-<DynamicIslandResult />
-
-Two systems, cleanly separated: a five-preset shell spring for the box, and
-an independent crossfade for whatever you put inside it.

--- a/apps/docs/content/docs/components/overlays/floating-toolbar/learn.mdx
+++ b/apps/docs/content/docs/components/overlays/floating-toolbar/learn.mdx
@@ -1,25 +1,15 @@
 ---
 title: Anatomy of the Floating Toolbar
 description: How one AnimatePresence and a shared spring turn a flat actions array into a toolbar that springs into place and lifts under the pointer.
+learnPlayer: true
 ---
 
-Floating Toolbar looks like a simple contextual bar, but it's built from one
-spring config reused three times: once for the whole shell mounting in,
-once for the shell leaving, and once per action button, per interaction. The
-component itself is small — the feel comes entirely from reusing that one
-number set consistently.
+<LearnPlayer>
 
-## Anatomy
-
-`actions` is a flat array, same shape philosophy as Context Menu — no
-compound components, just objects the toolbar maps over. Structurally, an
-"active" action is identical to an idle one; only `aria-pressed` and two
-class names differ:
-
-<FloatingToolbarAnatomy />
-
-```tsx
-<motion.div role="toolbar" aria-label="Floating toolbar" layout>
+<LearnChapter
+  label="Anatomy"
+  scene={<FloatingToolbarAnatomy />}
+  code={`<motion.div role="toolbar" aria-label="Floating toolbar" layout>
   {actions.map((action) => (
     <motion.button
       key={action.label}
@@ -34,22 +24,30 @@ class names differ:
       {action.icon}
     </motion.button>
   ))}
-</motion.div>
-```
+</motion.div>`}
+>
+
+Floating Toolbar looks like a simple contextual bar, but it's built from one
+spring config reused three times: once for the whole shell mounting in,
+once for the shell leaving, and once per action button, per interaction. The
+component itself is small — the feel comes entirely from reusing that one
+number set consistently.
+
+`actions` is a flat array, same shape philosophy as Context Menu — no
+compound components, just objects the toolbar maps over. Structurally, an
+"active" action is identical to an idle one; only `aria-pressed` and two
+class names differ.
 
 Every button — and the shell around them — carries `layout`. Add or remove
 an action and Framer measures the before/after boxes and animates the diff,
 so the row never jump-cuts when its contents change.
 
-## The motion
+</LearnChapter>
 
-The shell doesn't just fade — `AnimatePresence` mounts and unmounts the
-whole `motion.div`, and the enter is a stiff, barely-overshooting spring:
-
-<FloatingToolbarEnter />
-
-```tsx
-<AnimatePresence>
+<LearnChapter
+  label="The motion"
+  scene={<FloatingToolbarEnter />}
+  code={`<AnimatePresence>
   {open && (
     <motion.div
       initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 12, scale: 0.92 }}
@@ -60,8 +58,11 @@ whole `motion.div`, and the enter is a stiff, barely-overshooting spring:
       {/* actions */}
     </motion.div>
   )}
-</AnimatePresence>
-```
+</AnimatePresence>`}
+>
+
+The shell doesn't just fade — `AnimatePresence` mounts and unmounts the
+whole `motion.div`, and the enter is a stiff, barely-overshooting spring.
 
 `520/32` is a much stiffer, more critically-damped pair than the tooltip's
 `170/12/0.1` — this needs to feel *immediate*, like the toolbar was always
@@ -70,23 +71,23 @@ isn't the mirror of the enter (`y: 8`, not `12`; `scale: 0.95`, not `0.92`):
 it travels a shorter distance on the way out, because a lingering overshoot
 on dismissal would read as sluggish.
 
-## Per-action spring
+</LearnChapter>
 
-The same `520/32` spring drives every action's hover and press state,
-independent of the shell:
-
-<FloatingToolbarMagnetic />
-
-```tsx
-<motion.button
+<LearnChapter
+  label="Per-action spring"
+  scene={<FloatingToolbarMagnetic />}
+  code={`<motion.button
   layout
   whileHover={reduceMotion ? undefined : { y: -2, scale: 1.08 }}
   whileTap={reduceMotion ? undefined : { scale: 0.94 }}
   transition={{ type: "spring", stiffness: 520, damping: 32 }}
 >
   {action.icon}
-</motion.button>
-```
+</motion.button>`}
+>
+
+The same `520/32` spring drives every action's hover and press state,
+independent of the shell.
 
 `whileHover`/`whileTap` are declarative targets, not event handlers you wire
 up yourself — Framer owns the pointer listeners and animates toward whichever
@@ -94,6 +95,18 @@ state is currently true. Because it's the *same* spring as the shell's
 entrance, a button lifting under the cursor feels like it's made of the same
 material as the toolbar it's floating in, not a separate hover effect
 layered on top.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<FloatingToolbarResult />} isResult>
+
+Two springs, one number set: `stiffness: 520, damping: 32` gets the whole
+shell in and out, and gets each button lifting and settling under the
+pointer — reused, not reinvented, for every piece that moves.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility
 
@@ -108,11 +121,3 @@ respond to hover/tap, just without the y-shift, scale, or overshoot.
 ## Motion Score
 
 <MotionScorePanel name="floating-toolbar" />
-
-## The result
-
-<FloatingToolbarResult />
-
-Two springs, one number set: `stiffness: 520, damping: 32` gets the whole
-shell in and out, and gets each button lifting and settling under the
-pointer — reused, not reinvented, for every piece that moves.

--- a/apps/docs/content/docs/components/overlays/morphing-dialog/learn.mdx
+++ b/apps/docs/content/docs/components/overlays/morphing-dialog/learn.mdx
@@ -1,7 +1,25 @@
 ---
 title: Anatomy of the Morphing Dialog
 description: How one Framer Motion layoutId turns a card into a modal, and springs it back, without a single manually-coordinated animation.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="One id, two boxes"
+  scene={<MorphingDialogAnatomy />}
+  code={`const value = React.useMemo<MorphingDialogContextValue>(
+  () => ({
+    isOpen,
+    open: () => setOpen(true),
+    close: () => setOpen(false),
+    layoutId: \`morphing-dialog-\${layoutId}\`,
+    reduceMotion,
+  }),
+  [isOpen, setOpen, layoutId, reduceMotion],
+);`}
+>
 
 Most "expand to modal" implementations fake it: absolutely position a clone
 over the card, animate its box, then swap in the real modal underneath. Morphing
@@ -9,25 +27,8 @@ Dialog doesn't clone anything — it renders the trigger and the content as two
 components that share one `layoutId`, and lets Framer Motion's layout engine
 do the interpolation.
 
-## One id, two measured boxes
-
 `MorphingDialog` is a context provider; it mints a single `layoutId` and hands
-it to both `MorphingDialogTrigger` and `MorphingDialogContent`:
-
-<MorphingDialogAnatomy />
-
-```tsx
-const value = React.useMemo<MorphingDialogContextValue>(
-  () => ({
-    isOpen,
-    open: () => setOpen(true),
-    close: () => setOpen(false),
-    layoutId: `morphing-dialog-${layoutId}`,
-    reduceMotion,
-  }),
-  [isOpen, setOpen, layoutId, reduceMotion],
-);
-```
+it to both `MorphingDialogTrigger` and `MorphingDialogContent`.
 
 Both pieces are just `motion.div`s with `layoutId={layoutId}` set. Framer
 tracks every element with a shared `layoutId` across the tree; when one
@@ -37,15 +38,12 @@ and the other is present, it measures both rects and animates the difference
 `morph()` call anywhere in the source; the "morph" is just two elements
 agreeing to be the same thing.
 
-## The morph spring
+</LearnChapter>
 
-The interpolation itself runs on one transition, tuned specifically for this
-motion:
-
-<MorphingDialogSpring />
-
-```tsx
-// Underdamped so the card settles into the modal with a soft, premium overshoot.
+<LearnChapter
+  label="The morph spring"
+  scene={<MorphingDialogSpring />}
+  code={`// Underdamped so the card settles into the modal with a soft, premium overshoot.
 const MORPH_SPRING = {
   type: "spring" as const,
   stiffness: 320,
@@ -57,8 +55,11 @@ const MORPH_SPRING = {
   layoutId={layoutId}
   transition={reduceMotion ? { duration: 0 } : MORPH_SPRING}
   className="relative z-raised overflow-hidden bg-card text-card-foreground shadow-2xl"
+/>`}
 >
-```
+
+The interpolation itself runs on one transition, tuned specifically for this
+motion.
 
 `stiffness: 320` with `damping: 32` is underdamped enough to overshoot by a
 hair before settling — the card doesn't just resize, it feels like it has
@@ -67,17 +68,12 @@ Everything else about the panel — its border radius, its internal layout —
 rides along on the same spring because it's the same animated `layoutId`
 element, not a second thing chasing it.
 
-## Backdrop, portal, and independent timing
+</LearnChapter>
 
-The morph is only one of three things happening on open. `MorphingDialogContent`
-mounts through `createPortal` into `document.body` (so `z-modal` always wins,
-regardless of where the trigger lives in the DOM), and it renders its own
-backdrop with a completely separate transition:
-
-<MorphingDialogBackdrop />
-
-```tsx
-<motion.button
+<LearnChapter
+  label="Backdrop and portal"
+  scene={<MorphingDialogBackdrop />}
+  code={`<motion.button
   data-slot="morphing-dialog-backdrop"
   onClick={close}
   initial={{ opacity: 0 }}
@@ -85,8 +81,13 @@ backdrop with a completely separate transition:
   exit={{ opacity: 0 }}
   transition={{ duration: reduceMotion ? 0 : 0.2 }}
   className="absolute inset-0 cursor-default bg-black/50 backdrop-blur-sm"
-/>
-```
+/>`}
+>
+
+The morph is only one of three things happening on open. `MorphingDialogContent`
+mounts through `createPortal` into `document.body` (so `z-modal` always wins,
+regardless of where the trigger lives in the DOM), and it renders its own
+backdrop with a completely separate transition.
 
 The backdrop is a flat opacity tween — no spring, no overshoot, because a
 dimming layer springing would look like a glitch. The close button uses the
@@ -105,6 +106,18 @@ never appears mid-morph, only once the panel has essentially arrived:
 ```
 
 Three timelines, three easings, one moment.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<MorphingDialogResult />} isResult>
+
+One `layoutId`, one spring, and a portal — that's the entire mechanism.
+Everything else (the backdrop, the close delay, the escape key) is
+choreography layered on top of a single measured interpolation.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Dismissal and reduced motion
 
@@ -137,11 +150,3 @@ becomes the modal — it just doesn't travel to get there.
 ## Motion Score
 
 <MotionScorePanel name="morphing-dialog" />
-
-## The result
-
-<MorphingDialogResult />
-
-One `layoutId`, one spring, and a portal — that's the entire mechanism.
-Everything else (the backdrop, the close delay, the escape key) is
-choreography layered on top of a single measured interpolation.

--- a/apps/docs/content/docs/components/overlays/toast/learn.mdx
+++ b/apps/docs/content/docs/components/overlays/toast/learn.mdx
@@ -1,14 +1,31 @@
 ---
 title: Anatomy of the Toast
 description: How toast() reaches any component without context, and how a stack of plain divs becomes a hoverable, swipeable pile.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="Anatomy of the stack"
+  scene={<ToastAnatomy />}
+  code={`// Stacking tuning.
+const GAP = 14; // px between toasts when expanded
+const PEEK = 16; // px each toast peeks out behind the front when collapsed
+const SCALE_STEP = 0.05; // scale lost per depth when collapsed
+const MAX_VISIBLE = 3; // toasts shown behind the front when collapsed
+
+const dir = isBottom ? -1 : 1; // stack grows away from the anchored edge
+const hidden = !expanded && index >= MAX_VISIBLE;
+
+const y = expanded ? dir * expandedOffset : dir * index * PEEK;
+const scale = expanded ? 1 : Math.max(0, 1 - index * SCALE_STEP);`}
+>
 
 `toast()` works from anywhere — an event handler, a `fetch` callback, a
 non-component utility function — with no `<ToastContext>` to wrap your app
 in. That's because there isn't one. The whole system is a module-level array
 and a `Set` of subscribers.
-
-## An external store, not a context
 
 ```tsx
 // Minimal external store so `toast()` can be called from anywhere, no context needed.
@@ -34,47 +51,29 @@ function with no React tree in scope, and it mutates `records` and notifies
 every mounted `ToastProvider` — typically one, rendered once near your app
 root.
 
-## Anatomy of the stack
-
 The stack isn't a `<ul>` with `gap`; it's absolutely-positioned cards that
-compute their own offset from their index:
-
-<ToastAnatomy />
-
-```tsx
-// Stacking tuning.
-const GAP = 14; // px between toasts when expanded
-const PEEK = 16; // px each toast peeks out behind the front when collapsed
-const SCALE_STEP = 0.05; // scale lost per depth when collapsed
-const MAX_VISIBLE = 3; // toasts shown behind the front when collapsed
-
-const dir = isBottom ? -1 : 1; // stack grows away from the anchored edge
-const hidden = !expanded && index >= MAX_VISIBLE;
-
-const y = expanded ? dir * expandedOffset : dir * index * PEEK;
-const scale = expanded ? 1 : Math.max(0, 1 - index * SCALE_STEP);
-```
+compute their own offset from their index.
 
 Every card is full-size and positioned at the same `inset-x-0`; it's the `y`
 offset and `scale` shrinking with depth that make only a sliver of each
 back card visible above the front one. Past `MAX_VISIBLE`, a toast still
 exists in the DOM — it's just `opacity: 0`, ready the instant it's promoted.
 
-## Expand on hover, pause on hover
+</LearnChapter>
 
-`ToastProvider` tracks one `expanded` boolean, flipped by the mouse leaving
-or entering the stack region:
-
-<ToastExpand />
-
-```tsx
-<motion.ol
+<LearnChapter
+  label="Expand on hover"
+  scene={<ToastExpand />}
+  code={`<motion.ol
   onMouseEnter={() => setExpanded(true)}
   onMouseLeave={() => setExpanded(false)}
   animate={{ height: regionHeight }}
   transition={TOAST_SPRING}
+>`}
 >
-```
+
+`ToastProvider` tracks one `expanded` boolean, flipped by the mouse leaving
+or entering the stack region.
 
 Expanding swaps every card's `y` from the collapsed peek formula to a real
 cumulative offset — measured, not guessed, by a `ResizeObserver` on each
@@ -97,28 +96,40 @@ doesn't pause a running countdown — it cancels it and re-arms a fresh one on
 mouse-leave. Close enough for a toast, and far simpler than a real pause/resume
 clock.
 
-## Swipe to dismiss
+</LearnChapter>
 
-Every toast is also `drag="x"`, and `onDragEnd` makes the dismiss call:
-
-<ToastSwipe />
-
-```tsx
-const handleDragEnd = (
+<LearnChapter
+  label="Swipe to dismiss"
+  scene={<ToastSwipe />}
+  code={`const handleDragEnd = (
   _e: MouseEvent | TouchEvent | PointerEvent,
   info: PanInfo,
 ) => {
   if (Math.abs(info.offset.x) > 80 || Math.abs(info.velocity.x) > 500) {
     dismissToast(record.id);
   }
-};
-```
+};`}
+>
+
+Every toast is also `drag="x"`, and `onDragEnd` makes the dismiss call.
 
 It's an OR, not an AND — a slow, deliberate 80px drag dismisses, and so does
 a fast flick that never gets that far. `dragElastic={0.6}` gives the card a
 little resistance under the pointer before it commits, and there's no
 snap-back branch: cross either bar and `dismissToast` fires immediately,
 same as the swipe-and-let-go you'd expect from a native notification.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<ToastResult />} isResult>
+
+An external store instead of context, absolutely-positioned cards instead of
+a list, and one drag gesture instead of a dismiss button — the stack is three
+small decisions, not one big animation.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Entrance, exit, and semantics
 
@@ -143,11 +154,3 @@ was doing, and the whole provider renders through a portal into
 ## Motion Score
 
 <MotionScorePanel name="toast" />
-
-## The result
-
-<ToastResult />
-
-An external store instead of context, absolutely-positioned cards instead of
-a list, and one drag gesture instead of a dismiss button — the stack is three
-small decisions, not one big animation.

--- a/apps/docs/content/docs/components/text/aurora-text/learn.mdx
+++ b/apps/docs/content/docs/components/text/aurora-text/learn.mdx
@@ -1,67 +1,80 @@
 ---
 title: Anatomy of Aurora Text
 description: How a looping linear-gradient becomes drifting rainbow text via background-clip, and why the animation pauses the moment it leaves the viewport.
+learnPlayer: true
 ---
 
-AuroraText isn't a canvas, a SVG filter, or a font trick. It's a span with a
-200%-wide rainbow painted behind the letters, clipped so you only see the
-gradient through the glyphs — then one CSS keyframe that slides
-`background-position` back and forth. Here's the whole stack.
+<LearnPlayer>
 
-## Fill, clip, together
-
-The component renders two nested spans inside a relative wrapper. The first
-is `sr-only` — the real children for screen readers. The second is
-`aria-hidden` and carries the aurora: a `linear-gradient(135deg, …)` with
-every stop listed, then the first color repeated so the loop seams cleanly.
-
-<AuroraTextAnatomy />
-
-```tsx
-const stops = [...colors, colors[0]].join(", ");
+<LearnChapter
+  label="Fill, clip, together"
+  scene={<AuroraTextAnatomy />}
+  code={`const stops = [...colors, colors[0]].join(", ");
 
 <span className="sr-only">{children}</span>
 <span
   aria-hidden="true"
   className="animate-aurora-text bg-[length:200%_auto] bg-clip-text text-transparent motion-reduce:animate-none"
   style={{
-    backgroundImage: `linear-gradient(135deg, ${stops})`,
-    "--aurora-text-speed": `${10 / speed}s`,
+    backgroundImage: \`linear-gradient(135deg, \${stops})\`,
+    "--aurora-text-speed": \`\${10 / speed}s\`,
   }}
 >
   {children}
-</span>
-```
+</span>`}
+>
+
+AuroraText isn't a canvas, a SVG filter, or a font trick. It's a span with a
+200%-wide rainbow painted behind the letters, clipped so you only see the
+gradient through the glyphs — then one CSS keyframe that slides
+`background-position` back and forth. Here's the whole stack.
+
+The component renders two nested spans inside a relative wrapper. The first
+is `sr-only` — the real children for screen readers. The second is
+`aria-hidden` and carries the aurora: a `linear-gradient(135deg, …)` with
+every stop listed, then the first color repeated so the loop seams cleanly.
 
 `bg-clip-text` plus `text-transparent` is the whole clip. The gradient fills
 a box twice as wide as the text; only the letter shapes stay visible. Default
 stops are the system rainbow — `#ff2d55` through `#bf5af2` — but any
 `colors` array works the same way.
 
-## The background-position sweep
+</LearnChapter>
 
-The motion is one keyframe. `aurora-text` walks `background-position` from
-`0% 50%` to `100% 50%` and back, `linear infinite`, timed by
-`--aurora-text-speed` (defaults to `10s`; `speed` is just `10 / speed`).
-
-<AuroraTextSweep />
-
-```css
-@keyframes aurora-text {
+<LearnChapter
+  label="The background-position sweep"
+  scene={<AuroraTextSweep />}
+  code={`@keyframes aurora-text {
   0%   { background-position: 0% 50%; }
   50%  { background-position: 100% 50%; }
   100% { background-position: 0% 50%; }
 }
 
---animate-aurora-text: aurora-text var(--aurora-text-speed, 10s) infinite linear;
-```
+--animate-aurora-text: aurora-text var(--aurora-text-speed, 10s) infinite linear;`}
+>
+
+The motion is one keyframe. `aurora-text` walks `background-position` from
+`0% 50%` to `100% 50%` and back, `linear infinite`, timed by
+`--aurora-text-speed` (defaults to `10s`; `speed` is just `10 / speed`).
 
 Nothing else moves. No `transform`, no opacity pulse, no layout thrash —
 just the paint position of a gradient that's already there. Because the
 stops loop back to the first color, the turnaround at either end reads as
 continuous drift rather than a hard bounce.
 
-## Cheap when idle
+</LearnChapter>
+
+<LearnChapter
+  label="Cheap when idle"
+  scene={<AuroraTextLifecycle />}
+  code={`const io = new IntersectionObserver(
+  ([entry]) => {
+    el.style.animationPlayState = entry.isIntersecting ? "" : "paused";
+  },
+  { rootMargin: "128px" },
+);
+io.observe(el);`}
+>
 
 A forever-running `background-position` animation is main-thread paint work.
 AuroraText doesn't leave it spinning off-screen. An `IntersectionObserver`
@@ -69,22 +82,22 @@ with `rootMargin: "128px"` watches the gradient span and flips
 `animationPlayState` the moment it clears that margin — paused outside,
 running again on the way back in, timeline intact.
 
-<AuroraTextLifecycle />
-
-```tsx
-const io = new IntersectionObserver(
-  ([entry]) => {
-    el.style.animationPlayState = entry.isIntersecting ? "" : "paused";
-  },
-  { rootMargin: "128px" },
-);
-io.observe(el);
-```
-
 Clearing `animationPlayState` (empty string) restores the stylesheet
 default — it doesn't restart the keyframe, so scroll-in resumes wherever
 the aurora left off. The 128px pad means the sweep is already moving before
 the text fully enters the viewport.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<AuroraTextResult />} isResult>
+
+A clipped gradient, one background-position keyframe, an observer that
+kills the cost when you're not looking, and a sr-only twin so the light
+show never replaces the words. That's the whole aurora.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility
 
@@ -103,11 +116,3 @@ is harmless, and removing the effect would just add a branch for no gain.
 ## Motion Score
 
 <MotionScorePanel name="aurora-text" />
-
-## The result
-
-A clipped gradient, one background-position keyframe, an observer that
-kills the cost when you're not looking, and a sr-only twin so the light
-show never replaces the words. That's the whole aurora.
-
-<AuroraTextResult />

--- a/apps/docs/content/docs/components/text/elastic-text/learn.mdx
+++ b/apps/docs/content/docs/components/text/elastic-text/learn.mdx
@@ -1,26 +1,15 @@
 ---
 title: Anatomy of Elastic Text
 description: How a variable-font weight spotlight sweeps across characters on a spring — auto or pointer-driven — without layout thrash.
+learnPlayer: true
 ---
 
-ElasticText doesn't animate font-size or scale. It animates the `wght` axis
-of a variable font — one CSS custom property per character — chased by a
-spring. The "elastic" feel is that spring settling as a spotlight (or your
-pointer) moves across the string.
+<LearnPlayer>
 
-## Characters become segments
-
-`getTextContent(children)` flattens the tree to a string, then
-`[...textContent]` splits it into one segment per character (including
-spaces). Each segment is its own `motion.span` writing
-`--et-wght` into `font-variation-settings`. On Geist (or any `wght`-axis
-sans) the weight interpolates continuously; on a static font it snaps to
-the nearest cut.
-
-<ElasticTextAnatomy />
-
-```tsx
-const textContent = getTextContent(children);
+<LearnChapter
+  label="Characters become segments"
+  scene={<ElasticTextAnatomy />}
+  code={`const textContent = getTextContent(children);
 const segments = textContent ? [...textContent] : null;
 
 // …
@@ -29,14 +18,46 @@ const segments = textContent ? [...textContent] : null;
   style={{ "--et-wght": weight }}
 >
   {segment}
-</span>
-```
+</span>`}
+>
+
+ElasticText doesn't animate font-size or scale. It animates the `wght` axis
+of a variable font — one CSS custom property per character — chased by a
+spring. The "elastic" feel is that spring settling as a spotlight (or your
+pointer) moves across the string.
+
+`getTextContent(children)` flattens the tree to a string, then
+`[...textContent]` splits it into one segment per character (including
+spaces). Each segment is its own `motion.span` writing
+`--et-wght` into `font-variation-settings`. On Geist (or any `wght`-axis
+sans) the weight interpolates continuously; on a static font it snaps to
+the nearest cut.
 
 The container itself is an `inline-block` so the per-character spans stay
 on one baseline. Whitespace segments get `aria-hidden` so screen readers
 don't announce empty nodes.
 
-## Auto spotlight
+</LearnChapter>
+
+<LearnChapter
+  label="Auto spotlight"
+  scene={<ElasticTextSpotlight />}
+  code={`// Rest off the left edge so the first paint is uniform weight —
+// position 0 would flash the leading character at maxWeight.
+spotlight.set(-AUTO_SPREAD);
+
+loop
+  ? animate(spotlight, [0, last], {
+      duration,
+      repeat: Number.POSITIVE_INFINITY,
+      repeatType: "mirror",
+      ease: "easeInOut",
+    })
+  : animate(spotlight, [-AUTO_SPREAD, last + AUTO_SPREAD], {
+      duration,
+      ease: "easeInOut",
+    });`}
+>
 
 In `mode="auto"` (the default), a single `MotionValue` called `spotlight`
 is the index of the emphasis. Each segment computes influence from its
@@ -54,27 +75,7 @@ const autoWeight = useTransform(spotlight, (position) => {
 
 `AUTO_SPREAD = 2.5` means roughly five characters feel the bump at once —
 full weight under the spotlight, falling off over ±2.5 indices. The
-spotlight itself animates with Framer's `animate`:
-
-<ElasticTextSpotlight />
-
-```tsx
-// Rest off the left edge so the first paint is uniform weight —
-// position 0 would flash the leading character at maxWeight.
-spotlight.set(-AUTO_SPREAD);
-
-loop
-  ? animate(spotlight, [0, last], {
-      duration,
-      repeat: Number.POSITIVE_INFINITY,
-      repeatType: "mirror",
-      ease: "easeInOut",
-    })
-  : animate(spotlight, [-AUTO_SPREAD, last + AUTO_SPREAD], {
-      duration,
-      ease: "easeInOut",
-    });
-```
+spotlight itself animates with Framer's `animate`.
 
 Starting at `-AUTO_SPREAD` (not `0`) avoids the "big first letter" flash
 before the sweep begins. A one-shot run pads both ends the same way so
@@ -82,25 +83,6 @@ weight settles back to `minWeight` everywhere instead of parking on the
 trailing characters. With `startOnView` (default `true`), an
 `IntersectionObserver` at threshold `0.3` holds the sweep until the text
 is on screen, then disconnects.
-
-## The spring between target and paint
-
-Raw influence is the *target*. What you see is a spring chasing it:
-
-<ElasticTextSpring />
-
-```tsx
-const SPRING = { stiffness: 150, damping: 18, mass: 1 } as const;
-const weight = useSpring(rawWeight, SPRING);
-```
-
-Stiffness 150 / damping 18 / mass 1 is deliberately a bit underdamped —
-weight overshoots the target slightly and settles, which is why characters
-feel rubbery instead of rigidly locked to the spotlight. Because
-`--et-wght` is a CSS variable on `font-variation-settings`, the browser
-repaints glyphs without touching layout geometry.
-
-## Hover mode
 
 `mode="hover"` swaps the spotlight for pointer distance. Segment centers
 are cached from `getBoundingClientRect` on enter/resize; on `mousemove`
@@ -120,6 +102,34 @@ const hoverWeight = useTransform([pointerX, pointerActive], (latest) => {
 `pointerActive` is `0` until `mouseenter` and back to `0` on leave, so
 leaving the text relaxes every character to `minWeight` through the same
 spring — no separate exit timeline.
+
+</LearnChapter>
+
+<LearnChapter
+  label="The spring between target and paint"
+  scene={<ElasticTextSpring />}
+  code={`const SPRING = { stiffness: 150, damping: 18, mass: 1 } as const;
+const weight = useSpring(rawWeight, SPRING);`}
+>
+
+Raw influence is the *target*. What you see is a spring chasing it.
+
+Stiffness 150 / damping 18 / mass 1 is deliberately a bit underdamped —
+weight overshoots the target slightly and settles, which is why characters
+feel rubbery instead of rigidly locked to the spotlight. Because
+`--et-wght` is a CSS variable on `font-variation-settings`, the browser
+repaints glyphs without touching layout geometry.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<ElasticTextResult />} isResult>
+
+Auto sweep on top; hover on the muted line underneath. Same spring, two
+drivers.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility
 
@@ -145,10 +155,3 @@ if (reducedMotion) {
 ## Motion Score
 
 <MotionScorePanel name="elastic-text" />
-
-## The result
-
-Auto sweep on top; hover on the muted line underneath. Same spring, two
-drivers.
-
-<ElasticTextResult />

--- a/apps/docs/content/docs/components/text/highlighter/learn.mdx
+++ b/apps/docs/content/docs/components/text/highlighter/learn.mdx
@@ -1,7 +1,24 @@
 ---
 title: Anatomy of the Highlighter
 description: How an inline span gets a rough-notation sketch overlay, why draw-in waits for the viewport, and how resize keeps the mark glued to the text.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="Two layers, one span"
+  scene={<HighlighterAnatomy />}
+  code={`return (
+  <span
+    ref={mergedRef}
+    className={\`relative inline-block bg-transparent \${actionTextClass} \${className ?? ""}\`}
+    {...props}
+  >
+    {children}
+  </span>
+);`}
+>
 
 Highlighter doesn't paint with CSS. It hands a real DOM span to
 [`rough-notation`](https://roughnotation.com/)'s `annotate()`, which injects
@@ -9,41 +26,29 @@ an SVG sketch and animates the stroke in. The React wrapper is a thin lifecycle
 around that: when to create the annotation, when to redraw it, and when to tear
 it down.
 
-## Two layers, one span
-
 The component renders a single `inline-block` span. The children are ordinary
 text. The annotation is a separate SVG layer Rough Notation attaches to that
 element — not a background, not a pseudo-element.
-
-<HighlighterAnatomy />
-
-```tsx
-return (
-  <span
-    ref={mergedRef}
-    className={`relative inline-block bg-transparent ${actionTextClass} ${className ?? ""}`}
-    {...props}
-  >
-    {children}
-  </span>
-);
-```
 
 `annotate(element, { type: action, color, … })` measures the span and draws
 over it. Actions map 1:1 to Rough Notation types: `highlight`, `underline`,
 `box`, `circle`, `strike-through`, `crossed-off`, `bracket`.
 
-## The draw-in
-
-`show()` runs Rough Notation's built-in draw animation — typically a left-to-right
-stroke that lands in `animationDuration` milliseconds (default `600`). The scene
-below is a compositor stand-in: `scaleX` from `transform-origin: left`, the same
-direction the sketch grows.
-
-<HighlighterDraw />
+`highlight` paints a soft marker *behind* the glyphs. On a dark theme that
+would leave light text on a light wash — unreadable. So that action alone
+forces `text-neutral-950`, like real highlighter ink on paper. Every other
+action draws around the text and keeps the inherited color.
 
 ```tsx
-const currentAnnotation = annotate(element, {
+const actionTextClass = action === "highlight" ? "text-neutral-950" : "";
+```
+
+</LearnChapter>
+
+<LearnChapter
+  label="The draw-in"
+  scene={<HighlighterDraw />}
+  code={`const currentAnnotation = annotate(element, {
   type: action,
   color,
   strokeWidth,
@@ -53,32 +58,24 @@ const currentAnnotation = annotate(element, {
   multiline,
 });
 annotation = currentAnnotation;
-currentAnnotation.show();
-```
+currentAnnotation.show();`}
+>
+
+`show()` runs Rough Notation's built-in draw animation — typically a left-to-right
+stroke that lands in `animationDuration` milliseconds (default `600`). The scene
+is a compositor stand-in: `scaleX` from `transform-origin: left`, the same
+direction the sketch grows.
 
 `iterations` (default `2`) is how many sketch passes Rough Notation takes —
 higher looks more hand-drawn. `padding` keeps the stroke off the glyphs;
 `multiline` lets the mark wrap with the text.
 
-## When it draws — and when it redraws
+</LearnChapter>
 
-Two gates keep the sketch honest.
-
-**In-view.** With `isView`, Framer Motion's `useInView` (once, `margin: "-10%"`)
-holds off until the span crosses into the padded viewport. `shouldShow` is
-`!isView || isInView`, and the layout effect only calls `annotate` when that's
-true — so off-screen highlights don't burn animation budget on first paint.
-
-**Resize.** A `ResizeObserver` watches the span *and* `document.body`. On any
-size change it `hide()`s then `show()`s the same annotation, so the SVG remeasures
-instead of drifting when type reflows or the window resizes.
-
-Cleanup always runs `annotation.remove()` and disconnects the observer.
-
-<HighlighterLifecycle />
-
-```tsx
-const isInView = useInView(elementRef, {
+<LearnChapter
+  label="When it draws — and when it redraws"
+  scene={<HighlighterLifecycle />}
+  code={`const isInView = useInView(elementRef, {
   once: true,
   margin: "-10%",
 });
@@ -98,27 +95,33 @@ React.useLayoutEffect(() => {
     annotation?.remove();
     resizeObserver?.disconnect();
   };
-}, [shouldShow, action, color, /* … */]);
-```
+}, [shouldShow, action, color, /* … */]);`}
+>
 
-## Dark ink on a pale fill
+Two gates keep the sketch honest.
 
-`highlight` paints a soft marker *behind* the glyphs. On a dark theme that
-would leave light text on a light wash — unreadable. So that action alone
-forces `text-neutral-950`, like real highlighter ink on paper. Every other
-action draws around the text and keeps the inherited color.
+**In-view.** With `isView`, Framer Motion's `useInView` (once, `margin: "-10%"`)
+holds off until the span crosses into the padded viewport. `shouldShow` is
+`!isView || isInView`, and the layout effect only calls `annotate` when that's
+true — so off-screen highlights don't burn animation budget on first paint.
 
-```tsx
-const actionTextClass = action === "highlight" ? "text-neutral-950" : "";
-```
+**Resize.** A `ResizeObserver` watches the span *and* `document.body`. On any
+size change it `hide()`s then `show()`s the same annotation, so the SVG remeasures
+instead of drifting when type reflows or the window resizes.
 
-## Motion Score
+Cleanup always runs `annotation.remove()` and disconnects the observer.
 
-<MotionScorePanel name="highlighter" />
+</LearnChapter>
 
-## The result
+<LearnChapter label="The result" scene={<HighlighterResult />} isResult>
 
 One span, one SVG overlay, a viewport gate, and a resize redraw. Wrap a word
 and the sketch draws itself.
 
-<HighlighterResult />
+</LearnChapter>
+
+</LearnPlayer>
+
+## Motion Score
+
+<MotionScorePanel name="highlighter" />

--- a/apps/docs/content/docs/components/text/number-ticker/learn.mdx
+++ b/apps/docs/content/docs/components/text/number-ticker/learn.mdx
@@ -1,7 +1,20 @@
 ---
 title: Anatomy of the Number Ticker
 description: How a MotionValue, a spring, and an in-view gate turn a static span into a counting number — without re-rendering on every frame.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="Anatomy"
+  scene={<NumberTickerAnatomy />}
+  code={`const motionValue = useMotionValue(
+  direction === "down" ? value : startValue,
+);
+const springValue = useSpring(motionValue, { damping, stiffness });
+const isInView = useInView(ref, { once: true, margin: "0px" });`}
+>
 
 Number Ticker looks like a counter. Internally it's three hooks and a DOM
 write: a MotionValue holds the target, `useSpring` smooths the chase, and a
@@ -9,37 +22,20 @@ change listener formats the latest value into the span's `textContent`. The
 spring never starts until the element is in view — and even then, only after
 an optional delay.
 
-## Anatomy
-
 The public surface is a single `<span>`. Everything interesting lives in the
-hooks wired behind it:
-
-<NumberTickerAnatomy />
-
-```tsx
-const motionValue = useMotionValue(
-  direction === "down" ? value : startValue,
-);
-const springValue = useSpring(motionValue, { damping, stiffness });
-const isInView = useInView(ref, { once: true, margin: "0px" });
-```
+hooks wired behind it.
 
 Direction flips the endpoints. `"up"` starts at `startValue` and springs
 toward `value`; `"down"` starts at `value` and springs toward `startValue`.
 The initial render paints that start endpoint as formatted text so the span
 isn't empty before the first spring frame lands.
 
-## The spring
+</LearnChapter>
 
-Defaults are deliberately calm — `damping: 60`, `stiffness: 100`. That's
-enough to feel physical without the underdamped bounce of a tooltip mount.
-Each frame, the spring emits a float; the change listener snaps it to the
-requested decimal places and hands it to `Intl.NumberFormat`:
-
-<NumberTickerSpring />
-
-```tsx
-React.useEffect(
+<LearnChapter
+  label="The spring"
+  scene={<NumberTickerSpring />}
+  code={`React.useEffect(
   () =>
     springValue.on("change", (latest) => {
       if (ref.current) {
@@ -50,23 +46,24 @@ React.useEffect(
       }
     }),
   [springValue, decimalPlaces],
-);
-```
+);`}
+>
+
+Defaults are deliberately calm — `damping: 60`, `stiffness: 100`. That's
+enough to feel physical without the underdamped bounce of a tooltip mount.
+Each frame, the spring emits a float; the change listener snaps it to the
+requested decimal places and hands it to `Intl.NumberFormat`.
 
 Writing `textContent` keeps React out of the per-frame path. The span also
 carries `tabular-nums tracking-wider` so digit widths stay stable while the
 glyphs swap — no layout thrash as `9` becomes `1`.
 
-## The in-view gate
+</LearnChapter>
 
-Mounting alone does nothing. `useInView` with `once: true` opens the gate
-the first time the span crosses the viewport; a `setTimeout` then waits
-`delay` seconds before calling `motionValue.set(target)`:
-
-<NumberTickerView />
-
-```tsx
-React.useEffect(() => {
+<LearnChapter
+  label="The in-view gate"
+  scene={<NumberTickerView />}
+  code={`React.useEffect(() => {
   if (!isInView) return;
 
   const target = direction === "down" ? startValue : value;
@@ -76,12 +73,26 @@ React.useEffect(() => {
   }, delay * 1000);
 
   return () => clearTimeout(timer);
-}, [/* … */]);
-```
+}, [/* … */]);`}
+>
+
+Mounting alone does nothing. `useInView` with `once: true` opens the gate
+the first time the span crosses the viewport; a `setTimeout` then waits
+`delay` seconds before calling `motionValue.set(target)`.
 
 `once: true` means scrolling away and back won't re-run the count — the
 ticker is a reveal, not a perpetual odometer. The cleanup clears the timer
 so a fast unmount mid-delay never fires into a detached node.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<NumberTickerResult />} isResult>
+
+Three live instances: a plain count-up, decimals, and a delayed countdown.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Reduced motion
 
@@ -97,9 +108,3 @@ if (reduceMotion) springValue.jump(target);
 ## Motion Score
 
 <MotionScorePanel name="number-ticker" />
-
-## The result
-
-Three live instances: a plain count-up, decimals, and a delayed countdown.
-
-<NumberTickerResult />

--- a/apps/docs/content/docs/components/text/scroll-text-reveal/learn.mdx
+++ b/apps/docs/content/docs/components/text/scroll-text-reveal/learn.mdx
@@ -1,26 +1,15 @@
 ---
 title: Anatomy of Scroll Text Reveal
 description: How one scrollYProgress is sliced across words, scrubbed into opacity and blur, and optionally latched so revealed segments never re-dim.
+learnPlayer: true
 ---
 
-ScrollTextReveal isn't a staggered entrance. It's a scrubbed mapping: the
-paragraph's position in the viewport becomes one `scrollYProgress`, that
-number is carved into equal slices, and each slice drives a segment from
-dim to sharp. Scroll back up and — unless you latch — the sentence dims
-in reverse.
+<LearnPlayer>
 
-## One progress, n slices
-
-`useScroll` watches the root element with offset
-`["start 0.85", "end 0.35"]` — progress starts when the top hits ~85% of
-the viewport and finishes when the bottom clears ~35%. The copy is split
-by `word` (default), `character`, or `line`. Segment `i` of `n` owns
-`[i/n, (i+1)/n]`.
-
-<ScrollTextRevealAnatomy />
-
-```tsx
-const { scrollYProgress } = useScroll({
+<LearnChapter
+  label="One progress, n slices"
+  scene={<ScrollTextRevealAnatomy />}
+  code={`const { scrollYProgress } = useScroll({
   target: localRef,
   offset: offset ?? ["start 0.85", "end 0.35"],
 });
@@ -33,44 +22,66 @@ segments.map(({ key, segment }, i) => (
     end={(i + 1) / n}
     // …
   />
-))
-```
+))`}
+>
+
+ScrollTextReveal isn't a staggered entrance. It's a scrubbed mapping: the
+paragraph's position in the viewport becomes one `scrollYProgress`, that
+number is carved into equal slices, and each slice drives a segment from
+dim to sharp. Scroll back up and — unless you latch — the sentence dims
+in reverse.
+
+`useScroll` watches the root element with offset
+`["start 0.85", "end 0.35"]` — progress starts when the top hits ~85% of
+the viewport and finishes when the bottom clears ~35%. The copy is split
+by `word` (default), `character`, or `line`. Segment `i` of `n` owns
+`[i/n, (i+1)/n]`.
 
 At mid-progress the leading slices are already at reveal `1`, the active
 slice is interpolating, and trailing slices still sit at `dimOpacity`
 (default `0.15`) with optional `blur(6px)`.
 
-## The scrub
+</LearnChapter>
+
+<LearnChapter
+  label="The scrub"
+  scene={<ScrollTextRevealScrub />}
+  code={`const raw = useTransform(progress, [start, end], [0, 1]);
+const opacity = useTransform(reveal, [0, 1], [dimOpacity, 1]);
+const filter = useTransform(reveal, [0, 1], ["blur(6px)", "blur(0px)"]);`}
+>
 
 Each segment maps its slice onto a 0→1 reveal factor, then onto opacity
 (`dimOpacity` → `1`) and, when `blur` is on, `blur(6px)` → `blur(0)`.
 Because those transforms read the live progress value, scrolling up
 rewinds them — no timeline to cancel, no play-once flag.
 
-<ScrollTextRevealScrub />
-
-```tsx
-const raw = useTransform(progress, [start, end], [0, 1]);
-const opacity = useTransform(reveal, [0, 1], [dimOpacity, 1]);
-const filter = useTransform(reveal, [0, 1], ["blur(6px)", "blur(0px)"]);
-```
-
 Only compositor props move. Layout stays put; whitespace tokens keep
 `whitespace-pre` so the original spacing survives the split.
 
-## keepRevealed
+</LearnChapter>
+
+<LearnChapter
+  label="keepRevealed"
+  scene={<ScrollTextRevealLatch />}
+  code={`reveal.set(keepRevealed ? Math.max(reveal.get(), v) : v);`}
+>
 
 Default scrub is honest: leave the paragraph and the words re-dim. Set
-`keepRevealed` and each segment latches at its peak —
+`keepRevealed` and each segment latches at its peak — so scroll-up never
+undoes a word that already landed. Same progress driver, two exit
+behaviours.
 
-```tsx
-reveal.set(keepRevealed ? Math.max(reveal.get(), v) : v);
-```
+</LearnChapter>
 
-— so scroll-up never undoes a word that already landed. Same progress
-driver, two exit behaviours.
+<LearnChapter label="The result" scene={<ScrollTextRevealResult />} isResult>
 
-<ScrollTextRevealLatch />
+One progress value, equal slices, opacity and blur scrubbed to the
+scroll — latch optional. Scroll the page through the panel below.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility
 
@@ -93,10 +104,3 @@ if (reduceMotion) {
 ## Motion Score
 
 <MotionScorePanel name="scroll-text-reveal" />
-
-## The result
-
-One progress value, equal slices, opacity and blur scrubbed to the
-scroll — latch optional. Scroll the page through the panel below.
-
-<ScrollTextRevealResult />

--- a/apps/docs/content/docs/components/text/text-animate/learn.mdx
+++ b/apps/docs/content/docs/components/text/text-animate/learn.mdx
@@ -1,15 +1,36 @@
 ---
 title: Anatomy of Text Animate
 description: How text is split into segments, staggered through a preset, and gated by the viewport — with a plain fallback for reduced motion.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="Split first"
+  scene={<TextAnimateAnatomy />}
+  code={`const segments = React.useMemo(
+  () => splitTextAnimate(textContent, by),
+  [textContent, by],
+);
+
+{segments.map(({ key, segment }) => (
+  <motion.span
+    key={key}
+    variants={finalVariants.item}
+    className={getSegmentClassName(by, segmentClassName)}
+    aria-hidden={accessible ? true : undefined}
+  >
+    {segment}
+  </motion.span>
+))}`}
+>
 
 TextAnimate doesn't animate a string as one blob. It flattens children to
 text, splits that string by `by`, then hands each segment to Framer Motion
 as a child of a container with `staggerChildren`. The entrance you pick —
 `fadeIn`, `blurInUp`, `slideUp`, and friends — is just the item variant.
 Everything else is orchestration.
-
-## Split first
 
 `getTextContent(children)` collapses the tree to a string. Then
 `splitTextAnimate(text, by)` produces `{ key, segment }[]`:
@@ -24,30 +45,25 @@ Each segment becomes a `motion.span` with a class from
 lines). Keys encode split mode, offset, and content so remounts stay
 stable.
 
-<TextAnimateAnatomy />
-
-```tsx
-const segments = React.useMemo(
-  () => splitTextAnimate(textContent, by),
-  [textContent, by],
-);
-
-{segments.map(({ key, segment }) => (
-  <motion.span
-    key={key}
-    variants={finalVariants.item}
-    className={getSegmentClassName(by, segmentClassName)}
-    aria-hidden={accessible ? true : undefined}
-  >
-    {segment}
-  </motion.span>
-))}
-```
-
 Fewer segments (words) feel like a cascade of phrases. Characters feel like
 typewriter grit. Same preset, different density.
 
-## Stagger is the cascade
+</LearnChapter>
+
+<LearnChapter
+  label="Stagger is the cascade"
+  scene={<TextAnimateStagger />}
+  code={`const staggerChildren =
+  stagger ??
+  (segments.length > 1 ? duration / segments.length : STAGGER_BY_SPLIT[by]);
+
+const finalVariants = resolveTextAnimateVariants({
+  animation,
+  delay,
+  staggerChildren,
+  customVariants: variants,
+});`}
+>
 
 The container variants own the timing. `staggerChildren` defaults to
 `duration / segments.length` when there's more than one segment; otherwise
@@ -58,59 +74,8 @@ it falls back to `STAGGER_BY_SPLIT[by]` (`word: 0.05`, `character: 0.03`,
 Exit reverses the cascade (`staggerDirection: -1`) inside
 `AnimatePresence mode="popLayout"`.
 
-<TextAnimateStagger />
-
-```tsx
-const staggerChildren =
-  stagger ??
-  (segments.length > 1 ? duration / segments.length : STAGGER_BY_SPLIT[by]);
-
-const finalVariants = resolveTextAnimateVariants({
-  animation,
-  delay,
-  staggerChildren,
-  customVariants: variants,
-});
-```
-
 Pass your own `variants` and the resolver swaps the item map while keeping
 the same delay/stagger container shell.
-
-## Presets are item variants
-
-Ten named presets live in `TEXT_ANIMATE_PRESETS`. They share the same
-container shell; only the item `hidden` / `show` / `exit` differ. Two
-useful contrasts:
-
-- **`blurInUp`** — `opacity 0`, `filter: blur(10px)`, `y: 20` → rest
-  (filter and `y` at 0.3s, opacity slightly longer at 0.4s)
-- **`slideUp`** — `opacity 0`, `y: 20` → rest (no blur)
-
-`scaleUp` / `scaleDown` swap the linear duration for a spring on `scale`
-(`damping: 32`, `stiffness: 320`, `mass: 0.9`). Everything stays on the
-compositor: opacity, transform, filter.
-
-<TextAnimatePresets />
-
-```tsx
-blurInUp: {
-  item: {
-    hidden: { opacity: 0, filter: "blur(10px)", y: 20 },
-    show: {
-      opacity: 1,
-      filter: "blur(0px)",
-      y: 0,
-      transition: {
-        y: { duration: 0.3 },
-        opacity: { duration: 0.4 },
-        filter: { duration: 0.3 },
-      },
-    },
-  },
-},
-```
-
-## In view, once
 
 Default `startOnView` is `true`. The motion root uses
 `whileInView="show"` with `viewport={{ once, amount: viewportAmount }}`
@@ -132,6 +97,51 @@ component so a hero can be a real `h1` without losing the stagger.
   aria-label={accessible && textContent ? textContent : undefined}
 >
 ```
+
+</LearnChapter>
+
+<LearnChapter
+  label="Presets are item variants"
+  scene={<TextAnimatePresets />}
+  code={`blurInUp: {
+  item: {
+    hidden: { opacity: 0, filter: "blur(10px)", y: 20 },
+    show: {
+      opacity: 1,
+      filter: "blur(0px)",
+      y: 0,
+      transition: {
+        y: { duration: 0.3 },
+        opacity: { duration: 0.4 },
+        filter: { duration: 0.3 },
+      },
+    },
+  },
+},`}
+>
+
+Ten named presets live in `TEXT_ANIMATE_PRESETS`. They share the same
+container shell; only the item `hidden` / `show` / `exit` differ. Two
+useful contrasts:
+
+- **`blurInUp`** — `opacity 0`, `filter: blur(10px)`, `y: 20` → rest
+  (filter and `y` at 0.3s, opacity slightly longer at 0.4s)
+- **`slideUp`** — `opacity 0`, `y: 20` → rest (no blur)
+
+`scaleUp` / `scaleDown` swap the linear duration for a spring on `scale`
+(`damping: 32`, `stiffness: 320`, `mass: 0.9`). Everything stays on the
+compositor: opacity, transform, filter.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<TextAnimateResult />} isResult>
+
+Word blur-in, character slide-up, and a spring scale on a real heading —
+same splitter, three presets.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility
 
@@ -158,10 +168,3 @@ if (reducedMotion) {
 ## Motion Score
 
 <MotionScorePanel name="text-animate" />
-
-## The result
-
-Word blur-in, character slide-up, and a spring scale on a real heading —
-same splitter, three presets.
-
-<TextAnimateResult />

--- a/apps/docs/content/docs/components/text/text-scramble/learn.mdx
+++ b/apps/docs/content/docs/components/text/text-scramble/learn.mdx
@@ -1,48 +1,43 @@
 ---
 title: Anatomy of Text Scramble
 description: How a per-character cell queue flickers through a glyph pool and locks into the target — gated by mount, in-view, or hover.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="Cell states"
+  scene={<TextScrambleAnatomy />}
+  code={`type Cell = { from: string; to: string; start: number; end: number };
+
+for (let i = 0; i < len; i++) {
+  const start = Math.floor(Math.random() * spread);
+  const end = start + 10 + Math.floor(Math.random() * spread);
+  queue.push({ from: from[i] ?? "", to: toText[i] ?? "", start, end });
+}`}
+>
 
 TextScramble isn't a CSS animation. It's a frame loop over a queue of cells:
 each character gets a random `start` / `end` window, picks from a charset
 while unresolved, then locks to `to`. Unresolved glyphs glow
 `text-primary` for 120ms; assistive tech always sees the stable string.
 
-## Cell states
-
 `run(toText)` builds one `Cell` per index — `from` (what's on screen),
 `to` (the new glyph), plus staggered `start` / `end` frames derived from
 `spread`. Before `start` the slot holds `from`; between them it picks a
 random character from the pool; at `end` it settles on `to`.
 
-<TextScrambleAnatomy />
-
-```tsx
-type Cell = { from: string; to: string; start: number; end: number };
-
-for (let i = 0; i < len; i++) {
-  const start = Math.floor(Math.random() * spread);
-  const end = start + 10 + Math.floor(Math.random() * spread);
-  queue.push({ from: from[i] ?? "", to: toText[i] ?? "", start, end });
-}
-```
-
 Only differing positions matter on a text change: `from` is
 `displayed.current`, so identical characters stay quiet while the rest
 re-scramble.
 
-## The scramble cycle
+</LearnChapter>
 
-An `setInterval` ticks every `speed` ms (default `28`). Each frame maps
-the queue: unresolved cells pull `pool[Math.floor(Math.random() * length)]`
-and render with `text-primary [transition:color_120ms_ease]`; done cells
-get `to` and drop the accent. When every cell is complete the timer
-clears and `displayed.current` updates.
-
-<TextScrambleCycle />
-
-```tsx
-timer.current = setInterval(() => {
+<LearnChapter
+  label="The scramble cycle"
+  scene={<TextScrambleCycle />}
+  code={`timer.current = setInterval(() => {
   const next = queue.map((c) => {
     if (frame >= c.end) return { ch: c.to, done: true };
     if (frame >= c.start) {
@@ -53,22 +48,25 @@ timer.current = setInterval(() => {
   });
   setCells(next);
   frame++;
-}, speed);
-```
+}, speed);`}
+>
+
+An `setInterval` ticks every `speed` ms (default `28`). Each frame maps
+the queue: unresolved cells pull `pool[Math.floor(Math.random() * length)]`
+and render with `text-primary [transition:color_120ms_ease]`; done cells
+get `to` and drop the accent. When every cell is complete the timer
+clears and `displayed.current` updates.
 
 The root is `inline-block tabular-nums` so mono glyphs don't shift width
 as the pool cycles. Charsets are named pools (`alphanumeric`, `symbols`,
 `katakana`, `binary`) or any custom string passed as `charset`.
 
-## When it starts
+</LearnChapter>
 
-The first scramble is gated by `trigger`. Later `text` changes always
-call `run` — only the initial pass waits.
-
-<TextScrambleTrigger />
-
-```tsx
-if (trigger === "mount") {
+<LearnChapter
+  label="When it starts"
+  scene={<TextScrambleTrigger />}
+  code={`if (trigger === "mount") {
   started.current = true;
   run(text);
 } else if (trigger === "in-view") {
@@ -84,12 +82,26 @@ if (trigger === "mount") {
   );
   io.observe(el);
 }
-// hover: onPointerEnter sets started + run(text)
-```
+// hover: onPointerEnter sets started + run(text)`}
+>
+
+The first scramble is gated by `trigger`. Later `text` changes always
+call `run` — only the initial pass waits.
 
 `mount` fires in the effect. `in-view` observes at `threshold: 0.4`, runs
 once, then disconnects. `hover` waits for `onPointerEnter` — and every
 subsequent hover re-runs, so the decrypt can replay on demand.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<TextScrambleResult />} isResult>
+
+A cell queue, a charset pool, three trigger gates, and a stable sr-only
+string. Hover either line to watch it decrypt again.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility
 
@@ -112,10 +124,3 @@ entirely and jumps to final characters — no interval, no primary flash.
 ## Motion Score
 
 <MotionScorePanel name="text-scramble" />
-
-## The result
-
-A cell queue, a charset pool, three trigger gates, and a stable sr-only
-string. Hover either line to watch it decrypt again.
-
-<TextScrambleResult />

--- a/apps/docs/content/docs/components/visualizations/animated-beam/learn.mdx
+++ b/apps/docs/content/docs/components/visualizations/animated-beam/learn.mdx
@@ -1,14 +1,28 @@
 ---
 title: Anatomy of Animated Beam
 description: How a travelling gradient is drawn along a live-measured quadratic path between two DOM nodes, and why the path itself never has to move.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="From, to, and one quadratic curve"
+  scene={<AnimatedBeamAnatomy />}
+  code={`const startX = a.left - c.left + a.width / 2 + startXOffset;
+const startY = a.top - c.top + a.height / 2 + startYOffset;
+const endX = b.left - c.left + b.width / 2 + endXOffset;
+const endY = b.top - c.top + b.height / 2 + endYOffset;
+const controlX = (startX + endX) / 2;
+const controlY = (startY + endY) / 2 - curvature;
+
+setPath(\`M \${startX},\${startY} Q \${controlX},\${controlY} \${endX},\${endY}\`);`}
+>
 
 `AnimatedBeam` doesn't animate a line between two elements — it draws one
 static path and slides a gradient across it. Two completely separate
 problems, solved independently: geometry (where the path goes) and motion
 (what appears to travel along it).
-
-## From, to, and one quadratic curve
 
 Everything starts from two refs. `AnimatedBeam` reads both elements'
 `getBoundingClientRect()` relative to the container, takes their centers
@@ -16,35 +30,16 @@ Everything starts from two refs. `AnimatedBeam` reads both elements'
 Bézier: `M start Q control end`. The control point sits at the horizontal
 midpoint, pushed up or down by `curvature`.
 
-<AnimatedBeamAnatomy />
-
-```tsx
-const startX = a.left - c.left + a.width / 2 + startXOffset;
-const startY = a.top - c.top + a.height / 2 + startYOffset;
-const endX = b.left - c.left + b.width / 2 + endXOffset;
-const endY = b.top - c.top + b.height / 2 + endYOffset;
-const controlX = (startX + endX) / 2;
-const controlY = (startY + endY) / 2 - curvature;
-
-setPath(`M ${startX},${startY} Q ${controlX},${controlY} ${endX},${endY}`);
-```
-
 One `<path>` renders that string twice: once as a faint resting line
 (`pathColor`, `pathOpacity`), once with a gradient stroke on top. The second
 copy is the one that actually moves.
 
-## Live geometry, not a one-time measurement
+</LearnChapter>
 
-Refs don't dispatch events when their layout changes, so `AnimatedBeam`
-watches instead. A `ResizeObserver` on the container plus a window `resize`
-listener both call the same `update()` — recomputing every rect and
-rewriting `d` from scratch. Nothing is interpolated between measurements;
-each tick is a fresh, correct snapshot.
-
-<AnimatedBeamMeasure />
-
-```tsx
-const update = () => {
+<LearnChapter
+  label="Live geometry, not a one-time measurement"
+  scene={<AnimatedBeamMeasure />}
+  code={`const update = () => {
   const c = container.getBoundingClientRect();
   const a = from.getBoundingClientRect();
   const b = to.getBoundingClientRect();
@@ -55,24 +50,25 @@ const update = () => {
 update();
 const ro = new ResizeObserver(update);
 ro.observe(containerRef.current);
-window.addEventListener("resize", update);
-```
+window.addEventListener("resize", update);`}
+>
+
+Refs don't dispatch events when their layout changes, so `AnimatedBeam`
+watches instead. A `ResizeObserver` on the container plus a window `resize`
+listener both call the same `update()` — recomputing every rect and
+rewriting `d` from scratch. Nothing is interpolated between measurements;
+each tick is a fresh, correct snapshot.
 
 Sizing the `<svg>` from the same container rect (`box.width`/`box.height`)
 keeps the overlay pixel-aligned with whatever just resized it — there's no
 separate "layout" pass to fall out of sync with.
 
-## The showpiece: a gradient that travels, not a shape that moves
+</LearnChapter>
 
-The animated part is a `motion.linearGradient` living inside the path's
-`<defs>`. Its `x1`/`x2` tween from one edge to past the other — `["10%",
-"110%"]` — on an infinite, linear-eased loop. The path underneath never
-changes; only where the gradient's stops fall along it does.
-
-<AnimatedBeamGradient />
-
-```tsx
-<motion.linearGradient
+<LearnChapter
+  label="A gradient that travels"
+  scene={<AnimatedBeamGradient />}
+  code={`<motion.linearGradient
   gradientUnits="userSpaceOnUse"
   animate={{ x1: ["10%", "110%"], x2: ["0%", "100%"] }}
   transition={{ duration, delay, repeat: Infinity, ease: "linear" }}
@@ -81,15 +77,18 @@ changes; only where the gradient's stops fall along it does.
   <stop stopColor={gradientStartColor} />
   <stop offset="32.5%" stopColor={gradientStopColor} />
   <stop offset="100%" stopColor={gradientStopColor} stopOpacity="0" />
-</motion.linearGradient>
-```
+</motion.linearGradient>`}
+>
+
+The animated part is a `motion.linearGradient` living inside the path's
+`<defs>`. Its `x1`/`x2` tween from one edge to past the other — `["10%",
+"110%"]` — on an infinite, linear-eased loop. The path underneath never
+changes; only where the gradient's stops fall along it does.
 
 `reverse` doesn't reverse an animation direction flag — it swaps the
 tween's own start/end percentages (`["90%", "-10%"]`), so the gradient
 still animates forward through the same linear timeline, just mapped onto
 the opposite travel.
-
-## Why the path is cheap even while the gradient runs
 
 The only thing animating every frame is two SVG attributes on a `<stop>`'s
 parent — `x1`/`x2` on a `linearGradient`. That's a paint-level change
@@ -97,6 +96,17 @@ scoped to the gradient fill, not a layout or geometry recalculation of the
 `<path>` itself, and definitely not a JS-driven `requestAnimationFrame`
 loop. The expensive part — remeasuring rects and rebuilding `d` — only runs
 on an actual resize, not every animation frame.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<AnimatedBeamResult />} isResult>
+
+One measured path, one travelling gradient, and a `ResizeObserver` making
+sure the first never drifts out from under the second.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Reduced motion
 
@@ -118,10 +128,3 @@ transition={reduceMotion ? { duration: 0 } : { duration, delay, repeat: Infinity
 ## Motion Score
 
 <MotionScorePanel name="animated-beam" />
-
-## The result
-
-<AnimatedBeamResult />
-
-One measured path, one travelling gradient, and a `ResizeObserver` making
-sure the first never drifts out from under the second.

--- a/apps/docs/content/docs/components/visualizations/globe/learn.mdx
+++ b/apps/docs/content/docs/components/visualizations/globe/learn.mdx
@@ -1,32 +1,22 @@
 ---
 title: Anatomy of Globe
 description: How one rAF tick drives an idle drift or a dragged rotation off the same angle, and why the canvas gets destroyed instead of just hidden.
+learnPlayer: true
 ---
 
-`Globe` isn't a spinning image — it's a single WebGL surface that
-[cobe](https://github.com/shuding/cobe) repaints every frame from one
-number: `phi`. Idle or dragged, that's the only thing changing.
+<LearnPlayer>
 
-## One canvas, some markers, a pointer
-
-The whole component is `createGlobe(canvas, config)` handed a merged config
-— your `markers`, colors, and glow over sane defaults — plus pointer
-handlers that never touch the globe directly. They only record how far the
-pointer has moved.
-
-<GlobeAnatomy />
-
-```tsx
-const merged: COBEOptions = {
+<LearnChapter
+  label="One canvas, some markers, a pointer"
+  scene={<GlobeAnatomy />}
+  code={`const merged: COBEOptions = {
   ...DEFAULT_CONFIG,
   ...config,
   width: widthRef.current * 2,
   height: widthRef.current * 2,
 };
 const globe = createGlobe(canvas, merged);
-```
 
-```tsx
 onPointerDown={(e) => {
   pointerInteracting.current = e.clientX - pointerMovement.current;
 }}
@@ -34,21 +24,24 @@ onPointerMove={(e) => {
   if (pointerInteracting.current !== null) {
     pointerMovement.current = e.clientX - pointerInteracting.current;
   }
-}}
-```
+}}`}
+>
 
-## The motion: one tick, two sources for `phi`
+`Globe` isn't a spinning image — it's a single WebGL surface that
+[cobe](https://github.com/shuding/cobe) repaints every frame from one
+number: `phi`. Idle or dragged, that's the only thing changing.
 
-Every frame, the `requestAnimationFrame` loop decides where `phi` comes
-from. Nobody's holding the pointer: it drifts by a fixed `0.005`. Somebody
-is: the drift stops and `pointerMovement.current / 200` takes over instead
-— the same `phi` variable, read from a different place, fed into the exact
-same `globe.update()` call.
+The whole component is `createGlobe(canvas, config)` handed a merged config
+— your `markers`, colors, and glow over sane defaults — plus pointer
+handlers that never touch the globe directly. They only record how far the
+pointer has moved.
 
-<GlobeRotate />
+</LearnChapter>
 
-```tsx
-const tick = () => {
+<LearnChapter
+  label="One tick, two sources for phi"
+  scene={<GlobeRotate />}
+  code={`const tick = () => {
   if (pointerInteracting.current === null && !reduceMotion) {
     phiRef.current += 0.005;
   }
@@ -58,14 +51,18 @@ const tick = () => {
     height: widthRef.current * 2,
   });
   raf = requestAnimationFrame(tick);
-};
-```
+};`}
+>
+
+Every frame, the `requestAnimationFrame` loop decides where `phi` comes
+from. Nobody's holding the pointer: it drifts by a fixed `0.005`. Somebody
+is: the drift stops and `pointerMovement.current / 200` takes over instead
+— the same `phi` variable, read from a different place, fed into the exact
+same `globe.update()` call.
 
 There's no mode switch, no branch that swaps animation systems — `phi` is
 one accumulator, and the pointer's offset is just added on top of it, so
 letting go resumes the drift from wherever the drag left it.
-
-## Why the loop lives outside React
 
 `phi`, pointer state, and canvas width are all refs, not `useState`. If they
 were state, every one of those ~60 updates a second would trigger a React
@@ -78,18 +75,12 @@ const phiRef = React.useRef(0);
 const pointerMovement = React.useRef(0);
 ```
 
-## Lifecycle: a real teardown, not a pause
+</LearnChapter>
 
-Mounting starts the tick and reveals the canvas on the next frame (so it
-never flashes an unpainted state). Unmounting doesn't just stop rendering —
-the effect's cleanup cancels the frame **and** calls `globe.destroy()`,
-which frees the WebGL context cobe allocated. Leaving it running after the
-canvas is gone would leak a context per mount/unmount cycle.
-
-<GlobeLifecycle />
-
-```tsx
-useEffect(() => {
+<LearnChapter
+  label="Lifecycle: a real teardown"
+  scene={<GlobeLifecycle />}
+  code={`useEffect(() => {
   const globe = createGlobe(canvas, merged);
   let raf = requestAnimationFrame(tick);
   const reveal = requestAnimationFrame(() => {
@@ -101,8 +92,25 @@ useEffect(() => {
     cancelAnimationFrame(reveal);
     globe.destroy();
   };
-}, [config]);
-```
+}, [config]);`}
+>
+
+Mounting starts the tick and reveals the canvas on the next frame (so it
+never flashes an unpainted state). Unmounting doesn't just stop rendering —
+the effect's cleanup cancels the frame **and** calls `globe.destroy()`,
+which frees the WebGL context cobe allocated. Leaving it running after the
+canvas is gone would leak a context per mount/unmount cycle.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<GlobeResult />} isResult>
+
+Same tick, same `phi`, same `globe.update()` — whether it's drifting on its
+own or following your cursor.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility
 
@@ -120,10 +128,3 @@ const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").match
 ## Motion Score
 
 <MotionScorePanel name="globe" />
-
-## The result
-
-<GlobeResult />
-
-Same tick, same `phi`, same `globe.update()` — whether it's drifting on its
-own or following your cursor.

--- a/apps/docs/content/docs/components/visualizations/gravity/learn.mdx
+++ b/apps/docs/content/docs/components/visualizations/gravity/learn.mdx
@@ -1,24 +1,15 @@
 ---
 title: Anatomy of Gravity
 description: How a matter-js world lives inside a React tree, why the engine is created at render instead of in an effect, and how a rAF loop turns physics bodies into moving DOM.
+learnPlayer: true
 ---
 
-`Gravity` isn't a canvas — it's a real, invisible physics world running
-underneath ordinary DOM elements. `matter-js` never draws anything; every
-frame, a sync loop copies each body's position straight into
-`style.transform` on the element you actually see.
+<LearnPlayer>
 
-## One world, thick walls, a few bodies
-
-The canvas is a plain `relative overflow-hidden` div. On mount, `Gravity`
-adds static rectangle walls just past each edge — `200px` thick, so a body
-moving fast can't tunnel through in a single frame — and every `MatterBody`
-child becomes one more rectangle or circle body in that same world.
-
-<GravityAnatomy />
-
-```tsx
-const t = 200; // thick walls keep fast bodies contained
+<LearnChapter
+  label="One world, thick walls, a few bodies"
+  scene={<GravityAnatomy />}
+  code={`const t = 200; // thick walls keep fast bodies contained
 const walls = [
   Matter.Bodies.rectangle(width / 2, height + t / 2, width + t * 2, t, opts),
   Matter.Bodies.rectangle(-t / 2, height / 2, t, height + t * 2, opts),
@@ -26,13 +17,23 @@ const walls = [
 ];
 if (addTopWall) {
   walls.push(Matter.Bodies.rectangle(width / 2, -t / 2, width + t * 2, t, opts));
-}
-```
+}`}
+>
+
+`Gravity` isn't a canvas — it's a real, invisible physics world running
+underneath ordinary DOM elements. `matter-js` never draws anything; every
+frame, a sync loop copies each body's position straight into
+`style.transform` on the element you actually see.
+
+The canvas is a plain `relative overflow-hidden` div. On mount, `Gravity`
+adds static rectangle walls just past each edge — `200px` thick, so a body
+moving fast can't tunnel through in a single frame — and every `MatterBody`
+child becomes one more rectangle or circle body in that same world.
 
 A `ResizeObserver` rebuilds the walls whenever the canvas changes size, so
 they always sit just outside whatever the container currently measures.
 
-## The engine is created at render, not in an effect
+The engine is created at render, not in an effect:
 
 ```tsx
 const [engine] = React.useState(() => Matter.Engine.create());
@@ -46,27 +47,42 @@ tried to add itself to a `world` that doesn't exist yet. Creating it during
 render (via lazy `useState`) guarantees the engine — and its `world` — exist
 before any child can register a body against it.
 
-## Position and angle become `style.transform`
+`x`/`y` accept a `%` string, a px string, or a number, so a body can be
+placed relative to a container whose size isn't known at author time:
+
+```tsx
+function resolve(value: number | string, size: number): number {
+  if (typeof value === "number") return value;
+  if (value.endsWith("%")) return (parseFloat(value) / 100) * size;
+  return parseFloat(value);
+}
+```
+
+This only runs once, at registration — after that, the body is a free
+physics object and its position is whatever the simulation computes, not
+the original percentage.
+
+</LearnChapter>
+
+<LearnChapter
+  label="Position and angle become style.transform"
+  scene={<GravitySync />}
+  code={`const sync = () => {
+  for (const { element, body } of bodiesRef.current.values()) {
+    const w = element.offsetWidth;
+    const h = element.offsetHeight;
+    element.style.transform = \`translate(\${body.position.x - w / 2}px, \${
+      body.position.y - h / 2
+    }px) rotate(\${body.angle}rad)\`;
+  }
+  syncFrame = requestAnimationFrame(sync);
+};`}
+>
 
 Matter.js has no idea a DOM exists. A `sync` function, scheduled with
 `requestAnimationFrame`, reads every registered body's `position` and
 `angle` each frame and writes them into the matching element's `transform` —
 nothing else moves the plate.
-
-<GravitySync />
-
-```tsx
-const sync = () => {
-  for (const { element, body } of bodiesRef.current.values()) {
-    const w = element.offsetWidth;
-    const h = element.offsetHeight;
-    element.style.transform = `translate(${body.position.x - w / 2}px, ${
-      body.position.y - h / 2
-    }px) rotate(${body.angle}rad)`;
-  }
-  syncFrame = requestAnimationFrame(sync);
-};
-```
 
 Subtracting half the element's own width and height re-centers the
 translation, because Matter tracks a body's *center* while `transform`
@@ -74,8 +90,6 @@ moves from the element's top-left origin. `translate`/`rotate` are both
 compositor-only — the browser moves an already-painted layer without
 re-running layout, which is what makes dozens of simultaneously falling
 bodies stay smooth.
-
-## Only draggable bodies grab
 
 A single shared `Matter.MouseConstraint` handles every pointer interaction
 in the world. Each `MatterBody` carries its own `isDraggable` flag, checked
@@ -96,18 +110,12 @@ If the body that was grabbed isn't draggable, the constraint's target is
 cleared on the same tick — the pointer never actually attaches, so the body
 keeps falling under gravity instead of following the cursor.
 
-## Cheap when idle
+</LearnChapter>
 
-A physics world sitting off screen, or behind a hidden tab, has no business
-burning frames. An `IntersectionObserver` on the canvas and a
-`visibilitychange` listener on the document both gate the same two
-functions: `resume()` starts the Matter `Runner` and reschedules the rAF
-sync loop; `pause()` stops both.
-
-<GravityLifecycle />
-
-```tsx
-const io = new IntersectionObserver(
+<LearnChapter
+  label="Cheap when idle"
+  scene={<GravityLifecycle />}
+  code={`const io = new IntersectionObserver(
   ([entry]) => {
     visible = entry.isIntersecting;
     if (visible && !document.hidden) resume();
@@ -119,31 +127,36 @@ const io = new IntersectionObserver(
 document.addEventListener("visibilitychange", () => {
   if (document.hidden) pause();
   else if (visible) resume();
-});
-```
+});`}
+>
+
+A physics world sitting off screen, or behind a hidden tab, has no business
+burning frames. An `IntersectionObserver` on the canvas and a
+`visibilitychange` listener on the document both gate the same two
+functions: `resume()` starts the Matter `Runner` and reschedules the rAF
+sync loop; `pause()` stops both.
 
 Either condition failing is enough to pause — visible-but-hidden-tab and
 intersecting-but-off-screen both stop the simulation, and either one
 becoming true again resumes it exactly where the bodies were left.
 
-## Percent positions, resolved once
+</LearnChapter>
 
-`x`/`y` accept a `%` string, a px string, or a number, so a body can be
-placed relative to a container whose size isn't known at author time:
+<LearnChapter label="The result" scene={<GravityResult />} isResult>
 
-```tsx
-function resolve(value: number | string, size: number): number {
-  if (typeof value === "number") return value;
-  if (value.endsWith("%")) return (parseFloat(value) / 100) * size;
-  return parseFloat(value);
-}
-```
+A matter-js world, invisible and running underneath, mirrored onto the DOM
+one `transform` write per frame — paused the instant nobody's watching.
 
-This only runs once, at registration — after that, the body is a free
-physics object and its position is whatever the simulation computes, not
-the original percentage.
+</LearnChapter>
 
-## Reduced motion skips the engine entirely
+</LearnPlayer>
+
+## Reduced motion
+
+Under `prefers-reduced-motion`, `Gravity` never creates an engine and
+`MatterBody` never registers — each body just lays itself out statically at
+its authored `x`/`y`/`angle` using ordinary absolute positioning. No physics
+runs, no walls exist, nothing falls.
 
 ```tsx
 const staticPlacement =
@@ -156,18 +169,6 @@ const staticPlacement =
     : undefined;
 ```
 
-Under `prefers-reduced-motion`, `Gravity` never creates an engine and
-`MatterBody` never registers — each body just lays itself out statically at
-its authored `x`/`y`/`angle` using ordinary absolute positioning. No physics
-runs, no walls exist, nothing falls.
-
 ## Motion Score
 
 <MotionScorePanel name="gravity" />
-
-## The result
-
-<GravityResult />
-
-A matter-js world, invisible and running underneath, mirrored onto the DOM
-one `transform` write per frame — paused the instant nobody's watching.

--- a/apps/docs/content/docs/components/visualizations/orbiting-circles/learn.mdx
+++ b/apps/docs/content/docs/components/visualizations/orbiting-circles/learn.mdx
@@ -1,14 +1,32 @@
 ---
 title: Anatomy of Orbiting Circles
 description: How one rotating ring places every child on a circle, and the one counter-rotation that keeps them from tumbling as they travel.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="The box, the ring, and one angle per slot"
+  scene={<OrbitingCirclesAnatomy />}
+  code={`const box = radius * 2 + iconSize;
+const angle = (360 / n) * i;
+
+<div
+  style={{
+    width: iconSize,
+    height: iconSize,
+    transform: \`rotate(\${angle}deg) translateY(-\${radius}px)\`,
+  }}
+>
+  {child}
+</div>`}
+>
 
 `OrbitingCircles` doesn't animate each child individually — it spins **one**
 ring, positions every child at a fixed angle on that ring, and then spins
 each child's own content backward by the exact same amount. Three simple
 transforms, layered.
-
-## The box, the ring, and one angle per slot
 
 The component's outer box is sized from its own geometry —
 `radius * 2 + iconSize` — so it never clips the orbit. Every child gets an
@@ -16,44 +34,16 @@ even slice of the circle, `angle = (360 / n) * i`, and is placed with a
 single `rotate → translate` pair: rotate to the child's angle, then push it
 out along the now-rotated Y axis.
 
-<OrbitingCirclesAnatomy />
-
-```tsx
-const box = radius * 2 + iconSize;
-const angle = (360 / n) * i;
-```
-
-```tsx
-<div
-  style={{
-    width: iconSize,
-    height: iconSize,
-    transform: `rotate(${angle}deg) translateY(-${radius}px)`,
-  }}
->
-  {child}
-</div>
-```
-
 The outer `motion.div` — the ring — renders no visible markup of its own.
 It exists purely to rotate its children together; `showPath` is a separate,
 static circle drawn underneath for the faint track.
 
-## Why counter-rotation, and not just "don't rotate"
+</LearnChapter>
 
-The ring has to rotate as a whole — that's what makes every slot travel
-together in lockstep instead of each running its own orbit math. But
-rotating the ring also rotates everything inside it, including each slot's
-icon. Left alone, an icon would spin a full 360° every orbit — upside-down
-at the bottom, sideways at the sides.
-
-<OrbitingCirclesCounter />
-
-The fix is a second `motion.div` **inside** each slot, animating the exact
-inverse on the identical clock:
-
-```tsx
-<motion.div
+<LearnChapter
+  label="Counter-rotation"
+  scene={<OrbitingCirclesCounter />}
+  code={`<motion.div
   animate={{ rotate: reverse ? -360 : 360 }}   // the ring
   transition={spin}
 >
@@ -64,41 +54,59 @@ inverse on the identical clock:
   >
     {child}
   </motion.div>
-</motion.div>
-```
+</motion.div>`}
+>
+
+The ring has to rotate as a whole — that's what makes every slot travel
+together in lockstep instead of each running its own orbit math. But
+rotating the ring also rotates everything inside it, including each slot's
+icon. Left alone, an icon would spin a full 360° every orbit — upside-down
+at the bottom, sideways at the sides.
+
+The fix is a second `motion.div` **inside** each slot, animating the exact
+inverse on the identical clock.
 
 Same `duration`, same `ease: "linear"`, same `repeat: Infinity` — the two
 rotations are mirror images of each other, so their sum is always zero.
 `reverse` flips both signs together, which is why it never breaks the
 cancellation.
 
-## Two rings, sharing nothing but a center
+</LearnChapter>
 
-`radius`, `duration`, and `reverse` are all per-instance, so stacking two
-`OrbitingCircles` on the same absolutely-positioned center gives you two
-independently-timed orbits with no shared state — just two components that
-happen to overlap.
-
-<OrbitingCirclesRings />
-
-```tsx
-<div className="relative flex h-80 items-center justify-center">
+<LearnChapter
+  label="Two rings, sharing nothing but a center"
+  scene={<OrbitingCirclesRings />}
+  code={`<div className="relative flex h-80 items-center justify-center">
   <OrbitingCircles radius={60} duration={14} className="absolute">
     <Icon /><Icon />
   </OrbitingCircles>
   <OrbitingCircles radius={120} duration={24} reverse className="absolute">
     <Icon /><Icon /><Icon />
   </OrbitingCircles>
-</div>
-```
+</div>`}
+>
 
-## Why transform, not layout
+`radius`, `duration`, and `reverse` are all per-instance, so stacking two
+`OrbitingCircles` on the same absolutely-positioned center gives you two
+independently-timed orbits with no shared state — just two components that
+happen to overlap.
 
 Both rotations — the ring's and each slot's counter-rotation — are
 `rotate`/`translateY` on `transform`, computed once from `radius` and
 `iconSize` and never touched again after mount. A dense orbit of a dozen
 icons costs the same per frame as one: the browser is just compositing
 already-painted layers along a fixed circle, not recalculating positions.
+
+</LearnChapter>
+
+<LearnChapter label="The result" scene={<OrbitingCirclesResult />} isResult>
+
+One ring rotation, one exact inverse — that's the whole orbit, upright the
+entire way around.
+
+</LearnChapter>
+
+</LearnPlayer>
 
 ## Accessibility
 
@@ -115,10 +123,3 @@ style={reduceMotion ? { transform: `rotate(${-angle}deg)` } : undefined}
 ## Motion Score
 
 <MotionScorePanel name="orbiting-circles" />
-
-## The result
-
-<OrbitingCirclesResult />
-
-One ring rotation, one exact inverse — that's the whole orbit, upright the
-entire way around.

--- a/apps/docs/content/docs/components/visualizations/scroll-timeline/learn.mdx
+++ b/apps/docs/content/docs/components/visualizations/scroll-timeline/learn.mdx
@@ -1,26 +1,17 @@
 ---
 title: Anatomy of the Scroll Timeline
 description: Why the rail grows with scaleY instead of height, how a spring keeps the fill from feeling jittery, and how a sticky node and a fade-up entry share one flex row.
+learnPlayer: true
 ---
 
-A scrollytelling rail that visibly "draws" as you read only works if the
-fill can grow every scroll frame without ever asking the layout engine to
-recompute anything. `ScrollTimeline` gets there with one measured number, one
-spring, and a transform that never touches `height`.
+<LearnPlayer>
 
-## One rail, a node and a card per entry
-
-Each entry is a single flex row: a sticky node stays pinned to the rail
-while its section is in view, and a content card fades up once, the first
-time it enters. The rail itself is one absolutely-positioned line sized to
-the track's *measured* height — not one segment stitched per entry.
-
-<ScrollTimelineAnatomy />
-
-```tsx
-<div ref={trackRef} className="relative mx-auto max-w-4xl pb-20">
+<LearnChapter
+  label="One rail, a node and a card per entry"
+  scene={<ScrollTimelineAnatomy />}
+  code={`<div ref={trackRef} className="relative mx-auto max-w-4xl pb-20">
   {data.map((item, index) => (
-    <div key={`${item.title}-${index}`} className="flex justify-start pt-10 md:gap-10 md:pt-24">
+    <div key={\`\${item.title}-\${index}\`} className="flex justify-start pt-10 md:gap-10 md:pt-24">
       <div className="sticky top-24 z-base flex max-w-xs flex-col items-center self-start md:w-44 md:flex-row md:items-start">
         {/* node */}
       </div>
@@ -29,10 +20,18 @@ the track's *measured* height — not one segment stitched per entry.
       </motion.div>
     </div>
   ))}
-</div>
-```
+</div>`}
+>
 
-## Measuring the rail with `ResizeObserver`
+A scrollytelling rail that visibly "draws" as you read only works if the
+fill can grow every scroll frame without ever asking the layout engine to
+recompute anything. `ScrollTimeline` gets there with one measured number, one
+spring, and a transform that never touches `height`.
+
+Each entry is a single flex row: a sticky node stays pinned to the rail
+while its section is in view, and a content card fades up once, the first
+time it enters. The rail itself is one absolutely-positioned line sized to
+the track's *measured* height — not one segment stitched per entry.
 
 The line's total height can't be hard-coded — it depends on how much content
 each entry renders, which varies with the data and the viewport width. A
@@ -55,22 +54,22 @@ React.useLayoutEffect(() => {
 paints, so the rail's container is sized correctly on the very first frame
 instead of flashing at zero height and snapping.
 
-## `scaleY`, not `height`
+</LearnChapter>
 
-The fill is a fixed-height overlay clipped by `overflow: hidden` on its
-`height`-sized parent, transformed with `scaleY` from `transform-origin:
-top`. Scroll progress drives the scale, never the box's actual height.
-
-<ScrollTimelineScrub />
-
-```tsx
-<div style={{ height }} className="absolute top-0 left-7 w-px overflow-hidden bg-border">
+<LearnChapter
+  label="scaleY, not height"
+  scene={<ScrollTimelineScrub />}
+  code={`<div style={{ height }} className="absolute top-0 left-7 w-px overflow-hidden bg-border">
   <motion.div
     style={{ scaleY: reduce ? 1 : progress, opacity: reduce ? 1 : lineOpacity }}
     className="absolute inset-0 w-px origin-top rounded-full bg-[linear-gradient(to_top,var(--primary),transparent)]"
   />
-</div>
-```
+</div>`}
+>
+
+The fill is a fixed-height overlay clipped by `overflow: hidden` on its
+`height`-sized parent, transformed with `scaleY` from `transform-origin:
+top`. Scroll progress drives the scale, never the box's actual height.
 
 `scaleY` is a transform, so growing the line every scroll frame is a
 composited operation — the browser stretches an already-painted layer. If
@@ -78,18 +77,12 @@ this animated `height` instead, every single scroll event would force a
 layout recalculation on the rail's ancestors, which is exactly the kind of
 per-frame layout thrash `useScroll`-driven UI can't afford.
 
-## Why the fill is spring-smoothed
+</LearnChapter>
 
-`useScroll` reports `scrollYProgress` as a raw number that updates on every
-native scroll event — precise, but visually jittery, especially over a
-trackpad or an inertial mobile scroll. Feeding it straight into `scaleY`
-would make the rail twitch. `ScrollTimeline` re-emits it through a spring
-first:
-
-<ScrollTimelineSpring />
-
-```tsx
-const { scrollYProgress } = useScroll({
+<LearnChapter
+  label="Spring-smoothed fill"
+  scene={<ScrollTimelineSpring />}
+  code={`const { scrollYProgress } = useScroll({
   target: trackRef,
   offset: ["start 10%", "end 60%"],
 });
@@ -98,8 +91,14 @@ const progress = useSpring(scrollYProgress, {
   stiffness: 320,
   damping: 32,
   mass: 0.9,
-});
-```
+});`}
+>
+
+`useScroll` reports `scrollYProgress` as a raw number that updates on every
+native scroll event — precise, but visually jittery, especially over a
+trackpad or an inertial mobile scroll. Feeding it straight into `scaleY`
+would make the rail twitch. `ScrollTimeline` re-emits it through a spring
+first.
 
 `stiffness: 320` keeps the spring tight enough that it doesn't visibly lag
 behind fast scrolling; `damping: 32` is high enough relative to that
@@ -111,8 +110,6 @@ The `["start 10%", "end 60%"]` offset means the rail starts filling once the
 track's top has scrolled 10% into the viewport, and finishes once its
 bottom has scrolled up to the 60% line — not when the track enters or
 leaves entirely, which keeps both ends of the fill comfortably on screen.
-
-## Entries fade up once, the sticky label doesn't
 
 Content fades in with Framer's `whileInView`, gated by `once: true` so it
 never replays on scroll back up:
@@ -131,26 +128,30 @@ doesn't need one: `position: sticky` already gives it the "pinned while its
 section passes" behavior for free, so the only animated things on the page
 are the rail's fill and each card's one-time entrance.
 
-## Reduced motion resolves, it doesn't skip
+</LearnChapter>
 
-```tsx
-initial={reduce ? false : { opacity: 0, y: 12 }}
-style={{ scaleY: reduce ? 1 : progress, opacity: reduce ? 1 : lineOpacity }}
-```
+<LearnChapter label="The result" scene={<ScrollTimelineResult />} isResult>
+
+One measured number driving a `scaleY` transform, smoothed through a
+spring, next to sticky nodes that need no JavaScript at all. Scroll the page
+through it.
+
+</LearnChapter>
+
+</LearnPlayer>
+
+## Reduced motion
 
 Under `prefers-reduced-motion`, the rail renders fully drawn (`scaleY: 1`)
 and every entry starts already visible (`initial={false}`) — the timeline is
 immediately readable top to bottom, with no scroll-driven reveal to wait
 out.
 
+```tsx
+initial={reduce ? false : { opacity: 0, y: 12 }}
+style={{ scaleY: reduce ? 1 : progress, opacity: reduce ? 1 : lineOpacity }}
+```
+
 ## Motion Score
 
 <MotionScorePanel name="scroll-timeline" />
-
-## The result
-
-<ScrollTimelineResult />
-
-One measured number driving a `scaleY` transform, smoothed through a
-spring, next to sticky nodes that need no JavaScript at all. Scroll the page
-through it.

--- a/apps/docs/content/docs/components/visualizations/world-map/learn.mdx
+++ b/apps/docs/content/docs/components/visualizations/world-map/learn.mdx
@@ -1,39 +1,31 @@
 ---
 title: Anatomy of the World Map
 description: How a deterministic dot grid, a plain quadratic Bézier, and a fill-box ripple combine into a map that's identical on the server and the client.
+learnPlayer: true
 ---
+
+<LearnPlayer>
+
+<LearnChapter
+  label="Dots, pins, one arc"
+  scene={<WorldMapAnatomy />}
+  code={`const map = new DottedMap({ height: 60, grid: "diagonal" });
+const svg = map.getSVG({ radius: 0.22, color: "currentColor", shape: "circle" });`}
+>
 
 `WorldMap` never fetches a map image. The land is a grid of dots generated
 on the fly, the arcs are two-point curves computed from the same projection
 that placed the dots, and none of it depends on anything that could differ
 between server and client.
 
-## Dots, pins, one arc
-
 Everything shares a single SVG coordinate space. A static grid of land dots
 is generated once with [`dotted-map`](https://github.com/NTgamesoft/dotted-map)
 and drawn with `currentColor`; a pin marks every arc endpoint; an arc is
 just a quadratic Bézier bow between two pins.
 
-<WorldMapAnatomy />
-
-```tsx
-const map = new DottedMap({ height: 60, grid: "diagonal" });
-const svg = map.getSVG({ radius: 0.22, color: "currentColor", shape: "circle" });
-```
-
 Rendering the dots with `currentColor` instead of baking a fixed color into
 the generated markup means `dotColor`, set on the SVG's own `style.color`,
 can restyle every dot without regenerating the grid.
-
-## Deterministic, so the server and the client agree
-
-```tsx
-const { markup, width, height, map } = React.useMemo(() => {
-  const map = new DottedMap({ height: 60, grid: "diagonal" });
-  // …
-}, []);
-```
 
 `DottedMap` with fixed arguments always produces the exact same grid. That
 determinism is what lets `WorldMap` render this way at all: a hydration
@@ -42,7 +34,12 @@ client's, and there's no client-only escape hatch here — the dots are
 injected with `dangerouslySetInnerHTML` on first render, not patched in
 after mount.
 
-## Arcs are computed from the same projection as the dots
+```tsx
+const { markup, width, height, map } = React.useMemo(() => {
+  const map = new DottedMap({ height: 60, grid: "diagonal" });
+  // …
+}, []);
+```
 
 `map.getPin({ lat, lng })` is the same projection `dotted-map` used to place
 every dot, so an arc's endpoints land exactly on real dot positions instead
@@ -62,15 +59,12 @@ start-to-end distance — the farther apart two points are, the higher the
 arc bows, which is what keeps a short hop and a transcontinental line both
 reading as "an arc" instead of the long one looking almost flat.
 
-## The draw-in
+</LearnChapter>
 
-Each arc animates `pathLength` from `0` to `1`, staggered per connection so
-a whole map full of routes doesn't snap in all at once:
-
-<WorldMapDraw />
-
-```tsx
-initial={reduceMotion ? false : { pathLength: 0 }}
+<LearnChapter
+  label="The draw-in"
+  scene={<WorldMapDraw />}
+  code={`initial={reduceMotion ? false : { pathLength: 0 }}
 animate={{ pathLength: 1 }}
 transition={{
   duration,
@@ -78,14 +72,19 @@ transition={{
   ease: [0.22, 1, 0.36, 1],
   repeat: loop ? Number.POSITIVE_INFINITY : 0,
   repeatDelay: loop ? connections.length * 0.3 : 0,
-}}
-```
+}}`}
+>
+
+Each arc animates `pathLength` from `0` to `1`, staggered per connection so
+a whole map full of routes doesn't snap in all at once.
 
 `repeatDelay` scales with `connections.length` — more arcs means a longer
 pause before the whole set redraws together, so the loop always reads as
 "the map refreshes," not "arc 1 restarts while arc 4 is still drawing."
 
-## A gradient fades the arc's own ends
+Each arc strokes with a horizontal linear gradient instead of a flat color,
+so every beam visibly emerges from its start pin and dissolves into its end
+pin rather than terminating with a hard-edged cap:
 
 ```tsx
 <linearGradient id={gradientId} x1="0%" y1="0%" x2="100%" y2="0%">
@@ -96,52 +95,52 @@ pause before the whole set redraws together, so the loop always reads as
 </linearGradient>
 ```
 
-Each arc strokes with `url(#gradientId)` instead of a flat color, so every
-beam visibly emerges from its start pin and dissolves into its end pin
-rather than terminating with a hard-edged cap.
+</LearnChapter>
 
-## The pin ripple
+<LearnChapter
+  label="The pin ripple"
+  scene={<WorldMapPulse />}
+  code={`<motion.circle
+  initial={{ scale: 1, opacity: 0.6 }}
+  animate={{ scale: 3, opacity: 0 }}
+  transition={{ duration: 1.8, repeat: Number.POSITIVE_INFINITY, ease: [0.22, 1, 0.36, 1] }}
+  style={{ transformBox: "fill-box", transformOrigin: "center" }}
+/>`}
+>
 
 Every endpoint gets a second, purely decorative circle behind the solid pin
 — the ripple. It scales from `1` to `3` while fading from `0.6` to `0`,
 forever, using `transformBox: fill-box` so it scales around its own center
 instead of the SVG's coordinate origin.
 
-<WorldMapPulse />
-
-```tsx
-<motion.circle
-  initial={{ scale: 1, opacity: 0.6 }}
-  animate={{ scale: 3, opacity: 0 }}
-  transition={{ duration: 1.8, repeat: Number.POSITIVE_INFINITY, ease: [0.22, 1, 0.36, 1] }}
-  style={{ transformBox: "fill-box", transformOrigin: "center" }}
-/>
-```
-
 Without `transformBox: fill-box`, an SVG element's default transform origin
 is the coordinate `(0, 0)` of its nearest viewport, not its own shape — the
 ripple would scale away from the pin instead of growing outward from it.
 
-## Reduced motion removes both loops
+</LearnChapter>
 
-```tsx
-initial={reduceMotion ? false : { pathLength: 0 }}
-{!reduceMotion && <motion.circle /* ripple */ />}
-```
+<LearnChapter label="The result" scene={<WorldMapResult />} isResult>
+
+A deterministic dot grid, arcs projected from the same math that placed the
+dots, and two independent infinite loops — the draw and the ripple — that
+both vanish cleanly under reduced motion.
+
+</LearnChapter>
+
+</LearnPlayer>
+
+## Reduced motion
 
 Under `prefers-reduced-motion`, arcs render fully drawn immediately and the
 ripple circle isn't rendered at all — not paused, not frozen mid-animation,
 simply absent. The map is fully legible on first paint with nothing left
 looping.
 
+```tsx
+initial={reduceMotion ? false : { pathLength: 0 }}
+{!reduceMotion && <motion.circle /* ripple */ />}
+```
+
 ## Motion Score
 
 <MotionScorePanel name="world-map" />
-
-## The result
-
-<WorldMapResult />
-
-A deterministic dot grid, arcs projected from the same math that placed the
-dots, and two independent infinite loops — the draw and the ripple — that
-both vanish cleanly under reduced motion.

--- a/apps/docs/next-env.d.ts
+++ b/apps/docs/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -17,6 +17,10 @@ export const docs = defineDocs({
       // "Workbench" layout (live stage + dock + drawer) instead of the classic
       // linear column. Opt-in per page so un-migrated pages keep the old layout.
       workbench: frontmatterSchema.shape.full.optional(),
+      // When true, a Learn page renders in the stage-first <LearnPlayer> layout
+      // (pinned preview + chapter rail) and its auto-TOC is suppressed. Opt-in
+      // per page so un-migrated Learn articles keep the classic scroll layout.
+      learnPlayer: frontmatterSchema.shape.full.optional(),
     }),
   },
 });

--- a/apps/docs/src/app/docs/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/docs/[[...slug]]/page.tsx
@@ -8,6 +8,7 @@ import {
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { ComponentBadges } from "@/components/component-badges";
+import { LearnPlayerProvider } from "@/components/learn/learn-player-context";
 import { getMDXComponents } from "@/components/mdx";
 import {
   type BadgeItem,
@@ -73,7 +74,15 @@ export default async function Page(props: PageProps<"/docs/[[...slug]]">) {
       url: atComponentsRoot ? undefined : "/docs/components",
     });
     if (!atComponentsRoot) {
-      crumbs.push({ name: componentCrumbTitle ?? page.data.title });
+      // On the Learn page the component crumb links back to its docs page, and a
+      // trailing "Learn" crumb marks where you are (the Docs/Learn tabs are gone
+      // in the stage-first layout).
+      const componentHref = base ? `/docs/${base.join("/")}` : undefined;
+      crumbs.push({
+        name: componentCrumbTitle ?? page.data.title,
+        url: isLearnPage ? componentHref : undefined,
+      });
+      if (isLearnPage) crumbs.push({ name: "Learn" });
     }
   } else if (slug.length) {
     crumbs.push({ name: page.data.title });
@@ -203,43 +212,74 @@ export default async function Page(props: PageProps<"/docs/[[...slug]]">) {
       <TocCta />
     );
 
+  // The stage-first Learn layout renders the article title + description *below*
+  // its pinned preview (via <LearnPlayer>), so the page suppresses the default
+  // title/badges here and widens the column to give the stage room.
+  const isLearnPlayer =
+    isLearnPage &&
+    (page.data as { learnPlayer?: boolean }).learnPlayer === true;
+
   return (
     <DocsPage
-      toc={page.data.toc}
-      full={page.data.full}
+      toc={isLearnPlayer ? [] : page.data.toc}
+      full={page.data.full || isLearnPlayer}
       breadcrumb={{ enabled: false }}
-      tableOfContent={{ footer: tocFooter }}
-      tableOfContentPopover={{ footer: tocFooter }}
+      // The stage-first layout is self-navigating (chapter rail) and fills the
+      // full content width, so it drops the right TOC column entirely.
+      tableOfContent={
+        isLearnPlayer ? { enabled: false } : { footer: tocFooter }
+      }
+      tableOfContentPopover={
+        isLearnPlayer ? { enabled: false } : { footer: tocFooter }
+      }
+      className={isLearnPlayer ? "learn-player-page max-w-none" : undefined}
     >
       {isLearnPage && docsHref ? <SidebarActiveLink href={docsHref} /> : null}
       {crumbs.length > 1 || tabs ? (
         <div className="-mb-2 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
           <Breadcrumbs crumbs={crumbs} />
-          {tabs ? (
+          {tabs && !isLearnPlayer ? (
             <ComponentTabs tabs={tabs} className="self-start sm:self-auto" />
           ) : null}
         </div>
       ) : null}
-      {isComponentDocsPage ? (
-        <ComponentBadges
-          score={score}
-          scoreHref={
-            hasLearn && docsHref ? `${docsHref}/learn#motion-score` : undefined
-          }
-          perf={motionNote}
-          dep={dependencyNote}
-          isStatic={isStatic}
-        />
-      ) : isLearnPage ? (
-        <ComponentBadges placeholder />
-      ) : null}
-      <DocsTitle className="docs-title">{page.data.title}</DocsTitle>
-      <DocsDescription className="docs-lead">
-        {page.data.description}
-      </DocsDescription>
-      <DocsBody>
-        <MDX components={getMDXComponents()} />
-      </DocsBody>
+      {isLearnPlayer ? (
+        <LearnPlayerProvider
+          value={{
+            title: page.data.title,
+            description: page.data.description,
+          }}
+        >
+          <DocsBody>
+            <MDX components={getMDXComponents()} />
+          </DocsBody>
+        </LearnPlayerProvider>
+      ) : (
+        <>
+          {isComponentDocsPage ? (
+            <ComponentBadges
+              score={score}
+              scoreHref={
+                hasLearn && docsHref
+                  ? `${docsHref}/learn#motion-score`
+                  : undefined
+              }
+              perf={motionNote}
+              dep={dependencyNote}
+              isStatic={isStatic}
+            />
+          ) : isLearnPage ? (
+            <ComponentBadges placeholder />
+          ) : null}
+          <DocsTitle className="docs-title">{page.data.title}</DocsTitle>
+          <DocsDescription className="docs-lead">
+            {page.data.description}
+          </DocsDescription>
+          <DocsBody>
+            <MDX components={getMDXComponents()} />
+          </DocsBody>
+        </>
+      )}
     </DocsPage>
   );
 }

--- a/apps/docs/src/app/globals.css
+++ b/apps/docs/src/app/globals.css
@@ -144,6 +144,13 @@ body {
     padding-top: 0 !important;
   }
 
+  /* Learn player pages: match the content's right edge to the header's (px-4 /
+     1rem) so the pinned preview lines up with the header icons instead of
+     stopping short at the wider article padding (md:px-6 / xl:px-8). */
+  #nd-page.learn-player-page {
+    padding-right: 1rem !important;
+  }
+
   /* The mobile-only "Menu" block is hidden on desktop but its wrapper's mb-4
      margin still pushed the first nav label down. Remove it, then offset the
      first section label by the same amount as #nd-page's top padding so

--- a/apps/docs/src/components/learn/accordion-result.tsx
+++ b/apps/docs/src/components/learn/accordion-result.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Accordion } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive
@@ -27,6 +28,14 @@ const FAQ_ITEMS = [
 ];
 
 export function AccordionResult() {
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        <div className="w-full max-w-lg">
+          <Accordion items={FAQ_ITEMS} defaultValue="what" />
+        </div>
+      </div>
+    );
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">

--- a/apps/docs/src/components/learn/agent-flow-result.tsx
+++ b/apps/docs/src/components/learn/agent-flow-result.tsx
@@ -6,6 +6,7 @@ import {
   type AgentFlowNode,
 } from "@godui/components";
 import * as React from "react";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * The real `AgentFlow`, trimmed to four nodes so the whole run fits the
@@ -56,6 +57,27 @@ const EDGES: AgentFlowEdge[] = [
 
 export function AgentFlowResult() {
   const [run, setRun] = React.useState(0);
+  const bare = useBareScene();
+
+  const demo = (
+    <AgentFlow
+      key={run}
+      nodes={NODES}
+      edges={EDGES}
+      autoPlay
+      aria-label="Research agent workflow"
+      className="min-h-[360px] w-full"
+    />
+  );
+
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (bare)
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        {demo}
+      </div>
+    );
 
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
@@ -90,16 +112,7 @@ export function AgentFlowResult() {
           </svg>
         </button>
       </div>
-      <div className="p-4 md:p-6">
-        <AgentFlow
-          key={run}
-          nodes={NODES}
-          edges={EDGES}
-          autoPlay
-          aria-label="Research agent workflow"
-          className="min-h-[360px] w-full"
-        />
-      </div>
+      <div className="p-4 md:p-6">{demo}</div>
     </div>
   );
 }

--- a/apps/docs/src/components/learn/agent-timeline-result.tsx
+++ b/apps/docs/src/components/learn/agent-timeline-result.tsx
@@ -2,6 +2,7 @@
 
 import { AgentStep, AgentTimeline, type StepStatus } from "@godui/components";
 import * as React from "react";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive
@@ -53,6 +54,36 @@ export function AgentTimelineResult() {
   const statusFor = (i: number): StepStatus =>
     i < active ? "success" : i === active ? "running" : "pending";
 
+  // The live, interactive timeline — reused by both the bare stage render and
+  // the classic card below.
+  const demo = (
+    <div key={run} className="w-full max-w-md">
+      <AgentTimeline>
+        {STEPS.map((step, i) => (
+          <AgentStep
+            key={step.title}
+            status={statusFor(i)}
+            title={step.title}
+            meta={statusFor(i) === "pending" ? undefined : step.meta}
+            defaultOpen={i === active}
+            last={i === STEPS.length - 1}
+          >
+            {step.body}
+          </AgentStep>
+        ))}
+      </AgentTimeline>
+    </div>
+  );
+
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -90,22 +121,7 @@ export function AgentTimelineResult() {
         </button>
       </div>
       <div className="flex min-h-[280px] items-center justify-center p-6 md:p-10">
-        <div key={run} className="w-full max-w-md">
-          <AgentTimeline>
-            {STEPS.map((step, i) => (
-              <AgentStep
-                key={step.title}
-                status={statusFor(i)}
-                title={step.title}
-                meta={statusFor(i) === "pending" ? undefined : step.meta}
-                defaultOpen={i === active}
-                last={i === STEPS.length - 1}
-              >
-                {step.body}
-              </AgentStep>
-            ))}
-          </AgentTimeline>
-        </div>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/animated-beam-result.tsx
+++ b/apps/docs/src/components/learn/animated-beam-result.tsx
@@ -3,6 +3,7 @@
 import { AnimatedBeam } from "@godui/components";
 import { Box, Cloud, Database, Sparkles } from "lucide-react";
 import * as React from "react";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real `AnimatedBeam`, a
@@ -29,6 +30,56 @@ export function AnimatedBeamResult() {
   const bRef = React.useRef<HTMLDivElement>(null);
   const cRef = React.useRef<HTMLDivElement>(null);
 
+  const demo = (
+    <>
+      <div
+        ref={containerRef}
+        className="relative flex h-[280px] w-full max-w-md items-center justify-between px-8"
+      >
+        <div className="flex flex-col gap-8">
+          <Node ref={aRef} className="size-12">
+            <Box className="size-5 text-foreground" />
+          </Node>
+          <Node ref={bRef} className="size-12">
+            <Cloud className="size-5 text-foreground" />
+          </Node>
+          <Node ref={cRef} className="size-12">
+            <Database className="size-5 text-foreground" />
+          </Node>
+        </div>
+
+        <Node ref={hubRef} className="size-16 bg-primary">
+          <Sparkles className="size-7 text-primary-foreground" />
+        </Node>
+
+        <AnimatedBeam
+          containerRef={containerRef}
+          fromRef={aRef}
+          toRef={hubRef}
+          curvature={50}
+        />
+        <AnimatedBeam
+          containerRef={containerRef}
+          fromRef={bRef}
+          toRef={hubRef}
+        />
+        <AnimatedBeam
+          containerRef={containerRef}
+          fromRef={cRef}
+          toRef={hubRef}
+          curvature={-50}
+        />
+      </div>
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[320px] items-center justify-center p-6 md:p-6 w-full">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -40,44 +91,7 @@ export function AnimatedBeamResult() {
         </span>
       </div>
       <div className="flex min-h-[320px] items-center justify-center p-6 md:p-10">
-        <div
-          ref={containerRef}
-          className="relative flex h-[280px] w-full max-w-md items-center justify-between px-8"
-        >
-          <div className="flex flex-col gap-8">
-            <Node ref={aRef} className="size-12">
-              <Box className="size-5 text-foreground" />
-            </Node>
-            <Node ref={bRef} className="size-12">
-              <Cloud className="size-5 text-foreground" />
-            </Node>
-            <Node ref={cRef} className="size-12">
-              <Database className="size-5 text-foreground" />
-            </Node>
-          </div>
-
-          <Node ref={hubRef} className="size-16 bg-primary">
-            <Sparkles className="size-7 text-primary-foreground" />
-          </Node>
-
-          <AnimatedBeam
-            containerRef={containerRef}
-            fromRef={aRef}
-            toRef={hubRef}
-            curvature={50}
-          />
-          <AnimatedBeam
-            containerRef={containerRef}
-            fromRef={bRef}
-            toRef={hubRef}
-          />
-          <AnimatedBeam
-            containerRef={containerRef}
-            fromRef={cRef}
-            toRef={hubRef}
-            curvature={-50}
-          />
-        </div>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/animated-testimonials-result.tsx
+++ b/apps/docs/src/components/learn/animated-testimonials-result.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { AnimatedTestimonials } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive
@@ -24,6 +25,14 @@ const TESTIMONIALS = [
 ];
 
 export function AnimatedTestimonialsResult() {
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        <AnimatedTestimonials testimonials={TESTIMONIALS} />
+      </div>
+    );
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">

--- a/apps/docs/src/components/learn/animated-tooltip-result.tsx
+++ b/apps/docs/src/components/learn/animated-tooltip-result.tsx
@@ -3,6 +3,7 @@
 import { AnimatedTooltip } from "@godui/components";
 import { Bold, Italic, Link, Underline } from "lucide-react";
 import type { ComponentType } from "react";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 type Member = {
   name: string;
@@ -47,6 +48,52 @@ const TOOLS: { label: string; Icon: ComponentType<{ className?: string }> }[] =
  * screen at once.
  */
 export function AnimatedTooltipResult() {
+  const demo = (
+    <>
+      <div className="flex">
+        {TEAM.map((m) => (
+          <AnimatedTooltip
+            key={m.name}
+            className="-ml-3 first:ml-0"
+            content={
+              <span className="flex flex-col">
+                <span className="font-semibold">{m.name}</span>
+                <span className="text-background/70">{m.role}</span>
+              </span>
+            }
+          >
+            <span
+              className={`flex size-12 items-center justify-center rounded-full bg-gradient-to-br ${m.gradient} text-sm font-semibold text-white ring-2 ring-background`}
+            >
+              {m.initials}
+            </span>
+          </AnimatedTooltip>
+        ))}
+      </div>
+
+      <div className="flex items-center gap-1 rounded-xl border border-border bg-card p-1.5 shadow-sm">
+        {TOOLS.map(({ label, Icon }) => (
+          <AnimatedTooltip key={label} content={label} side="bottom">
+            <button
+              type="button"
+              aria-label={label}
+              className="flex size-9 items-center justify-center rounded-lg text-muted-foreground [transition:background_200ms_ease,color_200ms_ease] hover:bg-accent hover:text-foreground"
+            >
+              <Icon className="size-4" />
+            </button>
+          </AnimatedTooltip>
+        ))}
+      </div>
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[300px] w-full flex-col items-center justify-center gap-12 p-6">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -58,40 +105,7 @@ export function AnimatedTooltipResult() {
         </span>
       </div>
       <div className="flex min-h-[300px] w-full flex-col items-center justify-center gap-12 p-10">
-        <div className="flex">
-          {TEAM.map((m) => (
-            <AnimatedTooltip
-              key={m.name}
-              className="-ml-3 first:ml-0"
-              content={
-                <span className="flex flex-col">
-                  <span className="font-semibold">{m.name}</span>
-                  <span className="text-background/70">{m.role}</span>
-                </span>
-              }
-            >
-              <span
-                className={`flex size-12 items-center justify-center rounded-full bg-gradient-to-br ${m.gradient} text-sm font-semibold text-white ring-2 ring-background`}
-              >
-                {m.initials}
-              </span>
-            </AnimatedTooltip>
-          ))}
-        </div>
-
-        <div className="flex items-center gap-1 rounded-xl border border-border bg-card p-1.5 shadow-sm">
-          {TOOLS.map(({ label, Icon }) => (
-            <AnimatedTooltip key={label} content={label} side="bottom">
-              <button
-                type="button"
-                aria-label={label}
-                className="flex size-9 items-center justify-center rounded-lg text-muted-foreground [transition:background_200ms_ease,color_200ms_ease] hover:bg-accent hover:text-foreground"
-              >
-                <Icon className="size-4" />
-              </button>
-            </AnimatedTooltip>
-          ))}
-        </div>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/app-showcase-result.tsx
+++ b/apps/docs/src/components/learn/app-showcase-result.tsx
@@ -1,6 +1,17 @@
 "use client";
 
 import { AppShowcase } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
+
+const demo = (
+  <AppShowcase
+    device="iphone"
+    mode="loop"
+    width={220}
+    src="https://picsum.photos/seed/godui-learn-app/600/1300"
+    alt="App home screen"
+  />
+);
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive
@@ -8,6 +19,14 @@ import { AppShowcase } from "@godui/components";
  * the phone is in view, no scroll-linked JS required.
  */
 export function AppShowcaseResult() {
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        {demo}
+      </div>
+    );
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -19,13 +38,7 @@ export function AppShowcaseResult() {
         </span>
       </div>
       <div className="flex min-h-[320px] items-center justify-center p-10">
-        <AppShowcase
-          device="iphone"
-          mode="loop"
-          width={220}
-          src="https://picsum.photos/seed/godui-learn-app/600/1300"
-          alt="App home screen"
-        />
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/aurora-text-result.tsx
+++ b/apps/docs/src/components/learn/aurora-text-result.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { AuroraText } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real AuroraText so the
@@ -8,6 +9,21 @@ import { AuroraText } from "@godui/components";
  * the idle pause the article just explained.
  */
 export function AuroraTextResult() {
+  const demo = (
+    <>
+      <h2 className="text-center font-bold text-4xl tracking-tight md:text-5xl">
+        Ship <AuroraText>beautiful</AuroraText> UI
+      </h2>
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[240px] flex-wrap items-center justify-center gap-6 p-6 w-full">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -19,9 +35,7 @@ export function AuroraTextResult() {
         </span>
       </div>
       <div className="flex min-h-[240px] flex-wrap items-center justify-center gap-6 p-10">
-        <h2 className="text-center font-bold text-4xl tracking-tight md:text-5xl">
-          Ship <AuroraText>beautiful</AuroraText> UI
-        </h2>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/avatar-group-result.tsx
+++ b/apps/docs/src/components/learn/avatar-group-result.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { AvatarGroup } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive
@@ -17,6 +18,14 @@ const PEOPLE = [
 ];
 
 export function AvatarGroupResult() {
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        <AvatarGroup avatars={PEOPLE} max={4} />
+      </div>
+    );
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">

--- a/apps/docs/src/components/learn/bare-scene-context.tsx
+++ b/apps/docs/src/components/learn/bare-scene-context.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { createContext, type ReactNode, useContext } from "react";
+import type { SceneAnim } from "@/components/learn/scroll-scene";
+
+/**
+ * When a Learn scene is rendered on the `LearnPlayer` stage (rather than the
+ * classic scroll layout), the player owns the card chrome and the play lifecycle.
+ * This context signals that: any `<ScrollScene>` (or a `*-result` card) inside it
+ * renders its body ONLY — no border, bar, replay or IntersectionObserver — and
+ * reads `cycle` / `reduced` from here. Absent (null) = classic standalone card.
+ */
+export type BareScene = SceneAnim;
+
+const BareSceneContext = createContext<BareScene | null>(null);
+
+export function BareSceneProvider({
+  value,
+  children,
+}: {
+  value: BareScene;
+  children: ReactNode;
+}) {
+  return (
+    <BareSceneContext.Provider value={value}>
+      {children}
+    </BareSceneContext.Provider>
+  );
+}
+
+/** Returns the player's scene state when rendered on the stage, else null. */
+export function useBareScene(): BareScene | null {
+  return useContext(BareSceneContext);
+}

--- a/apps/docs/src/components/learn/beam-draw-result.tsx
+++ b/apps/docs/src/components/learn/beam-draw-result.tsx
@@ -1,12 +1,51 @@
 "use client";
 
 import { BeamDraw } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
+
+/**
+ * The real, interactive BeamDraw demo — no card chrome. Extra bottom travel so
+ * scrollYProgress can pass 0.8 and finish the draw — BeamDraw maps
+ * [0.1, 0.8] → pathLength and needs runway past the SVG.
+ */
+function BeamDrawResultBody() {
+  return (
+    <div className="flex flex-col items-center px-6 pt-10 pb-[70vh] md:px-10 md:pt-14">
+      <div className="relative aspect-[5/2] w-full max-w-lg overflow-hidden rounded-2xl border border-fd-border bg-[var(--card)]">
+        <BeamDraw
+          preserveAspectRatio="none"
+          className="absolute inset-0 size-full"
+        />
+        <div className="absolute top-1/2 left-3 flex size-9 -translate-y-1/2 items-center justify-center rounded-xl border border-border bg-background shadow-sm">
+          <span className="size-2 rounded-full bg-primary shadow-[0_0_10px_var(--primary)]" />
+        </div>
+        {[10, 37.5, 62.5, 90].map((top) => (
+          <div
+            key={top}
+            className="absolute right-3 flex h-7 w-14 -translate-y-1/2 items-center justify-center rounded-lg border border-border bg-background shadow-sm"
+            style={{ top: `${top}%` }}
+          >
+            <span className="h-1.5 w-6 rounded-full bg-foreground/25" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
 
 /**
  * Live BeamDraw — scroll the docs page (or this tall preview) to watch the
  * default four-path fan stroke in via spring-smoothed pathLength.
  */
 export function BeamDrawResult() {
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        <BeamDrawResultBody />
+      </div>
+    );
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -17,28 +56,7 @@ export function BeamDrawResult() {
           the real component — scroll to draw
         </span>
       </div>
-      {/* Extra bottom travel so scrollYProgress can pass 0.8 and finish the draw —
-          BeamDraw maps [0.1, 0.8] → pathLength and needs runway past the SVG. */}
-      <div className="flex flex-col items-center px-6 pt-10 pb-[70vh] md:px-10 md:pt-14">
-        <div className="relative aspect-[5/2] w-full max-w-lg overflow-hidden rounded-2xl border border-fd-border bg-[var(--card)]">
-          <BeamDraw
-            preserveAspectRatio="none"
-            className="absolute inset-0 size-full"
-          />
-          <div className="absolute top-1/2 left-3 flex size-9 -translate-y-1/2 items-center justify-center rounded-xl border border-border bg-background shadow-sm">
-            <span className="size-2 rounded-full bg-primary shadow-[0_0_10px_var(--primary)]" />
-          </div>
-          {[10, 37.5, 62.5, 90].map((top) => (
-            <div
-              key={top}
-              className="absolute right-3 flex h-7 w-14 -translate-y-1/2 items-center justify-center rounded-lg border border-border bg-background shadow-sm"
-              style={{ top: `${top}%` }}
-            >
-              <span className="h-1.5 w-6 rounded-full bg-foreground/25" />
-            </div>
-          ))}
-        </div>
-      </div>
+      <BeamDrawResultBody />
     </div>
   );
 }

--- a/apps/docs/src/components/learn/bento-grid-result.tsx
+++ b/apps/docs/src/components/learn/bento-grid-result.tsx
@@ -2,16 +2,74 @@
 
 import { BentoCard, BentoGrid } from "@godui/components";
 import { Activity, Globe2, ShieldCheck, Sparkles } from "lucide-react";
+import { useBareScene } from "@/components/learn/bare-scene-context";
+
+const iconWrap =
+  "inline-flex size-10 items-center justify-center rounded-lg bg-primary/10 text-primary";
+
+/**
+ * The real, interactive `BentoGrid` — no card chrome. Rendered on the shared
+ * `LearnPlayer` stage as the final chapter.
+ */
+export function BentoGridResultBody() {
+  return (
+    <BentoGrid className="max-w-3xl">
+      <BentoCard
+        colSpan={2}
+        icon={
+          <span className={iconWrap}>
+            <Sparkles className="size-5" />
+          </span>
+        }
+        title="Interfaces that feel alive"
+        description="Spring-driven motion and pixel-tuned details, ready to drop in."
+      />
+      <BentoCard
+        rowSpan={2}
+        icon={
+          <span className={iconWrap}>
+            <Activity className="size-5" />
+          </span>
+        }
+        title="Realtime analytics"
+        description="Every interaction streamed and charted as it happens."
+      />
+      <BentoCard
+        icon={
+          <span className={iconWrap}>
+            <ShieldCheck className="size-5" />
+          </span>
+        }
+        title="Enterprise-grade"
+        description="SOC 2 Type II, SSO, and audit logs out of the box."
+      />
+      <BentoCard
+        icon={
+          <span className={iconWrap}>
+            <Globe2 className="size-5" />
+          </span>
+        }
+        title="120ms p95 globally"
+        description="Served from 35 edge regions, close to every user."
+      />
+    </BentoGrid>
+  );
+}
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive
  * `BentoGrid`. Scroll it into view to see the stagger, then hover a card for
  * the lift + spotlight.
  */
-const iconWrap =
-  "inline-flex size-10 items-center justify-center rounded-lg bg-primary/10 text-primary";
-
 export function BentoGridResult() {
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        <BentoGridResultBody />
+      </div>
+    );
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -23,46 +81,7 @@ export function BentoGridResult() {
         </span>
       </div>
       <div className="flex min-h-[320px] items-center justify-center p-8">
-        <BentoGrid className="max-w-3xl">
-          <BentoCard
-            colSpan={2}
-            icon={
-              <span className={iconWrap}>
-                <Sparkles className="size-5" />
-              </span>
-            }
-            title="Interfaces that feel alive"
-            description="Spring-driven motion and pixel-tuned details, ready to drop in."
-          />
-          <BentoCard
-            rowSpan={2}
-            icon={
-              <span className={iconWrap}>
-                <Activity className="size-5" />
-              </span>
-            }
-            title="Realtime analytics"
-            description="Every interaction streamed and charted as it happens."
-          />
-          <BentoCard
-            icon={
-              <span className={iconWrap}>
-                <ShieldCheck className="size-5" />
-              </span>
-            }
-            title="Enterprise-grade"
-            description="SOC 2 Type II, SSO, and audit logs out of the box."
-          />
-          <BentoCard
-            icon={
-              <span className={iconWrap}>
-                <Globe2 className="size-5" />
-              </span>
-            }
-            title="120ms p95 globally"
-            description="Served from 35 edge regions, close to every user."
-          />
-        </BentoGrid>
+        <BentoGridResultBody />
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/blueprint-grid-result.tsx
+++ b/apps/docs/src/components/learn/blueprint-grid-result.tsx
@@ -1,8 +1,33 @@
 "use client";
 
 import { BlueprintGrid } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 export function BlueprintGridResult() {
+  const demo = (
+    <div className="relative w-full min-h-[300px] overflow-hidden md:min-h-[360px]">
+      <BlueprintGrid
+        variant="lines"
+        cellSize={32}
+        sweep
+        spotlight
+        sweepDuration={8}
+      />
+      <div className="pointer-events-none relative z-raised flex min-h-[300px] items-center justify-center md:min-h-[360px]">
+        <div className="h-2.5 w-28 rounded-full bg-[var(--foreground)]/25" />
+      </div>
+    </div>
+  );
+
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -13,18 +38,7 @@ export function BlueprintGridResult() {
           the real component — move for spotlight
         </span>
       </div>
-      <div className="relative min-h-[300px] overflow-hidden md:min-h-[360px]">
-        <BlueprintGrid
-          variant="lines"
-          cellSize={32}
-          sweep
-          spotlight
-          sweepDuration={8}
-        />
-        <div className="pointer-events-none relative z-raised flex min-h-[300px] items-center justify-center md:min-h-[360px]">
-          <div className="h-2.5 w-28 rounded-full bg-[var(--foreground)]/25" />
-        </div>
-      </div>
+      {demo}
     </div>
   );
 }

--- a/apps/docs/src/components/learn/border-beam-result.tsx
+++ b/apps/docs/src/components/learn/border-beam-result.tsx
@@ -1,12 +1,36 @@
 "use client";
 
 import { BorderBeam } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
+
+/**
+ * The live BorderBeam demo — a quiet card with a rainbow loop, no result
+ * chrome. Reused on the shared `LearnPlayer` stage as the final chapter.
+ */
+export function BorderBeamResultBody() {
+  return (
+    <div className="relative flex w-full max-w-[320px] flex-col gap-2 overflow-hidden rounded-xl border border-border bg-card p-6 text-card-foreground shadow-sm">
+      <div className="h-2 w-28 rounded-full bg-foreground/25" />
+      <div className="h-1.5 w-full max-w-[200px] rounded-full bg-muted-foreground/25" />
+      <div className="h-1.5 w-full max-w-[160px] rounded-full bg-muted-foreground/20" />
+      <BorderBeam duration={8} size={70} />
+    </div>
+  );
+}
 
 /**
  * Live BorderBeam on a quiet card — rainbow loop, optional glow off so the
  * mask + offsetPath read cleanly.
  */
 export function BorderBeamResult() {
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        <BorderBeamResultBody />
+      </div>
+    );
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -18,12 +42,7 @@ export function BorderBeamResult() {
         </span>
       </div>
       <div className="flex min-h-[260px] items-center justify-center p-8 md:p-12">
-        <div className="relative flex w-full max-w-[320px] flex-col gap-2 overflow-hidden rounded-xl border border-border bg-card p-6 text-card-foreground shadow-sm">
-          <div className="h-2 w-28 rounded-full bg-foreground/25" />
-          <div className="h-1.5 w-full max-w-[200px] rounded-full bg-muted-foreground/25" />
-          <div className="h-1.5 w-full max-w-[160px] rounded-full bg-muted-foreground/20" />
-          <BorderBeam duration={8} size={70} />
-        </div>
+        <BorderBeamResultBody />
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/breadcrumbs-result.tsx
+++ b/apps/docs/src/components/learn/breadcrumbs-result.tsx
@@ -3,6 +3,7 @@
 import { Breadcrumbs } from "@godui/components";
 import { Folder, FolderOpen, Home, Layers } from "lucide-react";
 import { useState } from "react";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive
@@ -11,6 +12,61 @@ import { useState } from "react";
  */
 export function BreadcrumbsResult() {
   const [path, setPath] = useState("billing");
+
+  const demo = (
+    <>
+      <div className="flex w-full max-w-md flex-col items-center gap-2">
+        <Breadcrumbs
+          items={[
+            {
+              label: "Home",
+              href: "home",
+              icon: <Home className="size-3.5" />,
+            },
+            {
+              label: "Workspace",
+              href: "workspace",
+              icon: <Layers className="size-3.5" />,
+            },
+            {
+              label: "Settings",
+              href: "settings",
+              icon: <Folder className="size-3.5" />,
+            },
+            { label: "Billing", icon: <FolderOpen className="size-3.5" /> },
+          ]}
+          onNavigate={setPath}
+        />
+        <p className="text-muted-foreground text-xs">
+          Viewing <span className="text-foreground">/{path}</span>
+        </p>
+      </div>
+
+      <div className="flex w-full max-w-md flex-col items-center gap-2 border-fd-border border-t pt-8">
+        <Breadcrumbs
+          maxItems={3}
+          items={[
+            { label: "Home", href: "#" },
+            { label: "Engineering", href: "#" },
+            { label: "Platform", href: "#" },
+            { label: "Services", href: "#" },
+            { label: "Auth", href: "#" },
+            { label: "Tokens" },
+          ]}
+        />
+        <p className="font-mono text-muted-foreground text-xs">
+          maxItems={"{3}"}
+        </p>
+      </div>
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[260px] flex-col items-center justify-center gap-8 p-6 w-full">
+        {demo}
+      </div>
+    );
 
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
@@ -23,49 +79,7 @@ export function BreadcrumbsResult() {
         </span>
       </div>
       <div className="flex min-h-[260px] flex-col items-center justify-center gap-8 p-10">
-        <div className="flex w-full max-w-md flex-col items-center gap-2">
-          <Breadcrumbs
-            items={[
-              {
-                label: "Home",
-                href: "home",
-                icon: <Home className="size-3.5" />,
-              },
-              {
-                label: "Workspace",
-                href: "workspace",
-                icon: <Layers className="size-3.5" />,
-              },
-              {
-                label: "Settings",
-                href: "settings",
-                icon: <Folder className="size-3.5" />,
-              },
-              { label: "Billing", icon: <FolderOpen className="size-3.5" /> },
-            ]}
-            onNavigate={setPath}
-          />
-          <p className="text-muted-foreground text-xs">
-            Viewing <span className="text-foreground">/{path}</span>
-          </p>
-        </div>
-
-        <div className="flex w-full max-w-md flex-col items-center gap-2 border-fd-border border-t pt-8">
-          <Breadcrumbs
-            maxItems={3}
-            items={[
-              { label: "Home", href: "#" },
-              { label: "Engineering", href: "#" },
-              { label: "Platform", href: "#" },
-              { label: "Services", href: "#" },
-              { label: "Auth", href: "#" },
-              { label: "Tokens" },
-            ]}
-          />
-          <p className="font-mono text-muted-foreground text-xs">
-            maxItems={"{3}"}
-          </p>
-        </div>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/card-swap-result.tsx
+++ b/apps/docs/src/components/learn/card-swap-result.tsx
@@ -2,6 +2,7 @@
 
 import { CardSwap } from "@godui/components";
 import { Activity, Globe, ScrollText, Zap } from "lucide-react";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive
@@ -31,7 +32,40 @@ const FEATURES = [
   },
 ];
 
+function CardSwapResultBody() {
+  return (
+    <CardSwap className="h-72 w-80">
+      {FEATURES.map(({ icon: Icon, ...f }) => (
+        <div
+          key={f.title}
+          className="flex h-full w-full flex-col justify-between rounded-2xl border border-border bg-card p-7 shadow-[0_24px_60px_-24px_rgba(0,0,0,0.5)]"
+        >
+          <span className="grid size-11 place-items-center rounded-xl bg-primary/10 text-primary ring-1 ring-primary/15 ring-inset">
+            <Icon className="size-5" strokeWidth={2} />
+          </span>
+          <div>
+            <h3 className="text-xl font-semibold tracking-tight text-foreground">
+              {f.title}
+            </h3>
+            <p className="mt-2 text-[15px] leading-relaxed text-muted-foreground">
+              {f.body}
+            </p>
+          </div>
+        </div>
+      ))}
+    </CardSwap>
+  );
+}
+
 export function CardSwapResult() {
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        <CardSwapResultBody />
+      </div>
+    );
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -43,26 +77,7 @@ export function CardSwapResult() {
         </span>
       </div>
       <div className="flex min-h-[340px] items-center justify-center p-10">
-        <CardSwap className="h-72 w-80">
-          {FEATURES.map(({ icon: Icon, ...f }) => (
-            <div
-              key={f.title}
-              className="flex h-full w-full flex-col justify-between rounded-2xl border border-border bg-card p-7 shadow-[0_24px_60px_-24px_rgba(0,0,0,0.5)]"
-            >
-              <span className="grid size-11 place-items-center rounded-xl bg-primary/10 text-primary ring-1 ring-primary/15 ring-inset">
-                <Icon className="size-5" strokeWidth={2} />
-              </span>
-              <div>
-                <h3 className="text-xl font-semibold tracking-tight text-foreground">
-                  {f.title}
-                </h3>
-                <p className="mt-2 text-[15px] leading-relaxed text-muted-foreground">
-                  {f.body}
-                </p>
-              </div>
-            </div>
-          ))}
-        </CardSwap>
+        <CardSwapResultBody />
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/combobox-result.tsx
+++ b/apps/docs/src/components/learn/combobox-result.tsx
@@ -2,6 +2,7 @@
 
 import { Combobox, type ComboboxOption } from "@godui/components";
 import { useState } from "react";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 const PEOPLE: ComboboxOption[] = [
   {
@@ -55,6 +56,37 @@ export function ComboboxResult() {
   const [value, setValue] = useState("");
   const selected = PEOPLE.find((p) => p.value === value);
 
+  const demo = (
+    <>
+      <div className="flex w-full max-w-sm flex-col gap-3">
+        <span className="font-medium text-foreground text-sm">Assignee</span>
+        <Combobox
+          options={PEOPLE}
+          value={value}
+          onChange={setValue}
+          placeholder="Assign to…"
+        />
+        <p className="text-muted-foreground text-xs">
+          {selected ? (
+            <>
+              Assigned to{" "}
+              <span className="text-foreground">{selected.label}</span>
+            </>
+          ) : (
+            "Search teammates by name"
+          )}
+        </p>
+      </div>
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[420px] w-full flex-col items-center gap-4 p-6">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -66,25 +98,7 @@ export function ComboboxResult() {
         </span>
       </div>
       <div className="flex min-h-[420px] w-full flex-col items-center gap-4 p-10">
-        <div className="flex w-full max-w-sm flex-col gap-3">
-          <span className="font-medium text-foreground text-sm">Assignee</span>
-          <Combobox
-            options={PEOPLE}
-            value={value}
-            onChange={setValue}
-            placeholder="Assign to…"
-          />
-          <p className="text-muted-foreground text-xs">
-            {selected ? (
-              <>
-                Assigned to{" "}
-                <span className="text-foreground">{selected.label}</span>
-              </>
-            ) : (
-              "Search teammates by name"
-            )}
-          </p>
-        </div>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/command-palette-result.tsx
+++ b/apps/docs/src/components/learn/command-palette-result.tsx
@@ -2,6 +2,7 @@
 
 import { type CommandGroup, CommandPalette } from "@godui/components";
 import { useState } from "react";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive
@@ -62,6 +63,45 @@ export function CommandPaletteResult() {
     },
   ];
 
+  const demo = (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="inline-flex items-center gap-2 rounded-lg border border-border bg-card px-4 py-2 text-sm font-medium text-foreground shadow-sm"
+      >
+        Open command palette
+        <kbd className="rounded border border-border px-1.5 py-0.5 text-muted-foreground text-xs">
+          ⌘K
+        </kbd>
+      </button>
+      <p className="text-muted-foreground text-xs">
+        {last ? (
+          <>
+            Selected: <span className="text-foreground">{last}</span>
+          </>
+        ) : (
+          "Open the palette and run a command"
+        )}
+      </p>
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <>
+        <div className="flex min-h-[300px] flex-col items-center justify-center gap-4 p-6 w-full">
+          {demo}
+        </div>
+        <CommandPalette
+          open={open}
+          onOpenChange={setOpen}
+          groups={groups}
+          enableShortcut
+        />
+      </>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -73,25 +113,7 @@ export function CommandPaletteResult() {
         </span>
       </div>
       <div className="flex min-h-[300px] flex-col items-center justify-center gap-4 p-10">
-        <button
-          type="button"
-          onClick={() => setOpen(true)}
-          className="inline-flex items-center gap-2 rounded-lg border border-border bg-card px-4 py-2 text-sm font-medium text-foreground shadow-sm"
-        >
-          Open command palette
-          <kbd className="rounded border border-border px-1.5 py-0.5 text-muted-foreground text-xs">
-            ⌘K
-          </kbd>
-        </button>
-        <p className="text-muted-foreground text-xs">
-          {last ? (
-            <>
-              Selected: <span className="text-foreground">{last}</span>
-            </>
-          ) : (
-            "Open the palette and run a command"
-          )}
-        </p>
+        {demo}
       </div>
       <CommandPalette
         open={open}

--- a/apps/docs/src/components/learn/comment-pin-result.tsx
+++ b/apps/docs/src/components/learn/comment-pin-result.tsx
@@ -2,6 +2,7 @@
 
 import { type Comment, CommentPin } from "@godui/components";
 import { useState } from "react";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — two real `CommentPin`s over a
@@ -47,8 +48,39 @@ const PINS: Pin[] = [
   },
 ];
 
-export function CommentPinResult() {
+/**
+ * The real, interactive canvas — two `CommentPin`s over a mock surface, no card
+ * chrome. Reused by both the standalone card and the bare `LearnPlayer` stage.
+ */
+function CommentPinResultBody() {
   const [openId, setOpenId] = useState<string | null>("p1");
+
+  return (
+    <div className="relative h-full w-full overflow-hidden rounded-xl bg-[var(--muted)]/40">
+      {PINS.map((pin) => (
+        <CommentPin
+          key={pin.id}
+          x={pin.x}
+          y={pin.y}
+          resolved={pin.resolved}
+          comments={pin.comments}
+          open={openId === pin.id}
+          onOpenChange={(open) => setOpenId(open ? pin.id : null)}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function CommentPinResult() {
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // canvas only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex h-[280px] w-full items-center justify-center p-6">
+        <CommentPinResultBody />
+      </div>
+    );
 
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
@@ -61,19 +93,7 @@ export function CommentPinResult() {
         </span>
       </div>
       <div className="relative h-[280px] p-6">
-        <div className="relative h-full w-full overflow-hidden rounded-xl bg-[var(--muted)]/40">
-          {PINS.map((pin) => (
-            <CommentPin
-              key={pin.id}
-              x={pin.x}
-              y={pin.y}
-              resolved={pin.resolved}
-              comments={pin.comments}
-              open={openId === pin.id}
-              onOpenChange={(open) => setOpenId(open ? pin.id : null)}
-            />
-          ))}
-        </div>
+        <CommentPinResultBody />
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/confetti-result.tsx
+++ b/apps/docs/src/components/learn/confetti-result.tsx
@@ -1,12 +1,30 @@
 "use client";
 
 import { ConfettiButton } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
+
+const Demo = () => (
+  <ConfettiButton
+    className="rounded-lg bg-primary px-5 py-2.5 font-semibold text-primary-foreground text-sm shadow-sm [transition:background_200ms_ease] hover:bg-primary/90 active:scale-[0.98]"
+    options={{ particleCount: 140, spread: 90, startVelocity: 46 }}
+  >
+    Celebrate
+  </ConfettiButton>
+);
 
 /**
  * Live ConfettiButton — click fires from the button's normalized viewport
  * origin with the DEFAULTS merge (spread 70, particleCount 120, …).
  */
 export function ConfettiResult() {
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        <Demo />
+      </div>
+    );
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -18,12 +36,7 @@ export function ConfettiResult() {
         </span>
       </div>
       <div className="flex min-h-[240px] items-center justify-center p-10">
-        <ConfettiButton
-          className="rounded-lg bg-primary px-5 py-2.5 font-semibold text-primary-foreground text-sm shadow-sm [transition:background_200ms_ease] hover:bg-primary/90 active:scale-[0.98]"
-          options={{ particleCount: 140, spread: 90, startVelocity: 46 }}
-        >
-          Celebrate
-        </ConfettiButton>
+        <Demo />
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/container-scroll-result.tsx
+++ b/apps/docs/src/components/learn/container-scroll-result.tsx
@@ -1,6 +1,24 @@
 "use client";
 
 import { ContainerScroll } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
+
+const demo = (
+  <ContainerScroll
+    header={
+      <>
+        <h2 className="text-3xl font-bold text-foreground md:text-5xl">
+          Scroll to bring it to life
+        </h2>
+        <p className="mt-4 text-muted-foreground">
+          The frame un-tilts and settles as you scroll.
+        </p>
+      </>
+    }
+  >
+    <img src="https://picsum.photos/id/1005/1200/750" alt="Dashboard" />
+  </ContainerScroll>
+);
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive
@@ -9,6 +27,14 @@ import { ContainerScroll } from "@godui/components";
  * page through it to watch the frame settle.
  */
 export function ContainerScrollResult() {
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        {demo}
+      </div>
+    );
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -19,20 +45,7 @@ export function ContainerScrollResult() {
           the real component — scroll through it
         </span>
       </div>
-      <ContainerScroll
-        header={
-          <>
-            <h2 className="text-3xl font-bold text-foreground md:text-5xl">
-              Scroll to bring it to life
-            </h2>
-            <p className="mt-4 text-muted-foreground">
-              The frame un-tilts and settles as you scroll.
-            </p>
-          </>
-        }
-      >
-        <img src="https://picsum.photos/id/1005/1200/750" alt="Dashboard" />
-      </ContainerScroll>
+      {demo}
     </div>
   );
 }

--- a/apps/docs/src/components/learn/context-menu-result.tsx
+++ b/apps/docs/src/components/learn/context-menu-result.tsx
@@ -3,6 +3,7 @@
 import { ContextMenu, type ContextMenuItem } from "@godui/components";
 import { Copy, Download, FileText, Pencil, Share2, Trash2 } from "lucide-react";
 import { useState } from "react";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive Context
@@ -54,6 +55,33 @@ export function ContextMenuResult() {
     },
   ];
 
+  const demo = (
+    <>
+      <ContextMenu items={items}>
+        <div className="flex w-full max-w-md select-none flex-col items-center gap-4 rounded-xl border border-border border-dashed bg-card px-6 py-10 text-center shadow-sm">
+          <div className="flex h-14 w-14 items-center justify-center rounded-xl bg-primary/10 text-primary">
+            <FileText className="size-7" />
+          </div>
+          <div>
+            <div className="font-medium text-foreground text-sm">
+              quarterly-report.pdf
+            </div>
+            <div className="mt-0.5 text-muted-foreground text-xs">
+              Right-click for actions{last ? ` · ${last}` : ""}
+            </div>
+          </div>
+        </div>
+      </ContextMenu>
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[240px] flex-col items-center justify-center gap-6 p-6 w-full">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -65,21 +93,7 @@ export function ContextMenuResult() {
         </span>
       </div>
       <div className="flex min-h-[240px] flex-col items-center justify-center gap-6 p-10">
-        <ContextMenu items={items}>
-          <div className="flex w-full max-w-md select-none flex-col items-center gap-4 rounded-xl border border-border border-dashed bg-card px-6 py-10 text-center shadow-sm">
-            <div className="flex h-14 w-14 items-center justify-center rounded-xl bg-primary/10 text-primary">
-              <FileText className="size-7" />
-            </div>
-            <div>
-              <div className="font-medium text-foreground text-sm">
-                quarterly-report.pdf
-              </div>
-              <div className="mt-0.5 text-muted-foreground text-xs">
-                Right-click for actions{last ? ` · ${last}` : ""}
-              </div>
-            </div>
-          </div>
-        </ContextMenu>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/conversation-thread-result.tsx
+++ b/apps/docs/src/components/learn/conversation-thread-result.tsx
@@ -8,6 +8,7 @@ import {
 } from "@godui/components";
 import { Copy, RotateCcw, ThumbsUp } from "lucide-react";
 import * as React from "react";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real `ConversationThread`
@@ -27,6 +28,40 @@ const ACTIONS = [
 export function ConversationThreadResult() {
   const [run, setRun] = React.useState(0);
   const [streaming, setStreaming] = React.useState(true);
+
+  const demo = (
+    <div
+      key={run}
+      className="mx-auto flex h-[320px] w-full max-w-md flex-col overflow-hidden rounded-xl border border-border bg-background"
+    >
+      <ConversationThread className="flex-1">
+        <ConversationMessage role="user" name="You">
+          How do I center a div in 2026?
+        </ConversationMessage>
+        <ConversationMessage
+          role="assistant"
+          name="GodUI"
+          actions={ACTIONS}
+          streaming={streaming}
+        >
+          {streaming ? (
+            <StreamingText text={ANSWER} onDone={() => setStreaming(false)} />
+          ) : (
+            ANSWER
+          )}
+        </ConversationMessage>
+      </ConversationThread>
+    </div>
+  );
+
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        {demo}
+      </div>
+    );
 
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
@@ -65,31 +100,7 @@ export function ConversationThreadResult() {
         </button>
       </div>
       <div className="flex min-h-[360px] items-center justify-center p-4 md:p-6">
-        <div
-          key={run}
-          className="mx-auto flex h-[320px] w-full max-w-md flex-col overflow-hidden rounded-xl border border-border bg-background"
-        >
-          <ConversationThread className="flex-1">
-            <ConversationMessage role="user" name="You">
-              How do I center a div in 2026?
-            </ConversationMessage>
-            <ConversationMessage
-              role="assistant"
-              name="GodUI"
-              actions={ACTIONS}
-              streaming={streaming}
-            >
-              {streaming ? (
-                <StreamingText
-                  text={ANSWER}
-                  onDone={() => setStreaming(false)}
-                />
-              ) : (
-                ANSWER
-              )}
-            </ConversationMessage>
-          </ConversationThread>
-        </div>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/cover-flow-result.tsx
+++ b/apps/docs/src/components/learn/cover-flow-result.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { CoverFlow } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive Cover
@@ -32,6 +33,23 @@ function Cover({ title, artist, img }: (typeof COVERS)[number]) {
 }
 
 export function CoverFlowResult() {
+  const demo = (
+    <CoverFlow defaultIndex={2} itemWidth={220} itemHeight={220}>
+      {COVERS.map((c) => (
+        <Cover key={c.title} {...c} />
+      ))}
+    </CoverFlow>
+  );
+
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[360px] w-full items-center justify-center p-6">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -43,11 +61,7 @@ export function CoverFlowResult() {
         </span>
       </div>
       <div className="relative flex min-h-[360px] items-center justify-center p-6 md:min-h-[420px] md:p-10">
-        <CoverFlow defaultIndex={2} itemWidth={220} itemHeight={220}>
-          {COVERS.map((c) => (
-            <Cover key={c.title} {...c} />
-          ))}
-        </CoverFlow>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/dock-result.tsx
+++ b/apps/docs/src/components/learn/dock-result.tsx
@@ -3,6 +3,7 @@
 import { Dock, DockItem } from "@godui/components";
 import { Calendar, Folder, Home, Mail, Search, Settings } from "lucide-react";
 import type { ComponentType } from "react";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive Dock. Sweep
@@ -25,6 +26,28 @@ const ITEMS: Item[] = [
 ];
 
 export function DockResult() {
+  const demo = (
+    <>
+      <div className="absolute inset-0 bg-[linear-gradient(135deg,oklch(0.55_0.18_265),oklch(0.62_0.16_320)_45%,oklch(0.7_0.12_25))] opacity-90" />
+      <div className="relative">
+        <Dock>
+          {ITEMS.map(({ label, color, Icon }) => (
+            <DockItem key={label} label={label}>
+              <Icon className={`size-1/2 ${color}`} strokeWidth={2} />
+            </DockItem>
+          ))}
+        </Dock>
+      </div>
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="relative flex min-h-[260px] items-end justify-center overflow-hidden p-6 w-full">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -36,16 +59,7 @@ export function DockResult() {
         </span>
       </div>
       <div className="relative flex min-h-[260px] items-end justify-center overflow-hidden p-10">
-        <div className="absolute inset-0 bg-[linear-gradient(135deg,oklch(0.55_0.18_265),oklch(0.62_0.16_320)_45%,oklch(0.7_0.12_25))] opacity-90" />
-        <div className="relative">
-          <Dock>
-            {ITEMS.map(({ label, color, Icon }) => (
-              <DockItem key={label} label={label}>
-                <Icon className={`size-1/2 ${color}`} strokeWidth={2} />
-              </DockItem>
-            ))}
-          </Dock>
-        </div>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/drawer-result.tsx
+++ b/apps/docs/src/components/learn/drawer-result.tsx
@@ -3,6 +3,7 @@
 import { Drawer } from "@godui/components";
 import { Link2, ShoppingBag } from "lucide-react";
 import { useState } from "react";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive Drawer,
@@ -13,6 +14,82 @@ import { useState } from "react";
 export function DrawerResult() {
   const [cartOpen, setCartOpen] = useState(false);
   const [shareOpen, setShareOpen] = useState(false);
+
+  const demo = (
+    <>
+      <button
+        type="button"
+        onClick={() => setCartOpen(true)}
+        className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground"
+      >
+        <ShoppingBag className="size-4" strokeWidth={2} />
+        Open cart
+      </button>
+      <button
+        type="button"
+        onClick={() => setShareOpen(true)}
+        className="inline-flex items-center gap-2 rounded-lg border border-border bg-card px-4 py-2 text-sm font-medium text-foreground shadow-sm"
+      >
+        <Link2 className="size-4" strokeWidth={2} />
+        Share
+      </button>
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <>
+        <div className="flex min-h-[280px] flex-wrap items-center justify-center gap-4 p-6 w-full">
+          {demo}
+        </div>
+        <Drawer
+          open={cartOpen}
+          onOpenChange={setCartOpen}
+          side="right"
+          title="Your cart"
+        >
+          <ul className="space-y-3">
+            <li className="flex justify-between text-sm">
+              <span className="text-foreground">Aurora Watch</span>
+              <span className="text-muted-foreground tabular-nums">$429</span>
+            </li>
+            <li className="flex justify-between text-sm">
+              <span className="text-foreground">Studio Headphones</span>
+              <span className="text-muted-foreground tabular-nums">$349</span>
+            </li>
+          </ul>
+          <button
+            type="button"
+            onClick={() => setCartOpen(false)}
+            className="mt-4 w-full rounded-lg bg-primary py-2.5 text-sm font-semibold text-primary-foreground"
+          >
+            Checkout · $778
+          </button>
+        </Drawer>
+        <Drawer
+          open={shareOpen}
+          onOpenChange={setShareOpen}
+          side="bottom"
+          title="Share"
+        >
+          <div className="flex items-center gap-2 rounded-lg border border-border bg-muted/40 p-1.5 pl-3">
+            <Link2
+              className="size-4 shrink-0 text-muted-foreground"
+              strokeWidth={2}
+            />
+            <span className="flex-1 truncate text-sm text-muted-foreground">
+              godui.design/p/aurora-x82k
+            </span>
+            <button
+              type="button"
+              className="rounded-md bg-primary px-2.5 py-1.5 text-primary-foreground text-xs font-medium"
+            >
+              Copy
+            </button>
+          </div>
+        </Drawer>
+      </>
+    );
 
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
@@ -25,24 +102,8 @@ export function DrawerResult() {
         </span>
       </div>
       <div className="flex min-h-[280px] flex-wrap items-center justify-center gap-4 p-10">
-        <button
-          type="button"
-          onClick={() => setCartOpen(true)}
-          className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground"
-        >
-          <ShoppingBag className="size-4" strokeWidth={2} />
-          Open cart
-        </button>
-        <button
-          type="button"
-          onClick={() => setShareOpen(true)}
-          className="inline-flex items-center gap-2 rounded-lg border border-border bg-card px-4 py-2 text-sm font-medium text-foreground shadow-sm"
-        >
-          <Link2 className="size-4" strokeWidth={2} />
-          Share
-        </button>
+        {demo}
       </div>
-
       <Drawer
         open={cartOpen}
         onOpenChange={setCartOpen}
@@ -67,7 +128,6 @@ export function DrawerResult() {
           Checkout · $778
         </button>
       </Drawer>
-
       <Drawer
         open={shareOpen}
         onOpenChange={setShareOpen}

--- a/apps/docs/src/components/learn/dropdown-menu-result.tsx
+++ b/apps/docs/src/components/learn/dropdown-menu-result.tsx
@@ -12,6 +12,7 @@ import {
   Users,
 } from "lucide-react";
 import { useState } from "react";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive
@@ -72,6 +73,40 @@ export function DropdownMenuResult() {
     },
   ];
 
+  const demo = (
+    <>
+      <DropdownMenu
+        align="end"
+        trigger={
+          <span className="inline-flex items-center gap-2 rounded-full border border-border bg-card py-1 pr-3 pl-1 font-medium text-foreground text-sm shadow-sm">
+            <span className="flex h-7 w-7 items-center justify-center rounded-full bg-primary font-semibold text-primary-foreground text-xs">
+              AL
+            </span>
+            Ada Lovelace
+            <ChevronDown className="size-4 text-muted-foreground" />
+          </span>
+        }
+        items={items}
+      />
+      <p className="text-muted-foreground text-xs">
+        {last ? (
+          <>
+            Selected: <span className="text-foreground">{last}</span>
+          </>
+        ) : (
+          "Open the menu and pick an action"
+        )}
+      </p>
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[460px] w-full flex-col items-center gap-4 p-6">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -83,28 +118,7 @@ export function DropdownMenuResult() {
         </span>
       </div>
       <div className="flex min-h-[460px] w-full flex-col items-center gap-4 p-10">
-        <DropdownMenu
-          align="end"
-          trigger={
-            <span className="inline-flex items-center gap-2 rounded-full border border-border bg-card py-1 pr-3 pl-1 font-medium text-foreground text-sm shadow-sm">
-              <span className="flex h-7 w-7 items-center justify-center rounded-full bg-primary font-semibold text-primary-foreground text-xs">
-                AL
-              </span>
-              Ada Lovelace
-              <ChevronDown className="size-4 text-muted-foreground" />
-            </span>
-          }
-          items={items}
-        />
-        <p className="text-muted-foreground text-xs">
-          {last ? (
-            <>
-              Selected: <span className="text-foreground">{last}</span>
-            </>
-          ) : (
-            "Open the menu and pick an action"
-          )}
-        </p>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/dynamic-island-result.tsx
+++ b/apps/docs/src/components/learn/dynamic-island-result.tsx
@@ -3,6 +3,7 @@
 import { DynamicIsland, type DynamicIslandSize } from "@godui/components";
 import { Music, Phone, Timer } from "lucide-react";
 import * as React from "react";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 const VIEWS: { key: DynamicIslandSize; label: string }[] = [
   { key: "compact", label: "Idle" },
@@ -19,6 +20,79 @@ const VIEWS: { key: DynamicIslandSize; label: string }[] = [
 export function DynamicIslandResult() {
   const [view, setView] = React.useState<DynamicIslandSize>("default");
 
+  const demo = (
+    <>
+      <div className="flex h-[220px] w-full items-start justify-center pt-2">
+        <DynamicIsland size={view} presenceKey={view}>
+          {view === "compact" ? (
+            <div className="size-2 rounded-full bg-white/70" />
+          ) : null}
+
+          {view === "default" ? (
+            <div className="flex w-full items-center justify-between gap-3 text-sm">
+              <span className="flex items-center gap-2">
+                <Phone className="size-4 text-green-400" />
+                Incoming
+              </span>
+              <span className="font-medium">Ada</span>
+            </div>
+          ) : null}
+
+          {view === "long" ? (
+            <div className="flex w-full items-center justify-between gap-3 text-sm">
+              <span className="flex items-center gap-2">
+                <Timer className="size-4 text-amber-400" />
+                Focus
+              </span>
+              <span className="font-mono tabular-nums">24:59</span>
+            </div>
+          ) : null}
+
+          {view === "large" ? (
+            <div className="flex w-full items-center gap-3">
+              <div className="flex size-12 items-center justify-center rounded-xl bg-white/10">
+                <Music className="size-6 text-white/80" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="truncate text-sm font-semibold">Midnight</div>
+                <div className="truncate text-xs text-white/60">
+                  The Sketches
+                </div>
+                <div className="mt-3 h-1 w-full overflow-hidden rounded-full bg-white/15">
+                  <div className="h-full w-2/3 rounded-full bg-white/80" />
+                </div>
+              </div>
+            </div>
+          ) : null}
+        </DynamicIsland>
+      </div>
+
+      <div className="flex flex-wrap justify-center gap-2">
+        {VIEWS.map((v) => (
+          <button
+            key={v.key}
+            type="button"
+            onClick={() => setView(v.key)}
+            className={`rounded-lg px-3 py-1.5 text-sm font-medium [transition:background_150ms_ease] ${
+              view === v.key
+                ? "bg-primary text-primary-foreground"
+                : "bg-accent text-accent-foreground hover:bg-accent/70"
+            }`}
+          >
+            {v.label}
+          </button>
+        ))}
+      </div>
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full flex-col items-center gap-8 p-6">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -30,67 +104,7 @@ export function DynamicIslandResult() {
         </span>
       </div>
       <div className="flex min-h-[280px] w-full flex-col items-center gap-8 p-10">
-        <div className="flex h-[220px] w-full items-start justify-center pt-2">
-          <DynamicIsland size={view} presenceKey={view}>
-            {view === "compact" ? (
-              <div className="size-2 rounded-full bg-white/70" />
-            ) : null}
-
-            {view === "default" ? (
-              <div className="flex w-full items-center justify-between gap-3 text-sm">
-                <span className="flex items-center gap-2">
-                  <Phone className="size-4 text-green-400" />
-                  Incoming
-                </span>
-                <span className="font-medium">Ada</span>
-              </div>
-            ) : null}
-
-            {view === "long" ? (
-              <div className="flex w-full items-center justify-between gap-3 text-sm">
-                <span className="flex items-center gap-2">
-                  <Timer className="size-4 text-amber-400" />
-                  Focus
-                </span>
-                <span className="font-mono tabular-nums">24:59</span>
-              </div>
-            ) : null}
-
-            {view === "large" ? (
-              <div className="flex w-full items-center gap-3">
-                <div className="flex size-12 items-center justify-center rounded-xl bg-white/10">
-                  <Music className="size-6 text-white/80" />
-                </div>
-                <div className="min-w-0 flex-1">
-                  <div className="truncate text-sm font-semibold">Midnight</div>
-                  <div className="truncate text-xs text-white/60">
-                    The Sketches
-                  </div>
-                  <div className="mt-3 h-1 w-full overflow-hidden rounded-full bg-white/15">
-                    <div className="h-full w-2/3 rounded-full bg-white/80" />
-                  </div>
-                </div>
-              </div>
-            ) : null}
-          </DynamicIsland>
-        </div>
-
-        <div className="flex flex-wrap justify-center gap-2">
-          {VIEWS.map((v) => (
-            <button
-              key={v.key}
-              type="button"
-              onClick={() => setView(v.key)}
-              className={`rounded-lg px-3 py-1.5 text-sm font-medium [transition:background_150ms_ease] ${
-                view === v.key
-                  ? "bg-primary text-primary-foreground"
-                  : "bg-accent text-accent-foreground hover:bg-accent/70"
-              }`}
-            >
-              {v.label}
-            </button>
-          ))}
-        </div>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/elastic-text-result.tsx
+++ b/apps/docs/src/components/learn/elastic-text-result.tsx
@@ -1,12 +1,34 @@
 "use client";
 
 import { ElasticText } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing panel — the real ElasticText so the reader feels the auto spotlight
  * sweep, the spring settle on each character, and the hover distance falloff.
  */
 export function ElasticTextResult() {
+  const demo = (
+    <>
+      <ElasticText className="text-4xl tracking-tight sm:text-5xl">
+        Design for Humans
+      </ElasticText>
+      <ElasticText
+        mode="hover"
+        className="text-2xl tracking-tight text-fd-muted-foreground sm:text-3xl"
+      >
+        Move Your Mouse
+      </ElasticText>
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[240px] flex-col items-center justify-center gap-10 p-6 w-full">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -18,15 +40,7 @@ export function ElasticTextResult() {
         </span>
       </div>
       <div className="flex min-h-[240px] flex-col items-center justify-center gap-10 p-10">
-        <ElasticText className="text-4xl tracking-tight sm:text-5xl">
-          Design for Humans
-        </ElasticText>
-        <ElasticText
-          mode="hover"
-          className="text-2xl tracking-tight text-fd-muted-foreground sm:text-3xl"
-        >
-          Move Your Mouse
-        </ElasticText>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/encrypted-card-result.tsx
+++ b/apps/docs/src/components/learn/encrypted-card-result.tsx
@@ -1,12 +1,21 @@
 "use client";
 
 import { EncryptedCardDemo } from "@/components/demos/encrypted-card-demo";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing panel — the real `EncryptedCard`. Hover and move the pointer to
  * see the radial reveal and the scrambling glyph stream underneath.
  */
 export function EncryptedCardResult() {
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        <EncryptedCardDemo />
+      </div>
+    );
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">

--- a/apps/docs/src/components/learn/filter-bar-result.tsx
+++ b/apps/docs/src/components/learn/filter-bar-result.tsx
@@ -2,6 +2,7 @@
 
 import { type Facet, FilterBar, type FilterValue } from "@godui/components";
 import { useState } from "react";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 const facets: Facet[] = [
   {
@@ -100,6 +101,50 @@ export function FilterBarResult() {
     ),
   );
 
+  const demo = (
+    <>
+      <div className="w-full max-w-lg rounded-xl border border-border bg-card shadow-sm">
+        <div className="flex items-center justify-between gap-3 border-border border-b px-4 py-3">
+          <span className="font-semibold text-foreground text-sm">Issues</span>
+          <span className="text-muted-foreground text-xs tabular-nums">
+            {matches.length} of {ISSUES.length}
+          </span>
+        </div>
+        <div className="border-border border-b px-4 py-3">
+          <FilterBar facets={facets} value={value} onChange={setValue} />
+        </div>
+        <ul className="divide-y divide-border overflow-hidden rounded-b-xl">
+          {matches.map((issue) => (
+            <li
+              key={issue.id}
+              className="flex items-center gap-3 px-4 py-3 text-sm"
+            >
+              <span
+                className={`h-2 w-2 shrink-0 rounded-full ${dot[issue.priority]}`}
+              />
+              <span className="font-mono text-muted-foreground text-xs">
+                {issue.id}
+              </span>
+              <span className="truncate text-foreground">{issue.title}</span>
+            </li>
+          ))}
+          {matches.length === 0 && (
+            <li className="px-4 py-10 text-center text-muted-foreground text-sm">
+              No issues match these filters.
+            </li>
+          )}
+        </ul>
+      </div>
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="min-h-[280px] flex w-full flex-col items-center p-6">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -110,42 +155,7 @@ export function FilterBarResult() {
           the real component — toggle a facet, watch the list narrow
         </span>
       </div>
-      <div className="flex w-full flex-col items-center p-10">
-        <div className="w-full max-w-lg rounded-xl border border-border bg-card shadow-sm">
-          <div className="flex items-center justify-between gap-3 border-border border-b px-4 py-3">
-            <span className="font-semibold text-foreground text-sm">
-              Issues
-            </span>
-            <span className="text-muted-foreground text-xs tabular-nums">
-              {matches.length} of {ISSUES.length}
-            </span>
-          </div>
-          <div className="border-border border-b px-4 py-3">
-            <FilterBar facets={facets} value={value} onChange={setValue} />
-          </div>
-          <ul className="divide-y divide-border overflow-hidden rounded-b-xl">
-            {matches.map((issue) => (
-              <li
-                key={issue.id}
-                className="flex items-center gap-3 px-4 py-3 text-sm"
-              >
-                <span
-                  className={`h-2 w-2 shrink-0 rounded-full ${dot[issue.priority]}`}
-                />
-                <span className="font-mono text-muted-foreground text-xs">
-                  {issue.id}
-                </span>
-                <span className="truncate text-foreground">{issue.title}</span>
-              </li>
-            ))}
-            {matches.length === 0 && (
-              <li className="px-4 py-10 text-center text-muted-foreground text-sm">
-                No issues match these filters.
-              </li>
-            )}
-          </ul>
-        </div>
-      </div>
+      <div className="flex w-full flex-col items-center p-10">{demo}</div>
     </div>
   );
 }

--- a/apps/docs/src/components/learn/floating-toolbar-result.tsx
+++ b/apps/docs/src/components/learn/floating-toolbar-result.tsx
@@ -3,6 +3,7 @@
 import { FloatingToolbar, type ToolbarAction } from "@godui/components";
 import { AlignLeft, Bold, Italic, Link2 } from "lucide-react";
 import { useState } from "react";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * The real, interactive `FloatingToolbar` — toggle it in and out to feel the
@@ -41,6 +42,26 @@ export function FloatingToolbarResult() {
     },
   ];
 
+  const demo = (
+    <>
+      <FloatingToolbar open={open} actions={actions} />
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="rounded-lg border border-border bg-card px-3 py-1.5 font-medium text-muted-foreground text-xs transition-colors hover:text-foreground"
+      >
+        {open ? "Hide toolbar" : "Show toolbar"}
+      </button>
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full flex-col items-center justify-center gap-6 p-6">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -52,14 +73,7 @@ export function FloatingToolbarResult() {
         </span>
       </div>
       <div className="flex min-h-[280px] w-full flex-col items-center justify-center gap-6 p-10">
-        <FloatingToolbar open={open} actions={actions} />
-        <button
-          type="button"
-          onClick={() => setOpen((v) => !v)}
-          className="rounded-lg border border-border bg-card px-3 py-1.5 font-medium text-muted-foreground text-xs transition-colors hover:text-foreground"
-        >
-          {open ? "Hide toolbar" : "Show toolbar"}
-        </button>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/flow-field-result.tsx
+++ b/apps/docs/src/components/learn/flow-field-result.tsx
@@ -1,8 +1,24 @@
 "use client";
 
 import { FlowField } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 export function FlowFieldResult() {
+  const demo = (
+    <div className="relative min-h-[320px] w-full overflow-hidden md:min-h-[380px]">
+      <FlowField speed={1} fade={0.06} noiseScale={0.0016} />
+    </div>
+  );
+
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -13,9 +29,7 @@ export function FlowFieldResult() {
           the real component — calm field
         </span>
       </div>
-      <div className="relative min-h-[320px] overflow-hidden md:min-h-[380px]">
-        <FlowField speed={1} fade={0.06} noiseScale={0.0016} />
-      </div>
+      {demo}
     </div>
   );
 }

--- a/apps/docs/src/components/learn/fluid-cursor-result.tsx
+++ b/apps/docs/src/components/learn/fluid-cursor-result.tsx
@@ -1,12 +1,21 @@
 "use client";
 
 import { FluidCursorDemo } from "@/components/demos/fluid-cursor-demo";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing panel — the real `FluidCursor`, scoped to the demo card. Fine
  * pointers only; reduced-motion users see nothing (component returns null).
  */
 export function FluidCursorResult() {
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        <FluidCursorDemo />
+      </div>
+    );
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">

--- a/apps/docs/src/components/learn/globe-result.tsx
+++ b/apps/docs/src/components/learn/globe-result.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Globe } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real `Globe`, tuned with
@@ -24,6 +25,20 @@ const GLOBE_CONFIG = {
 };
 
 export function GlobeResult() {
+  const demo = (
+    <>
+      <div className="absolute left-1/2 top-1/2 size-[420px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-[#2b50b8]/25 blur-3xl" />
+      <Globe config={GLOBE_CONFIG} className="relative max-w-[380px]" />
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="relative flex min-h-[360px] items-center justify-center overflow-hidden bg-[#04060f] p-6 md:min-h-[420px] md:p-6 w-full">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -35,8 +50,7 @@ export function GlobeResult() {
         </span>
       </div>
       <div className="relative flex min-h-[360px] items-center justify-center overflow-hidden bg-[#04060f] p-6 md:min-h-[420px] md:p-10">
-        <div className="absolute left-1/2 top-1/2 size-[420px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-[#2b50b8]/25 blur-3xl" />
-        <Globe config={GLOBE_CONFIG} className="relative max-w-[380px]" />
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/gooey-fab-result.tsx
+++ b/apps/docs/src/components/learn/gooey-fab-result.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { GooeyFab } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 const Icon = ({ d }: { d: string }) => (
   <svg
@@ -18,10 +19,43 @@ const Icon = ({ d }: { d: string }) => (
 );
 
 /**
+ * The real, interactive Gooey FAB — no card chrome. Rendered on the shared
+ * `LearnPlayer` stage as the final chapter. Accepts (and ignores) the injected
+ * `cycle`/`reduced` so the player can `cloneElement` it like any other scene.
+ */
+export function GooeyFabResultBody() {
+  return (
+    <div className="flex min-h-[280px] w-full items-end justify-center pb-4">
+      <GooeyFab
+        actions={[
+          {
+            label: "Edit",
+            icon: (
+              <Icon d="M12 20h9M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z" />
+            ),
+          },
+          {
+            label: "Share",
+            icon: <Icon d="M4 12v8h16v-8M12 16V4M8 8l4-4 4 4" />,
+          },
+          {
+            label: "Delete",
+            icon: <Icon d="M3 6h18M8 6V4h8v2M6 6l1 14h10l1-14" />,
+          },
+        ]}
+      />
+    </div>
+  );
+}
+
+/**
  * Closing "here's the finished thing" panel — the real, interactive Gooey FAB
  * so the reader can feel every mechanism the article just pulled apart.
  */
 export function GooeyFabResult() {
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene()) return <GooeyFabResultBody />;
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -33,24 +67,7 @@ export function GooeyFabResult() {
         </span>
       </div>
       <div className="flex min-h-[280px] items-end justify-center p-10 pb-14">
-        <GooeyFab
-          actions={[
-            {
-              label: "Edit",
-              icon: (
-                <Icon d="M12 20h9M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z" />
-              ),
-            },
-            {
-              label: "Share",
-              icon: <Icon d="M4 12v8h16v-8M12 16V4M8 8l4-4 4 4" />,
-            },
-            {
-              label: "Delete",
-              icon: <Icon d="M3 6h18M8 6V4h8v2M6 6l1 14h10l1-14" />,
-            },
-          ]}
-        />
+        <GooeyFabResultBody />
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/gooey-filter.tsx
+++ b/apps/docs/src/components/learn/gooey-filter.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ScrollScene } from "./scroll-scene";
+import { type SceneAnim, ScrollScene } from "./scroll-scene";
 
 /**
  * Illustrates the SVG metaball filter: blur the source, then punch the alpha
@@ -26,117 +26,124 @@ const CSS = `
 
 const FILTER_ID = "gooey-learn-filter";
 
-export function GooeyFilter() {
+export function GooeyFilterBody({
+  cycle = 0,
+  reduced = false,
+}: Partial<SceneAnim>) {
   return (
-    <ScrollScene label="Goo filter" note="blur + color-matrix metaballs">
-      {({ cycle, reduced }) => (
-        <div
-          key={cycle}
-          className={`flex w-full max-w-[480px] flex-col items-center gap-8 ${reduced ? "gf-static" : ""}`}
-        >
-          {/* biome-ignore lint/security/noDangerouslySetInnerHtml: static keyframes, no user input */}
-          <style dangerouslySetInnerHTML={{ __html: CSS }} />
+    <div
+      key={cycle}
+      className={`flex w-full max-w-[480px] flex-col items-center gap-8 ${reduced ? "gf-static" : ""}`}
+    >
+      {/* biome-ignore lint/security/noDangerouslySetInnerHtml: static keyframes, no user input */}
+      <style dangerouslySetInnerHTML={{ __html: CSS }} />
 
-          <div className="grid w-full grid-cols-2 gap-6">
-            <div className="flex flex-col items-center gap-3">
-              <div className="relative flex h-[120px] w-full items-center justify-center">
-                <div className="gf-a absolute size-14 rounded-full bg-[var(--foreground)]/55" />
-                <div className="gf-b absolute size-14 rounded-full bg-[var(--foreground)]/55" />
-              </div>
-              <p className="font-mono text-[11px] text-fd-muted-foreground">
-                raw circles
-              </p>
-            </div>
+      <div className="grid w-full grid-cols-2 gap-6">
+        <div className="flex flex-col items-center gap-3">
+          <div className="relative flex h-[120px] w-full items-center justify-center">
+            <div className="gf-a absolute size-14 rounded-full bg-[var(--foreground)]/55" />
+            <div className="gf-b absolute size-14 rounded-full bg-[var(--foreground)]/55" />
+          </div>
+          <p className="font-mono text-[11px] text-fd-muted-foreground">
+            raw circles
+          </p>
+        </div>
 
-            <div className="flex flex-col items-center gap-3">
-              {/* Native SVG (circles inside the filtered <g>) — Safari composites
+        <div className="flex flex-col items-center gap-3">
+          {/* Native SVG (circles inside the filtered <g>) — Safari composites
                   a transform-animated HTML child onto its own layer, escaping an
                   HTML `filter: url()`, so the metaballs never merge there. SVG
                   shapes stay inside the filter and fuse on every engine. */}
-              <div className="relative flex h-[120px] w-full items-center justify-center">
-                <svg
-                  aria-hidden="true"
-                  className="pointer-events-none overflow-visible"
-                  width={120}
-                  height={120}
-                  viewBox="-60 -60 120 120"
+          <div className="relative flex h-[120px] w-full items-center justify-center">
+            <svg
+              aria-hidden="true"
+              className="pointer-events-none overflow-visible"
+              width={120}
+              height={120}
+              viewBox="-60 -60 120 120"
+            >
+              <defs>
+                <filter
+                  id={FILTER_ID}
+                  x="-50%"
+                  y="-50%"
+                  width="200%"
+                  height="200%"
+                  colorInterpolationFilters="sRGB"
                 >
-                  <defs>
-                    <filter
-                      id={FILTER_ID}
-                      x="-50%"
-                      y="-50%"
-                      width="200%"
-                      height="200%"
-                      colorInterpolationFilters="sRGB"
-                    >
-                      <feGaussianBlur
-                        in="SourceGraphic"
-                        stdDeviation="6"
-                        result="blur"
-                      />
-                      <feColorMatrix
-                        in="blur"
-                        mode="matrix"
-                        values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 20 -10"
-                        result="goo"
-                      />
-                    </filter>
-                  </defs>
-                  <g
-                    filter={`url(#${FILTER_ID})`}
-                    fillOpacity={0.55}
-                    style={{ fill: "var(--foreground)" }}
-                  >
-                    <circle
-                      className="gf-a"
-                      cx={0}
-                      cy={0}
-                      r={28}
-                      style={{
-                        transformBox: "fill-box",
-                        transformOrigin: "center",
-                      }}
-                    />
-                    <circle
-                      className="gf-b"
-                      cx={0}
-                      cy={0}
-                      r={28}
-                      style={{
-                        transformBox: "fill-box",
-                        transformOrigin: "center",
-                      }}
-                    />
-                  </g>
-                </svg>
-              </div>
-              <p className="font-mono text-[11px] text-fd-muted-foreground">
-                after goo filter
-              </p>
-            </div>
+                  <feGaussianBlur
+                    in="SourceGraphic"
+                    stdDeviation="6"
+                    result="blur"
+                  />
+                  <feColorMatrix
+                    in="blur"
+                    mode="matrix"
+                    values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 20 -10"
+                    result="goo"
+                  />
+                </filter>
+              </defs>
+              <g
+                filter={`url(#${FILTER_ID})`}
+                fillOpacity={0.55}
+                style={{ fill: "var(--foreground)" }}
+              >
+                <circle
+                  className="gf-a"
+                  cx={0}
+                  cy={0}
+                  r={28}
+                  style={{
+                    transformBox: "fill-box",
+                    transformOrigin: "center",
+                  }}
+                />
+                <circle
+                  className="gf-b"
+                  cx={0}
+                  cy={0}
+                  r={28}
+                  style={{
+                    transformBox: "fill-box",
+                    transformOrigin: "center",
+                  }}
+                />
+              </g>
+            </svg>
           </div>
-
-          <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
-            <div className="flex flex-col gap-1.5">
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                feGaussianBlur
-              </dt>
-              <dd className="font-mono text-[12px] text-fd-muted-foreground">
-                {'stdDeviation="6"'}
-              </dd>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <dt className="font-medium text-[13px] text-fd-foreground">
-                feColorMatrix
-              </dt>
-              <dd className="font-mono text-[12px] text-fd-muted-foreground">
-                alpha ×20 − 10
-              </dd>
-            </div>
-          </dl>
+          <p className="font-mono text-[11px] text-fd-muted-foreground">
+            after goo filter
+          </p>
         </div>
-      )}
+      </div>
+
+      <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
+        <div className="flex flex-col gap-1.5">
+          <dt className="font-medium text-[13px] text-fd-foreground">
+            feGaussianBlur
+          </dt>
+          <dd className="font-mono text-[12px] text-fd-muted-foreground">
+            {'stdDeviation="6"'}
+          </dd>
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <dt className="font-medium text-[13px] text-fd-foreground">
+            feColorMatrix
+          </dt>
+          <dd className="font-mono text-[12px] text-fd-muted-foreground">
+            alpha ×20 − 10
+          </dd>
+        </div>
+      </dl>
+    </div>
+  );
+}
+
+export function GooeyFilter() {
+  return (
+    <ScrollScene label="Goo filter" note="blur + color-matrix metaballs">
+      {(anim) => <GooeyFilterBody {...anim} />}
     </ScrollScene>
   );
 }

--- a/apps/docs/src/components/learn/gooey-layers.tsx
+++ b/apps/docs/src/components/learn/gooey-layers.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { CSSProperties } from "react";
-import { ScrollScene } from "./scroll-scene";
+import { type SceneAnim, ScrollScene } from "./scroll-scene";
 
 /**
  * Anatomy of the real open FAB: same geometry three ways — blob paint only,
@@ -134,46 +134,58 @@ const COLUMNS: {
   },
 ];
 
+/**
+ * The raw animated body — no card chrome. Rendered directly by `LearnPlayer`
+ * (which owns one shared stage) and wrapped in `<ScrollScene>` by `GooeyLayers`
+ * for the classic scroll layout. `cycle` remounts the animated grid on replay.
+ */
+export function GooeyLayersBody({
+  cycle = 0,
+  reduced = false,
+}: Partial<SceneAnim>) {
+  return (
+    <div className="flex w-full max-w-[560px] flex-col items-center gap-8">
+      {/* biome-ignore lint/security/noDangerouslySetInnerHtml: static keyframes, no user input */}
+      <style dangerouslySetInnerHTML={{ __html: CSS }} />
+      <div
+        key={cycle}
+        className={`grid w-full grid-cols-3 items-end justify-items-center gap-3 sm:gap-6 ${reduced ? "gl-static" : ""}`}
+      >
+        {COLUMNS.map((col) => (
+          <div
+            key={col.key}
+            className="gl-col flex flex-col items-center gap-3"
+            style={{ "--d": `${col.delay}ms` } as CSSProperties}
+          >
+            <FabStage blobs={col.blobs} controls={col.controls} />
+            <p className="font-mono text-[11px] text-fd-muted-foreground">
+              {col.label}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
+        {LEGEND.map((item) => (
+          <div key={item.name} className="flex flex-col gap-1.5">
+            <LegendSwatch kind={item.kind} />
+            <dt className="font-medium text-[13px] text-fd-foreground">
+              {item.name}
+            </dt>
+            <dd className="text-[12px] text-fd-muted-foreground">
+              {item.desc}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}
+
 export function GooeyLayers() {
   return (
     <ScrollScene label="Anatomy" note="same open FAB, two layers">
-      {({ cycle, reduced }) => (
-        <div className="flex w-full max-w-[560px] flex-col items-center gap-8">
-          {/* biome-ignore lint/security/noDangerouslySetInnerHtml: static keyframes, no user input */}
-          <style dangerouslySetInnerHTML={{ __html: CSS }} />
-          <div
-            key={cycle}
-            className={`grid w-full grid-cols-3 items-end justify-items-center gap-3 sm:gap-6 ${reduced ? "gl-static" : ""}`}
-          >
-            {COLUMNS.map((col) => (
-              <div
-                key={col.key}
-                className="gl-col flex flex-col items-center gap-3"
-                style={{ "--d": `${col.delay}ms` } as CSSProperties}
-              >
-                <FabStage blobs={col.blobs} controls={col.controls} />
-                <p className="font-mono text-[11px] text-fd-muted-foreground">
-                  {col.label}
-                </p>
-              </div>
-            ))}
-          </div>
-
-          <dl className="grid w-full grid-cols-2 gap-4 border-fd-border border-t pt-5">
-            {LEGEND.map((item) => (
-              <div key={item.name} className="flex flex-col gap-1.5">
-                <LegendSwatch kind={item.kind} />
-                <dt className="font-medium text-[13px] text-fd-foreground">
-                  {item.name}
-                </dt>
-                <dd className="text-[12px] text-fd-muted-foreground">
-                  {item.desc}
-                </dd>
-              </div>
-            ))}
-          </dl>
-        </div>
-      )}
+      {(anim) => <GooeyLayersBody {...anim} />}
     </ScrollScene>
   );
 }

--- a/apps/docs/src/components/learn/gooey-spring.tsx
+++ b/apps/docs/src/components/learn/gooey-spring.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { CSSProperties } from "react";
-import { ScrollScene } from "./scroll-scene";
+import { type SceneAnim, ScrollScene } from "./scroll-scene";
 
 /**
  * One open → close cycle matching the component's spring feel: satellites
@@ -49,49 +49,56 @@ const PHASES: { label: string; value: string }[] = [
   { label: "close delay", value: "(n−i) × 20ms" },
 ];
 
+export function GooeySpringBody({
+  cycle = 0,
+  reduced = false,
+}: Partial<SceneAnim>) {
+  return (
+    <div
+      key={cycle}
+      className={`flex flex-col items-center gap-8 ${reduced ? "gs-static" : ""}`}
+    >
+      {/* biome-ignore lint/security/noDangerouslySetInnerHtml: static keyframes, no user input */}
+      <style dangerouslySetInnerHTML={{ __html: CSS }} />
+
+      <div className="relative flex h-[240px] w-[80px] items-end justify-center pb-2">
+        <div
+          className="gs-sat-2 absolute bottom-2 size-9 rounded-full bg-[var(--foreground)]/40"
+          style={{ "--ty": "-174px" } as CSSProperties}
+        />
+        <div
+          className="gs-sat-1 absolute bottom-2 size-9 rounded-full bg-[var(--foreground)]/45"
+          style={{ "--ty": "-116px" } as CSSProperties}
+        />
+        <div
+          className="gs-sat-0 absolute bottom-2 size-9 rounded-full bg-[var(--foreground)]/50"
+          style={{ "--ty": "-58px" } as CSSProperties}
+        />
+        <div className="relative z-10 flex size-14 items-center justify-center rounded-full border border-white/10 bg-[var(--card)] shadow-md">
+          <span className="gs-trigger flex size-full items-center justify-center font-semibold text-[20px] text-fd-foreground leading-none">
+            +
+          </span>
+        </div>
+      </div>
+
+      <dl className="grid grid-cols-3 gap-x-6 gap-y-1 text-center font-mono text-[11px] text-fd-muted-foreground">
+        {PHASES.map((p) => (
+          <dt key={p.label} className="text-fd-foreground">
+            {p.label}
+          </dt>
+        ))}
+        {PHASES.map((p) => (
+          <dd key={p.label}>{p.value}</dd>
+        ))}
+      </dl>
+    </div>
+  );
+}
+
 export function GooeySpring() {
   return (
     <ScrollScene label="Spring extrusion" note="staggered open / reverse close">
-      {({ cycle, reduced }) => (
-        <div
-          key={cycle}
-          className={`flex flex-col items-center gap-8 ${reduced ? "gs-static" : ""}`}
-        >
-          {/* biome-ignore lint/security/noDangerouslySetInnerHtml: static keyframes, no user input */}
-          <style dangerouslySetInnerHTML={{ __html: CSS }} />
-
-          <div className="relative flex h-[240px] w-[80px] items-end justify-center pb-2">
-            <div
-              className="gs-sat-2 absolute bottom-2 size-9 rounded-full bg-[var(--foreground)]/40"
-              style={{ "--ty": "-174px" } as CSSProperties}
-            />
-            <div
-              className="gs-sat-1 absolute bottom-2 size-9 rounded-full bg-[var(--foreground)]/45"
-              style={{ "--ty": "-116px" } as CSSProperties}
-            />
-            <div
-              className="gs-sat-0 absolute bottom-2 size-9 rounded-full bg-[var(--foreground)]/50"
-              style={{ "--ty": "-58px" } as CSSProperties}
-            />
-            <div className="relative z-10 flex size-14 items-center justify-center rounded-full border border-white/10 bg-[var(--card)] shadow-md">
-              <span className="gs-trigger flex size-full items-center justify-center font-semibold text-[20px] text-fd-foreground leading-none">
-                +
-              </span>
-            </div>
-          </div>
-
-          <dl className="grid grid-cols-3 gap-x-6 gap-y-1 text-center font-mono text-[11px] text-fd-muted-foreground">
-            {PHASES.map((p) => (
-              <dt key={p.label} className="text-fd-foreground">
-                {p.label}
-              </dt>
-            ))}
-            {PHASES.map((p) => (
-              <dd key={p.label}>{p.value}</dd>
-            ))}
-          </dl>
-        </div>
-      )}
+      {(anim) => <GooeySpringBody {...anim} />}
     </ScrollScene>
   );
 }

--- a/apps/docs/src/components/learn/gooey-stack-result.tsx
+++ b/apps/docs/src/components/learn/gooey-stack-result.tsx
@@ -2,6 +2,7 @@
 
 import { GooeyStack } from "@godui/components";
 import * as React from "react";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 function GitHubMark() {
   return (
@@ -114,6 +115,24 @@ function PromptCard({
 export function GooeyStackResult() {
   const [open, setOpen] = React.useState(false);
 
+  const demo = (
+    <>
+      <div className="w-full max-w-[26rem]">
+        <GooeyStack collapsed={!open}>
+          <ConnectorCard onClose={() => setOpen(false)} />
+          <PromptCard open={open} onToggle={() => setOpen((o) => !o)} />
+        </GooeyStack>
+      </div>
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="relative flex min-h-[300px] items-center justify-center p-6 md:min-h-[360px] md:p-6 w-full">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -125,12 +144,7 @@ export function GooeyStackResult() {
         </span>
       </div>
       <div className="relative flex min-h-[300px] items-center justify-center p-6 md:min-h-[360px] md:p-10">
-        <div className="w-full max-w-[26rem]">
-          <GooeyStack collapsed={!open}>
-            <ConnectorCard onClose={() => setOpen(false)} />
-            <PromptCard open={open} onToggle={() => setOpen((o) => !o)} />
-          </GooeyStack>
-        </div>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/gravity-result.tsx
+++ b/apps/docs/src/components/learn/gravity-result.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Gravity, MatterBody } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 const TAGS: { label: string; x: string; y: string; angle: number }[] = [
   { label: "design", x: "20%", y: "0%", angle: -8 },
@@ -15,6 +16,23 @@ const TAGS: { label: string; x: string; y: string; angle: number }[] = [
  * settle against the others and the walls.
  */
 export function GravityResult() {
+  const demo = (
+    <>
+      <Gravity className="h-[360px] w-full rounded-xl border border-border bg-muted/20">
+        {TAGS.map((tag) => (
+          <MatterBody key={tag.label} x={tag.x} y={tag.y} angle={tag.angle}>
+            <span className="rounded-full bg-primary px-5 py-2.5 text-lg font-medium text-primary-foreground">
+              {tag.label}
+            </span>
+          </MatterBody>
+        ))}
+      </Gravity>
+    </>
+  );
+
+  if (useBareScene())
+    return <div className="min-h-[280px] p-6 md:p-6 w-full">{demo}</div>;
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -25,17 +43,7 @@ export function GravityResult() {
           the real component — drag a pill and fling it
         </span>
       </div>
-      <div className="p-6 md:p-10">
-        <Gravity className="h-[360px] w-full rounded-xl border border-border bg-muted/20">
-          {TAGS.map((tag) => (
-            <MatterBody key={tag.label} x={tag.x} y={tag.y} angle={tag.angle}>
-              <span className="rounded-full bg-primary px-5 py-2.5 text-lg font-medium text-primary-foreground">
-                {tag.label}
-              </span>
-            </MatterBody>
-          ))}
-        </Gravity>
-      </div>
+      <div className="p-6 md:p-10">{demo}</div>
     </div>
   );
 }

--- a/apps/docs/src/components/learn/hero-parallax-result.tsx
+++ b/apps/docs/src/components/learn/hero-parallax-result.tsx
@@ -2,6 +2,7 @@
 
 import { HeroParallax } from "@godui/components";
 import * as React from "react";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real Hero Parallax in a
@@ -61,6 +62,26 @@ export function HeroParallaxResult() {
     return () => cancelAnimationFrame(id);
   }, []);
 
+  const demo = (
+    <>
+      <HeroParallax
+        products={PRODUCTS}
+        header={HEADER}
+        scrollContainer={scrollerRef}
+      />
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div
+        ref={scrollerRef}
+        className="relative h-[min(720px,75vh)] overflow-x-hidden overflow-y-auto overscroll-contain w-full"
+      >
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -75,11 +96,7 @@ export function HeroParallaxResult() {
         ref={scrollerRef}
         className="relative h-[min(720px,75vh)] overflow-x-hidden overflow-y-auto overscroll-contain"
       >
-        <HeroParallax
-          products={PRODUCTS}
-          header={HEADER}
-          scrollContainer={scrollerRef}
-        />
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/highlighter-result.tsx
+++ b/apps/docs/src/components/learn/highlighter-result.tsx
@@ -1,12 +1,47 @@
 "use client";
 
 import { Highlighter } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing panel — the real Highlighter so the reader can watch annotate()
  * draw highlight / underline / box over live inline text.
  */
 export function HighlighterResult() {
+  const demo = (
+    <>
+      <p className="max-w-md text-center text-2xl leading-relaxed">
+        The quick brown{" "}
+        <Highlighter action="underline" color="#60a5fa" isView>
+          fox
+        </Highlighter>{" "}
+        jumps over the{" "}
+        <Highlighter action="highlight" isView>
+          lazy dog
+        </Highlighter>
+        .
+      </p>
+      <p className="max-w-md text-center text-xl leading-relaxed text-fd-muted-foreground">
+        Try a{" "}
+        <Highlighter action="box" color="#f59e0b" isView>
+          boxed phrase
+        </Highlighter>{" "}
+        or a{" "}
+        <Highlighter action="circle" color="#34d399" isView>
+          circled word
+        </Highlighter>
+        .
+      </p>
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[240px] flex-col items-center justify-center gap-8 p-6 w-full">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -18,28 +53,7 @@ export function HighlighterResult() {
         </span>
       </div>
       <div className="flex min-h-[240px] flex-col items-center justify-center gap-8 p-10">
-        <p className="max-w-md text-center text-2xl leading-relaxed">
-          The quick brown{" "}
-          <Highlighter action="underline" color="#60a5fa" isView>
-            fox
-          </Highlighter>{" "}
-          jumps over the{" "}
-          <Highlighter action="highlight" isView>
-            lazy dog
-          </Highlighter>
-          .
-        </p>
-        <p className="max-w-md text-center text-xl leading-relaxed text-fd-muted-foreground">
-          Try a{" "}
-          <Highlighter action="box" color="#f59e0b" isView>
-            boxed phrase
-          </Highlighter>{" "}
-          or a{" "}
-          <Highlighter action="circle" color="#34d399" isView>
-            circled word
-          </Highlighter>
-          .
-        </p>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/hold-confirm-result.tsx
+++ b/apps/docs/src/components/learn/hold-confirm-result.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { HoldConfirmButton } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive
@@ -8,6 +9,26 @@ import { HoldConfirmButton } from "@godui/components";
  * apart: press and hold, or release early to cancel.
  */
 export function HoldConfirmResult() {
+  const demo = (
+    <>
+      <HoldConfirmButton variant="destructive">
+        Hold to delete
+      </HoldConfirmButton>
+      <HoldConfirmButton variant="default" duration={1400}>
+        Hold to publish
+      </HoldConfirmButton>
+    </>
+  );
+
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full flex-wrap items-center justify-center gap-6 p-6">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -19,12 +40,7 @@ export function HoldConfirmResult() {
         </span>
       </div>
       <div className="flex min-h-[240px] flex-wrap items-center justify-center gap-6 p-10">
-        <HoldConfirmButton variant="destructive">
-          Hold to delete
-        </HoldConfirmButton>
-        <HoldConfirmButton variant="default" duration={1400}>
-          Hold to publish
-        </HoldConfirmButton>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/holographic-card-result.tsx
+++ b/apps/docs/src/components/learn/holographic-card-result.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { HolographicCard } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive
@@ -8,6 +9,32 @@ import { HolographicCard } from "@godui/components";
  * and glitter all shift together as it tilts, like a real trading-card holo.
  */
 export function HolographicCardResult() {
+  const demo = (
+    <>
+      <HolographicCard variant="rainbow" className="h-72 w-52 p-5">
+        <span className="text-[10px] font-medium uppercase tracking-widest text-white/60">
+          Founding Member
+        </span>
+        <div className="mt-24">
+          <h3 className="text-xl font-semibold tracking-tight text-white">
+            GodUI
+          </h3>
+          <p className="mt-1 text-xs text-white/70">
+            Move your pointer across the card.
+          </p>
+        </div>
+      </HolographicCard>
+      <HolographicCard variant="galaxy" className="h-72 w-52" />
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[340px] flex-wrap items-center justify-center gap-8 p-6 w-full">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -19,20 +46,7 @@ export function HolographicCardResult() {
         </span>
       </div>
       <div className="flex min-h-[340px] flex-wrap items-center justify-center gap-8 p-10">
-        <HolographicCard variant="rainbow" className="h-72 w-52 p-5">
-          <span className="text-[10px] font-medium uppercase tracking-widest text-white/60">
-            Founding Member
-          </span>
-          <div className="mt-24">
-            <h3 className="text-xl font-semibold tracking-tight text-white">
-              GodUI
-            </h3>
-            <p className="mt-1 text-xs text-white/70">
-              Move your pointer across the card.
-            </p>
-          </div>
-        </HolographicCard>
-        <HolographicCard variant="galaxy" className="h-72 w-52" />
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/image-accordion-result.tsx
+++ b/apps/docs/src/components/learn/image-accordion-result.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ImageAccordion } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive
@@ -31,6 +32,23 @@ const PANELS = [
 ];
 
 export function ImageAccordionResult() {
+  const demo = (
+    <>
+      <ImageAccordion
+        panels={PANELS}
+        className="w-full max-w-2xl"
+        height="22rem"
+      />
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="relative flex min-h-[280px] items-center justify-center overflow-hidden p-6 sm:p-6 w-full">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -42,11 +60,7 @@ export function ImageAccordionResult() {
         </span>
       </div>
       <div className="relative flex min-h-[280px] items-center justify-center overflow-hidden p-6 sm:p-10">
-        <ImageAccordion
-          panels={PANELS}
-          className="w-full max-w-2xl"
-          height="22rem"
-        />
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/image-compare-result.tsx
+++ b/apps/docs/src/components/learn/image-compare-result.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ImageCompare } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive
@@ -9,6 +10,26 @@ import { ImageCompare } from "@godui/components";
 const SRC = "https://picsum.photos/id/1015/800/600";
 
 export function ImageCompareResult() {
+  const demo = (
+    <>
+      <div className="aspect-[4/3] w-full max-w-md">
+        <ImageCompare
+          beforeLabel="Color"
+          afterLabel="B&W"
+          before={<img src={SRC} alt="Color" />}
+          after={<img src={SRC} alt="Black and white" className="grayscale" />}
+        />
+      </div>
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="relative flex min-h-[280px] items-center justify-center overflow-hidden p-6 sm:p-6 w-full">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -20,16 +41,7 @@ export function ImageCompareResult() {
         </span>
       </div>
       <div className="relative flex min-h-[280px] items-center justify-center overflow-hidden p-6 sm:p-10">
-        <div className="aspect-[4/3] w-full max-w-md">
-          <ImageCompare
-            beforeLabel="Color"
-            afterLabel="B&W"
-            before={<img src={SRC} alt="Color" />}
-            after={
-              <img src={SRC} alt="Black and white" className="grayscale" />
-            }
-          />
-        </div>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/image-trail-result.tsx
+++ b/apps/docs/src/components/learn/image-trail-result.tsx
@@ -1,12 +1,21 @@
 "use client";
 
 import { ImageTrailDemo } from "@/components/demos/image-trail-demo";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing panel — the real `ImageTrail`. Move across the stage to spawn
  * recycled images; reduced-motion users see the static five-image gallery.
  */
 export function ImageTrailResult() {
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        <ImageTrailDemo />
+      </div>
+    );
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">

--- a/apps/docs/src/components/learn/inertia-gallery-result.tsx
+++ b/apps/docs/src/components/learn/inertia-gallery-result.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { InertiaGallery } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive
@@ -31,6 +32,23 @@ function Shot({ label, img }: (typeof SHOTS)[number]) {
 }
 
 export function InertiaGalleryResult() {
+  const demo = (
+    <>
+      <InertiaGallery snap defaultIndex={2} itemWidth={200} gap={24}>
+        {SHOTS.map((s) => (
+          <Shot key={s.label} {...s} />
+        ))}
+      </InertiaGallery>
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="relative flex min-h-[300px] items-center justify-center overflow-hidden p-6 sm:p-6 w-full">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -42,11 +60,7 @@ export function InertiaGalleryResult() {
         </span>
       </div>
       <div className="relative flex min-h-[300px] items-center justify-center overflow-hidden p-6 sm:p-10">
-        <InertiaGallery snap defaultIndex={2} itemWidth={200} gap={24}>
-          {SHOTS.map((s) => (
-            <Shot key={s.label} {...s} />
-          ))}
-        </InertiaGallery>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/jelly-button-result.tsx
+++ b/apps/docs/src/components/learn/jelly-button-result.tsx
@@ -1,6 +1,21 @@
 "use client";
 
 import { JellyButton } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
+
+/**
+ * The real, interactive Jelly Buttons — no card chrome. Reused on the shared
+ * `LearnPlayer` stage and inside the classic result card.
+ */
+function JellyButtonResultBody() {
+  return (
+    <>
+      <JellyButton variant="primary">Press me</JellyButton>
+      <JellyButton variant="secondary">Press me</JellyButton>
+      <JellyButton variant="outline">Press me</JellyButton>
+    </>
+  );
+}
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive Jelly
@@ -8,6 +23,14 @@ import { JellyButton } from "@godui/components";
  * pulled apart.
  */
 export function JellyButtonResult() {
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full flex-wrap items-center justify-center gap-6 p-6">
+        <JellyButtonResultBody />
+      </div>
+    );
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -19,9 +42,7 @@ export function JellyButtonResult() {
         </span>
       </div>
       <div className="flex min-h-[240px] flex-wrap items-center justify-center gap-6 p-10">
-        <JellyButton variant="primary">Press me</JellyButton>
-        <JellyButton variant="secondary">Press me</JellyButton>
-        <JellyButton variant="outline">Press me</JellyButton>
+        <JellyButtonResultBody />
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/lamp-result.tsx
+++ b/apps/docs/src/components/learn/lamp-result.tsx
@@ -1,12 +1,31 @@
 "use client";
 
 import { Lamp } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
+
+const LampDemo = (
+  <Lamp className="w-full min-h-[20rem]">
+    <h2 className="bg-gradient-to-b from-foreground to-muted-foreground bg-clip-text text-2xl font-semibold tracking-tight text-transparent md:text-3xl">
+      Build something
+      <br />
+      the world remembers
+    </h2>
+  </Lamp>
+);
 
 /**
  * Closing panel — the real `Lamp` so the reader feels the whileInView ignite
  * and the delayed children rise together.
  */
 export function LampResult() {
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        {LampDemo}
+      </div>
+    );
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -18,13 +37,7 @@ export function LampResult() {
         </span>
       </div>
       <div className="flex min-h-[320px] items-center justify-center p-4 md:p-6">
-        <Lamp className="w-full min-h-[20rem]">
-          <h2 className="bg-gradient-to-b from-foreground to-muted-foreground bg-clip-text text-2xl font-semibold tracking-tight text-transparent md:text-3xl">
-            Build something
-            <br />
-            the world remembers
-          </h2>
-        </Lamp>
+        {LampDemo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/learn-chapter.tsx
+++ b/apps/docs/src/components/learn/learn-chapter.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from "react";
+
+export type LearnChapterProps = {
+  /** Short rail label + numbered step name, e.g. "The goo filter". */
+  label: string;
+  /**
+   * The animated scene body for this chapter — a raw `*Body` element (no card
+   * chrome). `LearnPlayer` injects `{ cycle, reduced }` via `cloneElement`, so
+   * the element you pass should accept those (all the gooey `*Body` scenes do).
+   */
+  scene: ReactNode;
+  /** Source shown in the stage's Code tab. Omit to hide the Code tab entirely. */
+  code?: string;
+  /** Language for the Code tab (default "tsx"). */
+  lang?: string;
+  /**
+   * Marks the final "live component" chapter. Its scene is interactive (not a
+   * replayable animation), so the stage hides the Replay control for it.
+   */
+  isResult?: boolean;
+  /** The prose shown below the stage while this chapter is active. */
+  children: ReactNode;
+};
+
+/**
+ * Declares one chapter inside a <LearnPlayer>. Renders nothing on its own —
+ * <LearnPlayer> (a server component) reads its props to build the carousel.
+ * Kept as a stable module identity so `child.type === LearnChapter` matches
+ * across the server-MDX → client boundary.
+ */
+export function LearnChapter(_props: LearnChapterProps): null {
+  return null;
+}

--- a/apps/docs/src/components/learn/learn-player-client.tsx
+++ b/apps/docs/src/components/learn/learn-player-client.tsx
@@ -1,0 +1,584 @@
+"use client";
+
+import { DynamicCodeBlock } from "fumadocs-ui/components/dynamic-codeblock";
+import { ChevronLeft, ChevronRight, Code, X } from "lucide-react";
+import {
+  type CSSProperties,
+  type ReactNode,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { BorderBeam } from "@/components/border-beam";
+import { CopyButton } from "@/components/copy-button";
+import { BareSceneProvider } from "@/components/learn/bare-scene-context";
+import { useLearnMeta } from "@/components/learn/learn-player-context";
+import { usePrefersReducedMotion } from "@/components/learn/scroll-scene";
+import { ReplayButton } from "@/components/replay-button";
+import { cn } from "@/lib/cn";
+import { formatCode } from "@/lib/format-code";
+
+export type PlayerChapter = {
+  label: string;
+  scene: ReactNode;
+  code?: string;
+  lang: string;
+  isResult: boolean;
+  prose: ReactNode;
+};
+
+const pad = (n: number) => String(n).padStart(2, "0");
+
+// Subtle enter for the swapped scene, plus prose styling for the chapter text —
+// the player root is `not-prose` (so the stage chrome is fully controlled), so
+// the MDX chapter bodies need paragraph spacing + inline-code chips re-applied.
+const PLAYER_CSS = `
+@keyframes learn-scene-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: none; }
+}
+.learn-scene-in { animation: learn-scene-in 0.42s cubic-bezier(0.16, 1, 0.3, 1) both; }
+
+.learn-step-prose {
+  color: var(--foreground);
+  font-size: 1.0625rem;
+  line-height: 1.75;
+  text-wrap: pretty;
+}
+.learn-step-prose p { margin-top: 1rem; }
+.learn-step-prose p:first-child { margin-top: 0; }
+.learn-step-prose strong { font-weight: 600; }
+.learn-step-prose em { font-style: italic; }
+.learn-step-prose code {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 0.85em;
+  padding: 0.12em 0.36em;
+  border-radius: 6px;
+  background: var(--muted, rgba(0, 0, 0, 0.05));
+  border: 1px solid var(--border, rgba(0, 0, 0, 0.1));
+  white-space: nowrap;
+}
+`;
+
+// Grid card: bar row + scene row + an animated code row. The code container is
+// always mounted; toggling `--code-row` between 0 and its height animates
+// `grid-template-rows` (same technique as the Workbench code pane).
+const STAGE_CARD =
+  "relative grid overflow-hidden rounded-2xl border border-fd-border bg-fd-card shadow-[0_1px_2px_rgba(0,0,0,0.04),0_10px_30px_-14px_rgba(0,0,0,0.22)]";
+const CODE_H_DESKTOP = "clamp(180px, 40vh, 360px)";
+const CODE_H_MOBILE = "min(52svh, 420px)";
+
+function stageRows(
+  hasCode: boolean,
+  codeOpen: boolean,
+  sceneRow: string,
+  codeH: string,
+  reduced: boolean,
+): CSSProperties {
+  return {
+    gridTemplateRows: hasCode
+      ? `auto ${sceneRow} var(--code-row, 0px)`
+      : `auto ${sceneRow}`,
+    "--code-row": hasCode && codeOpen ? codeH : "0px",
+    // easeOutCubic — a gentle, even glide (not the snappy front-load of expo) so
+    // the scene resize + code reveal read as one soft, flowing motion.
+    transition: reduced
+      ? undefined
+      : "grid-template-rows 340ms cubic-bezier(0.33, 1, 0.68, 1)",
+  } as CSSProperties;
+}
+
+const BAR = "flex items-center gap-2.5 border-fd-border border-b px-3 py-2";
+const COUNTER = "font-mono text-[13px] text-fd-muted-foreground tabular-nums";
+const NAV_BTN =
+  "inline-flex size-8 items-center justify-center rounded-[10px] border border-fd-border bg-fd-card text-fd-muted-foreground transition-colors hover:border-fd-primary/45 hover:text-fd-primary disabled:pointer-events-none disabled:opacity-40";
+const STEP_TITLE =
+  "flex items-baseline gap-3 [&>h2]:text-balance [&>h2]:font-semibold [&>h2]:text-2xl [&>h2]:text-[var(--foreground)] [&>h2]:tracking-tight";
+
+/** Prettier-formats a chapter's code; seeds with the raw source so there's no
+ * empty flash before prettier resolves. */
+function useFormattedCode(code: string | undefined, lang: string) {
+  const [formatted, setFormatted] = useState(() => code?.trim() ?? "");
+  useEffect(() => {
+    if (!code) {
+      setFormatted("");
+      return;
+    }
+    let alive = true;
+    void formatCode(code, lang).then((next) => {
+      if (alive) setFormatted(next);
+    });
+    return () => {
+      alive = false;
+    };
+  }, [code, lang]);
+  return formatted;
+}
+
+function StepDot({
+  index,
+  active,
+  onClick,
+}: {
+  index: number;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={`Go to chapter ${index + 1}`}
+      aria-current={active ? "step" : undefined}
+      className="group relative inline-flex items-center justify-center p-2 active:scale-[0.96] motion-reduce:active:scale-100"
+    >
+      <span
+        className={cn(
+          "block h-1.5 rounded-full transition-[width,background-color] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none",
+          active
+            ? "w-5 bg-[var(--foreground)]"
+            : "w-1.5 bg-[var(--muted-foreground)]/40 group-hover:bg-[var(--muted-foreground)]",
+        )}
+      />
+    </button>
+  );
+}
+
+/** The `</>` toggle that opens/closes the bottom code container. */
+function CodeToggle({ open, onClick }: { open: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={open}
+      aria-label={open ? "Hide code" : "Show code"}
+      className={cn(
+        "inline-flex size-8 items-center justify-center rounded-[10px] border transition-colors",
+        open
+          ? "border-fd-primary/45 bg-fd-primary/10 text-fd-primary"
+          : "border-fd-border bg-fd-card text-fd-muted-foreground hover:border-fd-primary/45 hover:text-fd-primary",
+      )}
+    >
+      <Code className="size-4" aria-hidden="true" />
+    </button>
+  );
+}
+
+/** The centered scene canvas that fills a stage card. The scene is a Learn scene
+ * element (usually `<ScrollScene>`-wrapped); `BareSceneProvider` makes it render
+ * chrome-less and drives its play state from `cycle`. */
+function SceneCanvas({
+  scene,
+  cycle,
+  playKey,
+  reduced,
+  className,
+}: {
+  scene: ReactNode;
+  cycle: number;
+  playKey: string;
+  reduced: boolean;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "relative flex items-center justify-center p-6 md:p-8",
+        className,
+      )}
+    >
+      <BareSceneProvider value={{ cycle, reduced }}>
+        <div
+          key={playKey}
+          className={cn(
+            "flex w-full items-center justify-center [&>*]:min-w-0",
+            reduced ? "" : "learn-scene-in",
+          )}
+        >
+          {scene}
+        </div>
+      </BareSceneProvider>
+    </div>
+  );
+}
+
+/** The bottom code drawer inside a stage card — header (lang + copy + close) +
+ * scrollable highlighted source. */
+function CodeContainer({
+  lang,
+  formatted,
+  onClose,
+  open,
+}: {
+  lang: string;
+  formatted: string;
+  onClose: () => void;
+  open: boolean;
+}) {
+  return (
+    <div
+      // Always mounted so the grid-row height can animate; `inert` when closed
+      // keeps it out of focus/AT while collapsed to 0px. Content fades + comes
+      // into focus as the drawer opens (materialize, not a hard wipe).
+      inert={!open}
+      className={cn(
+        "flex min-h-0 flex-col overflow-hidden border-fd-border border-t bg-fd-card transition-[opacity,filter] duration-[440ms] ease-[cubic-bezier(0.33,1,0.68,1)] motion-reduce:transition-none",
+        open ? "opacity-100 blur-0" : "opacity-0 blur-[6px]",
+      )}
+    >
+      <div className="flex items-center gap-2 border-fd-border/60 border-b px-3 py-1.5">
+        <span className="font-mono text-[11px] text-fd-muted-foreground uppercase tracking-wider">
+          {lang}
+        </span>
+        <div className="ms-auto flex items-center gap-1">
+          <CopyButton value={formatted} className="rounded-[8px]" />
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Hide code"
+            className="inline-flex size-7 items-center justify-center rounded-[8px] text-fd-muted-foreground transition-colors hover:bg-[var(--muted)] hover:text-[var(--foreground)]"
+          >
+            <X className="size-4" aria-hidden="true" />
+          </button>
+        </div>
+      </div>
+      <div className="min-h-0 flex-1 overflow-auto">
+        <DynamicCodeBlock
+          lang={lang}
+          code={formatted}
+          codeblock={{
+            allowCopy: false,
+            className: "my-0 h-full rounded-none border-0 shadow-none",
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+/** One self-contained, non-sticky chapter card — the mobile layout. Height is
+ * dynamic (min-height + grows with content) so nothing is clipped. */
+function MobileChapter({
+  chapter,
+  index,
+  total,
+  reduced,
+}: {
+  chapter: PlayerChapter;
+  index: number;
+  total: number;
+  reduced: boolean;
+}) {
+  const [codeOpen, setCodeOpen] = useState(false);
+  const [cycle, setCycle] = useState(0);
+  const [plays, setPlays] = useState(0);
+  const ref = useRef<HTMLElement>(null);
+  const formatted = useFormattedCode(chapter.code, chapter.lang);
+  const hasCode = !chapter.isResult && Boolean(chapter.code);
+
+  // Play the scene once, when the card scrolls into view.
+  useEffect(() => {
+    const el = ref.current;
+    if (reduced || !el || typeof IntersectionObserver === "undefined") {
+      setCycle((c) => (c === 0 ? 1 : c));
+      return;
+    }
+    const io = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setCycle((c) => (c === 0 ? 1 : c));
+          io.disconnect();
+        }
+      },
+      { rootMargin: "0px 0px -20% 0px" },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [reduced]);
+
+  return (
+    <section ref={ref} className="mb-12">
+      <div
+        className={cn(STAGE_CARD, "min-h-[360px]")}
+        style={stageRows(hasCode, codeOpen, "auto", CODE_H_MOBILE, reduced)}
+      >
+        <BorderBeam play={plays} />
+        <div className={BAR}>
+          <span className={COUNTER}>
+            {pad(index + 1)}
+            <span className="text-fd-muted-foreground/50">/{pad(total)}</span>
+          </span>
+          <span className="min-w-0 truncate font-medium text-[13px] text-[var(--foreground)]">
+            {chapter.isResult ? "Result" : chapter.label}
+          </span>
+          <div className="ms-auto flex items-center gap-1.5">
+            {hasCode ? (
+              <CodeToggle
+                open={codeOpen}
+                onClick={() => setCodeOpen((o) => !o)}
+              />
+            ) : null}
+            {chapter.isResult ? null : (
+              <ReplayButton onReplay={() => setPlays((p) => p + 1)} />
+            )}
+          </div>
+        </div>
+        <SceneCanvas
+          scene={chapter.scene}
+          cycle={cycle}
+          playKey={`${cycle}-${plays}`}
+          reduced={reduced}
+          className="min-h-0 overflow-hidden"
+        />
+        {hasCode ? (
+          <CodeContainer
+            lang={chapter.lang}
+            formatted={formatted}
+            onClose={() => setCodeOpen(false)}
+            open={codeOpen}
+          />
+        ) : null}
+      </div>
+      <div className="mt-4">
+        <div className={STEP_TITLE}>
+          <span className="font-mono text-fd-muted-foreground/60 text-sm tabular-nums">
+            {pad(index + 1)}
+          </span>
+          <h2>{chapter.label}</h2>
+        </div>
+        <div className="learn-step-prose mt-3">{chapter.prose}</div>
+      </div>
+    </section>
+  );
+}
+
+/**
+ * Scroll-driven Learn article.
+ *
+ * Desktop (md+): a two-column read — the chapter texts scroll in the LEFT
+ * column while the preview card pins on the RIGHT (`position: sticky`, aligned
+ * under the breadcrumb). Whichever text step crosses the read-line swaps the
+ * pinned preview's scene. A `</>` toggle opens a bottom code container inside
+ * the card (collapsed by default).
+ *
+ * Mobile: a plain vertical stack of self-contained chapter cards (dynamic
+ * height), each with its own scene + `</>` code toggle + text.
+ *
+ * Title + description come from `LearnPlayerProvider`. Supporting sections
+ * (Accessibility, Motion Score) render as full-width MDX prose after this.
+ */
+export function LearnPlayerClient({ chapters }: { chapters: PlayerChapter[] }) {
+  const meta = useLearnMeta();
+  const [active, setActive] = useState(0);
+  const [codeOpen, setCodeOpen] = useState(false);
+  // Bumped only on a manual replay — drives the border beam + a fresh scene key.
+  const [plays, setPlays] = useState(0);
+  const reduced = usePrefersReducedMotion();
+  const stepEls = useRef<(HTMLElement | null)[]>([]);
+  const inView = useRef<Set<number>>(new Set());
+
+  const chapter = chapters[active];
+  const hasCode = !chapter.isResult && Boolean(chapter.code);
+  const last = chapters.length - 1;
+  const formatted = useFormattedCode(chapter.code, chapter.lang);
+
+  // Scroll drives the active chapter: whichever left-column text step is
+  // crossing the read-line wins. `max` so scrolling down advances to the later
+  // step and scrolling up releases it.
+  useEffect(() => {
+    const els = stepEls.current.filter(Boolean) as HTMLElement[];
+    if (!els.length || typeof IntersectionObserver === "undefined") return;
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const e of entries) {
+          const idx = Number((e.target as HTMLElement).dataset.step);
+          if (e.isIntersecting) inView.current.add(idx);
+          else inView.current.delete(idx);
+        }
+        if (inView.current.size) setActive(Math.max(...inView.current));
+      },
+      { rootMargin: "-24% 0px -52% 0px", threshold: 0 },
+    );
+    for (const el of els) io.observe(el);
+    return () => io.disconnect();
+  }, []);
+
+  // Land the step's title just under the header (desktop two-column read).
+  const goto = (i: number) => {
+    const el = stepEls.current[i];
+    if (!el) return;
+    setActive(i);
+    const y = el.getBoundingClientRect().top + window.scrollY - 76;
+    window.scrollTo({ top: y, behavior: reduced ? "auto" : "smooth" });
+  };
+  const replay = () => setPlays((p) => p + 1);
+
+  return (
+    <div className="not-prose">
+      {/* biome-ignore lint/security/noDangerouslySetInnerHtml: static keyframes, no user input */}
+      <style dangerouslySetInnerHTML={{ __html: PLAYER_CSS }} />
+
+      {/* Desktop: text (left) scrolls, preview (right) pins under the breadcrumb. */}
+      <div className="hidden lg:grid lg:grid-cols-[minmax(0,1fr)_minmax(0,1.15fr)] lg:items-start lg:gap-10">
+        {/* Text column. */}
+        <div className="min-w-0">
+          {meta ? (
+            <header className="flex flex-col pt-1 pb-[8svh]">
+              <h1 className="text-balance font-semibold text-3xl text-[var(--foreground)] tracking-tight">
+                {meta.title}
+              </h1>
+              {meta.description ? (
+                <p className="mt-4 text-pretty text-fd-muted-foreground text-lg leading-relaxed">
+                  {meta.description}
+                </p>
+              ) : null}
+              <p className="mt-8 inline-flex items-center gap-2 font-medium text-fd-muted-foreground text-xs uppercase tracking-wider">
+                <span className="motion-safe:animate-bounce">↓</span>
+                Scroll to step through it
+              </p>
+            </header>
+          ) : null}
+
+          {chapters.map((c, i) => (
+            <section
+              // biome-ignore lint/suspicious/noArrayIndexKey: fixed authored order
+              key={i}
+              data-step={i}
+              ref={(el) => {
+                stepEls.current[i] = el;
+              }}
+              className={cn(
+                "flex flex-col justify-start border-fd-border/60 border-t pt-[5svh] transition-opacity duration-500 first:border-t-0 motion-reduce:transition-none",
+                // Last step matches the sticky stage height so the title can
+                // reach the card top — then the stage unpins and post-player
+                // sections (Motion Score) scroll in. Earlier steps keep a
+                // shorter reading window + bottom gap before the next title.
+                i === last
+                  ? "min-h-[calc(100svh-var(--fd-docs-row-1,3.5rem)-2rem)] pb-0"
+                  : "min-h-[66svh] pb-[11svh]",
+                i === active ? "opacity-100" : "opacity-45",
+              )}
+            >
+              <div className={STEP_TITLE}>
+                <span className="font-mono text-fd-muted-foreground/60 text-sm tabular-nums">
+                  {pad(i + 1)}
+                </span>
+                <h2>{c.label}</h2>
+              </div>
+              <div className="learn-step-prose mt-4">{c.prose}</div>
+            </section>
+          ))}
+        </div>
+
+        {/* Preview column — pinned. Pulled up to sit at the sticky position
+            (aligned with the breadcrumb row) from the start, not below it. */}
+        <div className="sticky top-[var(--fd-docs-row-1,3.5rem)] z-20 self-start pt-3 lg:-mt-[3.25rem]">
+          <div
+            className={cn(
+              STAGE_CARD,
+              "h-[calc(100svh-var(--fd-docs-row-1,3.5rem)-2rem)] min-h-[420px]",
+            )}
+            style={stageRows(
+              hasCode,
+              codeOpen,
+              "minmax(0, 1fr)",
+              CODE_H_DESKTOP,
+              reduced,
+            )}
+          >
+            <BorderBeam play={plays} />
+            <div className={BAR}>
+              <span className={COUNTER}>
+                {pad(active + 1)}
+                <span className="text-fd-muted-foreground/50">
+                  /{pad(chapters.length)}
+                </span>
+              </span>
+              <span className="hidden min-w-0 truncate font-medium text-[13px] text-[var(--foreground)] lg:inline">
+                {chapter.isResult ? "Result" : chapter.label}
+              </span>
+              <div className="ms-auto flex items-center gap-1.5">
+                <div className="mr-1 hidden items-center lg:flex">
+                  {chapters.map((c, i) => (
+                    <StepDot
+                      key={c.label}
+                      index={i}
+                      active={i === active}
+                      onClick={() => goto(i)}
+                    />
+                  ))}
+                </div>
+                <button
+                  type="button"
+                  aria-label="Previous chapter"
+                  disabled={active === 0}
+                  onClick={() => goto(Math.max(0, active - 1))}
+                  className={NAV_BTN}
+                >
+                  <ChevronLeft className="size-4" aria-hidden="true" />
+                </button>
+                <button
+                  type="button"
+                  aria-label="Next chapter"
+                  disabled={active === last}
+                  onClick={() => goto(Math.min(last, active + 1))}
+                  className={NAV_BTN}
+                >
+                  <ChevronRight className="size-4" aria-hidden="true" />
+                </button>
+                {hasCode ? (
+                  <CodeToggle
+                    open={codeOpen}
+                    onClick={() => setCodeOpen((o) => !o)}
+                  />
+                ) : null}
+                {chapter.isResult ? null : <ReplayButton onReplay={replay} />}
+              </div>
+            </div>
+            <SceneCanvas
+              scene={chapter.scene}
+              cycle={plays}
+              playKey={`${active}-${plays}`}
+              reduced={reduced}
+              className="min-h-0 overflow-hidden"
+            />
+            {hasCode ? (
+              <CodeContainer
+                lang={chapter.lang}
+                formatted={formatted}
+                onClose={() => setCodeOpen(false)}
+                open={codeOpen}
+              />
+            ) : null}
+          </div>
+        </div>
+      </div>
+
+      {/* Mobile + tablet: a plain stack of self-contained chapter cards. */}
+      <div className="lg:hidden">
+        {meta ? (
+          <header className="pt-[2svh] pb-8">
+            <h1 className="text-balance font-semibold text-3xl text-[var(--foreground)] tracking-tight">
+              {meta.title}
+            </h1>
+            {meta.description ? (
+              <p className="mt-4 text-pretty text-fd-muted-foreground text-lg leading-relaxed">
+                {meta.description}
+              </p>
+            ) : null}
+          </header>
+        ) : null}
+        {chapters.map((c, i) => (
+          <MobileChapter
+            // biome-ignore lint/suspicious/noArrayIndexKey: fixed authored order
+            key={i}
+            chapter={c}
+            index={i}
+            total={chapters.length}
+            reduced={reduced}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/docs/src/components/learn/learn-player-client.tsx
+++ b/apps/docs/src/components/learn/learn-player-client.tsx
@@ -96,23 +96,30 @@ const STEP_TITLE =
   "flex items-baseline gap-3 [&>h2]:text-balance [&>h2]:font-semibold [&>h2]:text-2xl [&>h2]:text-[var(--foreground)] [&>h2]:tracking-tight";
 
 /** Prettier-formats a chapter's code; seeds with the raw source so there's no
- * empty flash before prettier resolves. */
+ * empty flash before prettier resolves. Empty / chapter switches derive the
+ * seed during render — no sync setState in the effect. */
 function useFormattedCode(code: string | undefined, lang: string) {
-  const [formatted, setFormatted] = useState(() => code?.trim() ?? "");
+  const seed = code?.trim() ?? "";
+  const [pretty, setPretty] = useState<{
+    source: string;
+    value: string;
+  } | null>(null);
+
   useEffect(() => {
-    if (!code) {
-      setFormatted("");
-      return;
-    }
+    if (!code) return;
     let alive = true;
-    void formatCode(code, lang).then((next) => {
-      if (alive) setFormatted(next);
+    const source = code;
+    void formatCode(source, lang).then((next) => {
+      if (alive) setPretty({ source, value: next });
     });
     return () => {
       alive = false;
     };
   }, [code, lang]);
-  return formatted;
+
+  if (!code) return "";
+  if (pretty?.source === code) return pretty.value;
+  return seed;
 }
 
 function StepDot({

--- a/apps/docs/src/components/learn/learn-player-context.tsx
+++ b/apps/docs/src/components/learn/learn-player-context.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { createContext, type ReactNode, useContext } from "react";
+
+/**
+ * Page-level metadata the MDX body doesn't own. Set by the docs page and read by
+ * <LearnPlayer> so it can render the article title + description *below* the
+ * pinned preview (instead of the default position above the body).
+ */
+export type LearnMeta = {
+  title: string;
+  description?: string;
+};
+
+const LearnMetaContext = createContext<LearnMeta | null>(null);
+
+export function LearnPlayerProvider({
+  value,
+  children,
+}: {
+  value: LearnMeta;
+  children: ReactNode;
+}) {
+  return (
+    <LearnMetaContext.Provider value={value}>
+      {children}
+    </LearnMetaContext.Provider>
+  );
+}
+
+/** Returns the article meta, or null when rendered outside a provider. */
+export function useLearnMeta(): LearnMeta | null {
+  return useContext(LearnMetaContext);
+}

--- a/apps/docs/src/components/learn/learn-player.tsx
+++ b/apps/docs/src/components/learn/learn-player.tsx
@@ -1,0 +1,40 @@
+import { Children, isValidElement, type ReactNode } from "react";
+import {
+  LearnChapter,
+  type LearnChapterProps,
+} from "@/components/learn/learn-chapter";
+import { LearnPlayerClient } from "@/components/learn/learn-player-client";
+
+/**
+ * Server-side entry for the stage-first Learn layout. It partitions its MDX
+ * children — every <LearnChapter> becomes a carousel step — then hands the
+ * split to the interactive client shell. Prose (the chapter's children) and the
+ * scene element both cross the server → client boundary intact.
+ *
+ * The partition MUST happen here (a server component): MDX creates <LearnChapter>
+ * from the same reference this module imports, so `child.type === LearnChapter`
+ * matches. Across the boundary that identity is lost, so partitioning inside the
+ * client shell would find zero chapters.
+ */
+export function LearnPlayer({ children }: { children: ReactNode }) {
+  const chapters: LearnChapterProps[] = [];
+
+  for (const child of Children.toArray(children)) {
+    if (isValidElement(child) && child.type === LearnChapter) {
+      chapters.push(child.props as LearnChapterProps);
+    }
+  }
+
+  return (
+    <LearnPlayerClient
+      chapters={chapters.map((c) => ({
+        label: c.label,
+        scene: c.scene,
+        code: c.code,
+        lang: c.lang ?? "tsx",
+        isResult: c.isResult ?? false,
+        prose: c.children,
+      }))}
+    />
+  );
+}

--- a/apps/docs/src/components/learn/light-rays-result.tsx
+++ b/apps/docs/src/components/learn/light-rays-result.tsx
@@ -1,12 +1,44 @@
 "use client";
 
 import { LightRays } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
+
+/**
+ * The live LightRays demo — no card chrome. Rendered on the shared
+ * `LearnPlayer` stage as the final chapter, and reused inside the full card
+ * return below.
+ */
+function LightRaysResultBody() {
+  return (
+    <div className="relative min-h-[340px] w-full overflow-hidden bg-[var(--background)] md:min-h-[400px]">
+      <LightRays
+        rayCount={14}
+        intensity={0.65}
+        angle={0}
+        speed={1}
+        grain={0.12}
+      />
+      <div className="relative z-raised flex min-h-[340px] flex-col items-center justify-center gap-3 md:min-h-[400px]">
+        <div className="h-3 w-36 rounded-full bg-[var(--foreground)]/35" />
+        <div className="h-2 w-48 rounded-full bg-[var(--foreground)]/18" />
+      </div>
+    </div>
+  );
+}
 
 /**
  * Live LightRays with a slightly stronger grain so the film layer from the
  * article is actually visible in the Result panel.
  */
 export function LightRaysResult() {
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        <LightRaysResultBody />
+      </div>
+    );
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -17,19 +49,7 @@ export function LightRaysResult() {
           the real component — watch the fan breathe
         </span>
       </div>
-      <div className="relative min-h-[340px] overflow-hidden bg-[var(--background)] md:min-h-[400px]">
-        <LightRays
-          rayCount={14}
-          intensity={0.65}
-          angle={0}
-          speed={1}
-          grain={0.12}
-        />
-        <div className="relative z-raised flex min-h-[340px] flex-col items-center justify-center gap-3 md:min-h-[400px]">
-          <div className="h-3 w-36 rounded-full bg-[var(--foreground)]/35" />
-          <div className="h-2 w-48 rounded-full bg-[var(--foreground)]/18" />
-        </div>
-      </div>
+      <LightRaysResultBody />
     </div>
   );
 }

--- a/apps/docs/src/components/learn/liquid-glass-card-result.tsx
+++ b/apps/docs/src/components/learn/liquid-glass-card-result.tsx
@@ -1,6 +1,34 @@
 "use client";
 
 import { LiquidGlassCard } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
+
+/**
+ * The live card over its busy *neutral* backdrop — the interactive demo, with
+ * no card chrome. Shared by the standalone panel and the `LearnPlayer` stage.
+ */
+function LiquidGlassCardDemo() {
+  return (
+    <div
+      className="relative flex min-h-[320px] w-full items-center justify-center overflow-hidden bg-[var(--muted)] p-8 md:min-h-[380px]"
+      style={{
+        backgroundImage:
+          "radial-gradient(circle at 30% 25%, color-mix(in oklab, var(--foreground) 14%, transparent), transparent 42%), radial-gradient(circle at 75% 70%, color-mix(in oklab, var(--foreground) 10%, transparent), transparent 40%), linear-gradient(to right, color-mix(in oklab, var(--foreground) 8%, transparent) 1px, transparent 1px), linear-gradient(to bottom, color-mix(in oklab, var(--foreground) 8%, transparent) 1px, transparent 1px)",
+        backgroundSize: "auto, auto, 28px 28px, 28px 28px",
+      }}
+    >
+      <LiquidGlassCard className="relative w-80 p-8" radius={28} sheen={0.55}>
+        <div className="h-2.5 w-28 rounded-full bg-[var(--foreground)]/50" />
+        <div className="mt-4 h-2 w-full rounded-full bg-[var(--foreground)]/25" />
+        <div className="mt-2 h-2 w-[80%] rounded-full bg-[var(--foreground)]/18" />
+        <div className="mt-6 flex gap-2">
+          <div className="h-8 w-20 rounded-lg bg-[var(--foreground)]/15" />
+          <div className="h-8 w-8 rounded-lg bg-[var(--foreground)]/10" />
+        </div>
+      </LiquidGlassCard>
+    </div>
+  );
+}
 
 /**
  * Live card over a busy *neutral* backdrop — contrast + grid so refraction
@@ -8,6 +36,14 @@ import { LiquidGlassCard } from "@godui/components";
  * only when the subject needs it; glass needs structure behind it, not hue.
  */
 export function LiquidGlassCardResult() {
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // demo only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        <LiquidGlassCardDemo />
+      </div>
+    );
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -18,24 +54,7 @@ export function LiquidGlassCardResult() {
           the real component — move across the panel
         </span>
       </div>
-      <div
-        className="relative flex min-h-[320px] items-center justify-center overflow-hidden bg-[var(--muted)] p-8 md:min-h-[380px]"
-        style={{
-          backgroundImage:
-            "radial-gradient(circle at 30% 25%, color-mix(in oklab, var(--foreground) 14%, transparent), transparent 42%), radial-gradient(circle at 75% 70%, color-mix(in oklab, var(--foreground) 10%, transparent), transparent 40%), linear-gradient(to right, color-mix(in oklab, var(--foreground) 8%, transparent) 1px, transparent 1px), linear-gradient(to bottom, color-mix(in oklab, var(--foreground) 8%, transparent) 1px, transparent 1px)",
-          backgroundSize: "auto, auto, 28px 28px, 28px 28px",
-        }}
-      >
-        <LiquidGlassCard className="relative w-80 p-8" radius={28} sheen={0.55}>
-          <div className="h-2.5 w-28 rounded-full bg-[var(--foreground)]/50" />
-          <div className="mt-4 h-2 w-full rounded-full bg-[var(--foreground)]/25" />
-          <div className="mt-2 h-2 w-[80%] rounded-full bg-[var(--foreground)]/18" />
-          <div className="mt-6 flex gap-2">
-            <div className="h-8 w-20 rounded-lg bg-[var(--foreground)]/15" />
-            <div className="h-8 w-8 rounded-lg bg-[var(--foreground)]/10" />
-          </div>
-        </LiquidGlassCard>
-      </div>
+      <LiquidGlassCardDemo />
     </div>
   );
 }

--- a/apps/docs/src/components/learn/liquid-glass-lens-result.tsx
+++ b/apps/docs/src/components/learn/liquid-glass-lens-result.tsx
@@ -1,12 +1,41 @@
 "use client";
 
 import { LiquidGlassLens } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Live lens over a neutral structured stage — enough contrast for refraction,
  * no brand-colored conic.
  */
 export function LiquidGlassLensResult() {
+  const demo = (
+    <div
+      className="relative flex min-h-[320px] w-full items-center justify-center overflow-hidden bg-[var(--muted)] p-10 md:min-h-[380px]"
+      style={{
+        backgroundImage:
+          "radial-gradient(circle at 70% 20%, color-mix(in oklab, var(--foreground) 12%, transparent), transparent 40%), linear-gradient(to right, color-mix(in oklab, var(--foreground) 8%, transparent) 1px, transparent 1px), linear-gradient(to bottom, color-mix(in oklab, var(--foreground) 8%, transparent) 1px, transparent 1px)",
+        backgroundSize: "auto, 28px 28px, 28px 28px",
+      }}
+    >
+      <div className="relative z-raised max-w-sm space-y-4 text-center">
+        <div className="mx-auto h-3 w-40 rounded-full bg-[var(--foreground)]/45" />
+        <div className="mx-auto h-2 w-full rounded-full bg-[var(--foreground)]/22" />
+        <div className="mx-auto h-2 w-[80%] rounded-full bg-[var(--foreground)]/15" />
+        <div className="mx-auto h-2 w-[60%] rounded-full bg-[var(--foreground)]/12" />
+      </div>
+      <LiquidGlassLens size={220} strength={80} sheen={0.5} />
+    </div>
+  );
+
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -17,22 +46,7 @@ export function LiquidGlassLensResult() {
           the real component — hover the stage
         </span>
       </div>
-      <div
-        className="relative flex min-h-[320px] items-center justify-center overflow-hidden bg-[var(--muted)] p-10 md:min-h-[380px]"
-        style={{
-          backgroundImage:
-            "radial-gradient(circle at 70% 20%, color-mix(in oklab, var(--foreground) 12%, transparent), transparent 40%), linear-gradient(to right, color-mix(in oklab, var(--foreground) 8%, transparent) 1px, transparent 1px), linear-gradient(to bottom, color-mix(in oklab, var(--foreground) 8%, transparent) 1px, transparent 1px)",
-          backgroundSize: "auto, 28px 28px, 28px 28px",
-        }}
-      >
-        <div className="relative z-raised max-w-sm space-y-4 text-center">
-          <div className="mx-auto h-3 w-40 rounded-full bg-[var(--foreground)]/45" />
-          <div className="mx-auto h-2 w-full rounded-full bg-[var(--foreground)]/22" />
-          <div className="mx-auto h-2 w-[80%] rounded-full bg-[var(--foreground)]/15" />
-          <div className="mx-auto h-2 w-[60%] rounded-full bg-[var(--foreground)]/12" />
-        </div>
-        <LiquidGlassLens size={220} strength={80} sheen={0.5} />
-      </div>
+      {demo}
     </div>
   );
 }

--- a/apps/docs/src/components/learn/liquid-image-result.tsx
+++ b/apps/docs/src/components/learn/liquid-image-result.tsx
@@ -1,12 +1,41 @@
 "use client";
 
 import { LiquidImage } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
+
+const Demo = () => (
+  <div className="grid w-full max-w-md grid-cols-2 gap-4 sm:grid-cols-3">
+    <LiquidImage
+      src="https://picsum.photos/id/1018/640/640"
+      alt="Mountain landscape"
+      className="aspect-square w-full shadow-lg"
+    />
+    <LiquidImage
+      src="https://picsum.photos/id/1015/640/640"
+      alt="River valley"
+      className="aspect-square w-full shadow-lg"
+    />
+    <LiquidImage
+      src="https://picsum.photos/id/1039/640/640"
+      alt="Waterfall"
+      className="col-span-2 aspect-square w-full shadow-lg sm:col-span-1"
+    />
+  </div>
+);
 
 /**
  * Closing panel — real `LiquidImage` tiles so the reader can hover and feel
  * the displacement lerp + velocity boost the article described.
  */
 export function LiquidImageResult() {
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        <Demo />
+      </div>
+    );
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -18,23 +47,7 @@ export function LiquidImageResult() {
         </span>
       </div>
       <div className="flex min-h-[280px] items-center justify-center p-6 md:p-10">
-        <div className="grid w-full max-w-md grid-cols-2 gap-4 sm:grid-cols-3">
-          <LiquidImage
-            src="https://picsum.photos/id/1018/640/640"
-            alt="Mountain landscape"
-            className="aspect-square w-full shadow-lg"
-          />
-          <LiquidImage
-            src="https://picsum.photos/id/1015/640/640"
-            alt="River valley"
-            className="aspect-square w-full shadow-lg"
-          />
-          <LiquidImage
-            src="https://picsum.photos/id/1039/640/640"
-            alt="Waterfall"
-            className="col-span-2 aspect-square w-full shadow-lg sm:col-span-1"
-          />
-        </div>
+        <Demo />
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/liquid-metaballs-result.tsx
+++ b/apps/docs/src/components/learn/liquid-metaballs-result.tsx
@@ -1,8 +1,24 @@
 "use client";
 
 import { LiquidMetaballs } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 export function LiquidMetaballsResult() {
+  const demo = (
+    <div className="relative min-h-[320px] w-full overflow-hidden md:min-h-[380px]">
+      <LiquidMetaballs blobCount={7} gooeyness={16} speed={1} interactive />
+    </div>
+  );
+
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -13,9 +29,7 @@ export function LiquidMetaballsResult() {
           the real component — move to merge
         </span>
       </div>
-      <div className="relative min-h-[320px] overflow-hidden md:min-h-[380px]">
-        <LiquidMetaballs blobCount={7} gooeyness={16} speed={1} interactive />
-      </div>
+      {demo}
     </div>
   );
 }

--- a/apps/docs/src/components/learn/live-cursors-result.tsx
+++ b/apps/docs/src/components/learn/live-cursors-result.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { SimulatedCursors } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — `SimulatedCursors` driving
@@ -8,6 +9,18 @@ import { SimulatedCursors } from "@godui/components";
  * component page's own demo uses for a hands-free preview.
  */
 export function LiveCursorsResult() {
+  const demo = (
+    <div className="relative h-full w-full overflow-hidden rounded-xl bg-[var(--muted)]/40">
+      <SimulatedCursors names={["Ana", "Marco", "Priya"]} />
+    </div>
+  );
+
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene()) {
+    return <div className="relative h-[280px] w-full p-6">{demo}</div>;
+  }
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -18,11 +31,7 @@ export function LiveCursorsResult() {
           the real component — self-driving peers
         </span>
       </div>
-      <div className="relative h-[280px] p-6">
-        <div className="relative h-full w-full overflow-hidden rounded-xl bg-[var(--muted)]/40">
-          <SimulatedCursors names={["Ana", "Marco", "Priya"]} />
-        </div>
-      </div>
+      <div className="relative h-[280px] p-6">{demo}</div>
     </div>
   );
 }

--- a/apps/docs/src/components/learn/magic-input-result.tsx
+++ b/apps/docs/src/components/learn/magic-input-result.tsx
@@ -1,6 +1,26 @@
 "use client";
 
 import { MagicInput } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
+
+/**
+ * The real, interactive Magic Input — no card chrome. Rendered on the shared
+ * `LearnPlayer` stage as the final chapter.
+ */
+export function MagicInputResultBody() {
+  return (
+    <div className="flex w-full max-w-xs flex-col gap-6">
+      <MagicInput placeholder="Focus me" submitButton />
+      <MagicInput rainbow={false} placeholder="Primary edge" />
+      <MagicInput
+        variant="secondary"
+        rainbow={false}
+        depth="always"
+        placeholder="Always raised"
+      />
+    </div>
+  );
+}
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive Magic
@@ -8,6 +28,14 @@ import { MagicInput } from "@godui/components";
  * to lift it, watch the rainbow edge, submit to run the progress lifecycle.
  */
 export function MagicInputResult() {
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        <MagicInputResultBody />
+      </div>
+    );
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -19,16 +47,7 @@ export function MagicInputResult() {
         </span>
       </div>
       <div className="flex min-h-[240px] items-center justify-center p-10">
-        <div className="flex w-full max-w-xs flex-col gap-6">
-          <MagicInput placeholder="Focus me" submitButton />
-          <MagicInput rainbow={false} placeholder="Primary edge" />
-          <MagicInput
-            variant="secondary"
-            rainbow={false}
-            depth="always"
-            placeholder="Always raised"
-          />
-        </div>
+        <MagicInputResultBody />
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/magic-tab-result.tsx
+++ b/apps/docs/src/components/learn/magic-tab-result.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { MagicTab, type MagicTabItem } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 const ITEMS: MagicTabItem[] = [
   { value: "overview", label: "Overview" },
@@ -15,6 +16,19 @@ const ITEMS: MagicTabItem[] = [
  * selected tab.
  */
 export function MagicTabResult() {
+  const demo = (
+    <>
+      <MagicTab items={ITEMS} defaultValue="overview" rainbow />
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[240px] items-center justify-center p-6 w-full">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -26,7 +40,7 @@ export function MagicTabResult() {
         </span>
       </div>
       <div className="flex min-h-[240px] items-center justify-center p-10">
-        <MagicTab items={ITEMS} defaultValue="overview" rainbow />
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/magnetic-result.tsx
+++ b/apps/docs/src/components/learn/magnetic-result.tsx
@@ -2,15 +2,53 @@
 
 import { MagneticButton } from "@godui/components";
 import type { CSSProperties } from "react";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 const SENSOR_RANGE = 32;
 
 /**
+ * The real, interactive MagneticButton set — no card chrome. One instance gets a
+ * dashed overlay the width of `range` so the invisible sensor (normally 0px) is
+ * visible while you move the cursor. Rendered on the shared `LearnPlayer` stage
+ * as the final chapter.
+ */
+export function MagneticResultBody() {
+  return (
+    <div className="flex min-h-[240px] flex-wrap items-center justify-center gap-10 p-10">
+      <div className="relative inline-flex">
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute rounded-[16px] border border-dashed border-fd-border/70"
+          style={{ inset: -SENSOR_RANGE } as CSSProperties}
+        />
+        <MagneticButton size="lg" range={SENSOR_RANGE}>
+          Sensor range={SENSOR_RANGE}
+        </MagneticButton>
+      </div>
+      <MagneticButton variant="secondary" size="lg" strength={0.8}>
+        strength=0.8
+      </MagneticButton>
+      <MagneticButton variant="outline" size="lg" staticLabel>
+        staticLabel
+      </MagneticButton>
+    </div>
+  );
+}
+
+/**
  * Closing "here's the finished thing" panel — the real, interactive
- * MagneticButton. One instance gets a dashed overlay the width of `range` so
- * the invisible sensor (normally 0px) is visible while you move the cursor.
+ * MagneticButton set so the reader can feel every mechanism the article just
+ * pulled apart.
  */
 export function MagneticResult() {
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        <MagneticResultBody />
+      </div>
+    );
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -21,24 +59,7 @@ export function MagneticResult() {
           the real component — move the cursor near each button
         </span>
       </div>
-      <div className="flex min-h-[240px] flex-wrap items-center justify-center gap-10 p-10">
-        <div className="relative inline-flex">
-          <span
-            aria-hidden="true"
-            className="pointer-events-none absolute rounded-[16px] border border-dashed border-fd-border/70"
-            style={{ inset: -SENSOR_RANGE } as CSSProperties}
-          />
-          <MagneticButton size="lg" range={SENSOR_RANGE}>
-            Sensor range={SENSOR_RANGE}
-          </MagneticButton>
-        </div>
-        <MagneticButton variant="secondary" size="lg" strength={0.8}>
-          strength=0.8
-        </MagneticButton>
-        <MagneticButton variant="outline" size="lg" staticLabel>
-          staticLabel
-        </MagneticButton>
-      </div>
+      <MagneticResultBody />
     </div>
   );
 }

--- a/apps/docs/src/components/learn/marquee-result.tsx
+++ b/apps/docs/src/components/learn/marquee-result.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Marquee } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing panel — the real Marquee with token-bar stand-ins (no brand copy
@@ -9,7 +10,30 @@ import { Marquee } from "@godui/components";
 
 const CELLS = [0, 1, 2, 3, 4, 5, 6, 7] as const;
 
+function MarqueeResultDemo() {
+  return (
+    <Marquee speed={28} className="w-full">
+      {CELLS.map((i) => (
+        <span
+          key={i}
+          className="flex h-12 w-28 items-center justify-center rounded-lg border border-border bg-card shadow-sm"
+        >
+          <span className="h-2 w-14 rounded-full bg-foreground/25" />
+        </span>
+      ))}
+    </Marquee>
+  );
+}
+
 export function MarqueeResult() {
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        <MarqueeResultDemo />
+      </div>
+    );
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -21,16 +45,7 @@ export function MarqueeResult() {
         </span>
       </div>
       <div className="flex min-h-[200px] items-center justify-center py-10">
-        <Marquee speed={28} className="w-full">
-          {CELLS.map((i) => (
-            <span
-              key={i}
-              className="flex h-12 w-28 items-center justify-center rounded-lg border border-border bg-card shadow-sm"
-            >
-              <span className="h-2 w-14 rounded-full bg-foreground/25" />
-            </span>
-          ))}
-        </Marquee>
+        <MarqueeResultDemo />
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/mask-result.tsx
+++ b/apps/docs/src/components/learn/mask-result.tsx
@@ -1,12 +1,29 @@
 "use client";
 
 import { MaskButton } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
+
+const MaskButtons = () => (
+  <>
+    <MaskButton mask="nature">Hover me</MaskButton>
+    <MaskButton mask="urban">Hover me</MaskButton>
+    <MaskButton mask="forest">Hover me</MaskButton>
+  </>
+);
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive
  * MaskButton, one per sprite. Hover or tab to each and watch the flipbook.
  */
 export function MaskResult() {
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full flex-wrap items-center justify-center gap-6 p-6">
+        <MaskButtons />
+      </div>
+    );
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -18,9 +35,7 @@ export function MaskResult() {
         </span>
       </div>
       <div className="flex min-h-[240px] flex-wrap items-center justify-center gap-6 p-10">
-        <MaskButton mask="nature">Hover me</MaskButton>
-        <MaskButton mask="urban">Hover me</MaskButton>
-        <MaskButton mask="forest">Hover me</MaskButton>
+        <MaskButtons />
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/mega-menu-result.tsx
+++ b/apps/docs/src/components/learn/mega-menu-result.tsx
@@ -9,6 +9,7 @@ import {
   Rocket,
   ShieldCheck,
 } from "lucide-react";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 const ITEMS: MegaMenuItem[] = [
   {
@@ -82,6 +83,19 @@ const ITEMS: MegaMenuItem[] = [
  * `position: absolute` and would get clipped otherwise.
  */
 export function MegaMenuResult() {
+  const demo = (
+    <>
+      <MegaMenu items={ITEMS} />
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[380px] items-start justify-center px-6 pt-8 pb-6 w-full">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-fd-border border-b px-2.5 py-2">
@@ -93,7 +107,7 @@ export function MegaMenuResult() {
         </span>
       </div>
       <div className="flex min-h-[380px] items-start justify-center px-6 pt-8 pb-6">
-        <MegaMenu items={ITEMS} />
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/morph-gallery-result.tsx
+++ b/apps/docs/src/components/learn/morph-gallery-result.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { MorphGallery } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive
@@ -17,6 +18,27 @@ const PHOTOS = [
 ];
 
 export function MorphGalleryResult() {
+  const demo = (
+    <>
+      <MorphGallery
+        columns={3}
+        className="max-w-md"
+        items={PHOTOS.map((p) => ({
+          src: `https://picsum.photos/id/${p.id}/900/900`,
+          alt: p.caption,
+          caption: p.caption,
+        }))}
+      />
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="relative flex min-h-[280px] items-center justify-center p-6 sm:p-6 w-full">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -28,15 +50,7 @@ export function MorphGalleryResult() {
         </span>
       </div>
       <div className="relative flex min-h-[280px] items-center justify-center p-6 sm:p-10">
-        <MorphGallery
-          columns={3}
-          className="max-w-md"
-          items={PHOTOS.map((p) => ({
-            src: `https://picsum.photos/id/${p.id}/900/900`,
-            alt: p.caption,
-            caption: p.caption,
-          }))}
-        />
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/morphing-dialog-result.tsx
+++ b/apps/docs/src/components/learn/morphing-dialog-result.tsx
@@ -6,6 +6,7 @@ import {
   MorphingDialogContent,
   MorphingDialogTrigger,
 } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive
@@ -14,6 +15,38 @@ import {
  * button to spring it back.
  */
 export function MorphingDialogResult() {
+  const demo = (
+    <>
+      <MorphingDialog>
+        <MorphingDialogTrigger className="w-64 rounded-2xl border border-border bg-card p-4 text-left shadow-sm [transition:box-shadow_200ms_ease] hover:shadow-md">
+          <div className="h-28 rounded-xl bg-gradient-to-br from-chart-1 to-chart-3" />
+          <div className="mt-3 font-semibold">Aurora Sessions</div>
+          <div className="text-sm text-muted-foreground">Tap to expand</div>
+        </MorphingDialogTrigger>
+
+        <MorphingDialogContent className="w-[min(92vw,28rem)] rounded-2xl">
+          <div className="h-44 bg-gradient-to-br from-chart-1 to-chart-3" />
+          <div className="p-5">
+            <div className="text-lg font-semibold">Aurora Sessions</div>
+            <p className="mt-2 text-sm text-muted-foreground">
+              The card physically morphs into this modal through a shared
+              <code className="mx-1">layoutId</code>, then springs back on
+              close.
+            </p>
+          </div>
+          <MorphingDialogClose />
+        </MorphingDialogContent>
+      </MorphingDialog>
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[260px] w-full items-center justify-center p-6">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -25,26 +58,7 @@ export function MorphingDialogResult() {
         </span>
       </div>
       <div className="flex min-h-[260px] w-full items-center justify-center p-10">
-        <MorphingDialog>
-          <MorphingDialogTrigger className="w-64 rounded-2xl border border-border bg-card p-4 text-left shadow-sm [transition:box-shadow_200ms_ease] hover:shadow-md">
-            <div className="h-28 rounded-xl bg-gradient-to-br from-chart-1 to-chart-3" />
-            <div className="mt-3 font-semibold">Aurora Sessions</div>
-            <div className="text-sm text-muted-foreground">Tap to expand</div>
-          </MorphingDialogTrigger>
-
-          <MorphingDialogContent className="w-[min(92vw,28rem)] rounded-2xl">
-            <div className="h-44 bg-gradient-to-br from-chart-1 to-chart-3" />
-            <div className="p-5">
-              <div className="text-lg font-semibold">Aurora Sessions</div>
-              <p className="mt-2 text-sm text-muted-foreground">
-                The card physically morphs into this modal through a shared
-                <code className="mx-1">layoutId</code>, then springs back on
-                close.
-              </p>
-            </div>
-            <MorphingDialogClose />
-          </MorphingDialogContent>
-        </MorphingDialog>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/notification-inbox-result.tsx
+++ b/apps/docs/src/components/learn/notification-inbox-result.tsx
@@ -3,6 +3,7 @@
 import { type Notification, NotificationInbox } from "@godui/components";
 import { GitPullRequest, MessageCircle, UserPlus } from "lucide-react";
 import { useState } from "react";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, stateful
@@ -52,6 +53,33 @@ const SEED: Notification[] = [
 
 export function NotificationInboxResult() {
   const [items, setItems] = useState(SEED);
+  const bare = useBareScene();
+
+  const demo = (
+    <NotificationInbox
+      notifications={items}
+      onRead={(id) =>
+        setItems((prev) =>
+          prev.map((n) => (n.id === id ? { ...n, read: true } : n)),
+        )
+      }
+      onArchive={(id) => setItems((prev) => prev.filter((n) => n.id !== id))}
+      onMarkAllRead={() =>
+        setItems((prev) => prev.map((n) => ({ ...n, read: true })))
+      }
+      className="max-w-sm"
+    />
+  );
+
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (bare) {
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        {demo}
+      </div>
+    );
+  }
 
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
@@ -64,21 +92,7 @@ export function NotificationInboxResult() {
         </span>
       </div>
       <div className="flex min-h-[280px] items-center justify-center p-10">
-        <NotificationInbox
-          notifications={items}
-          onRead={(id) =>
-            setItems((prev) =>
-              prev.map((n) => (n.id === id ? { ...n, read: true } : n)),
-            )
-          }
-          onArchive={(id) =>
-            setItems((prev) => prev.filter((n) => n.id !== id))
-          }
-          onMarkAllRead={() =>
-            setItems((prev) => prev.map((n) => ({ ...n, read: true })))
-          }
-          className="max-w-sm"
-        />
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/number-ticker-result.tsx
+++ b/apps/docs/src/components/learn/number-ticker-result.tsx
@@ -1,12 +1,55 @@
 "use client";
 
 import { NumberTicker } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing panel — live NumberTicker instances so the reader feels the
  * in-view spring, direction, delay, and decimal formatting in one place.
  */
 export function NumberTickerResult() {
+  const demo = (
+    <>
+      <div className="flex flex-col items-center gap-2">
+        <NumberTicker
+          value={100}
+          className="text-5xl font-bold tracking-tight"
+        />
+        <span className="font-mono text-[11px] text-fd-muted-foreground">
+          up · 0→100
+        </span>
+      </div>
+      <div className="flex flex-col items-center gap-2">
+        <NumberTicker
+          value={1984.42}
+          decimalPlaces={2}
+          className="text-5xl font-bold tracking-tight"
+        />
+        <span className="font-mono text-[11px] text-fd-muted-foreground">
+          decimals
+        </span>
+      </div>
+      <div className="flex flex-col items-center gap-2">
+        <NumberTicker
+          value={100}
+          direction="down"
+          delay={0.4}
+          className="text-5xl font-bold tracking-tight"
+        />
+        <span className="font-mono text-[11px] text-fd-muted-foreground">
+          down · delay 0.4s
+        </span>
+      </div>
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[240px] flex-wrap items-end justify-center gap-10 p-6 w-full">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -18,36 +61,7 @@ export function NumberTickerResult() {
         </span>
       </div>
       <div className="flex min-h-[240px] flex-wrap items-end justify-center gap-10 p-10">
-        <div className="flex flex-col items-center gap-2">
-          <NumberTicker
-            value={100}
-            className="text-5xl font-bold tracking-tight"
-          />
-          <span className="font-mono text-[11px] text-fd-muted-foreground">
-            up · 0→100
-          </span>
-        </div>
-        <div className="flex flex-col items-center gap-2">
-          <NumberTicker
-            value={1984.42}
-            decimalPlaces={2}
-            className="text-5xl font-bold tracking-tight"
-          />
-          <span className="font-mono text-[11px] text-fd-muted-foreground">
-            decimals
-          </span>
-        </div>
-        <div className="flex flex-col items-center gap-2">
-          <NumberTicker
-            value={100}
-            direction="down"
-            delay={0.4}
-            className="text-5xl font-bold tracking-tight"
-          />
-          <span className="font-mono text-[11px] text-fd-muted-foreground">
-            down · delay 0.4s
-          </span>
-        </div>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/orbit-carousel-result.tsx
+++ b/apps/docs/src/components/learn/orbit-carousel-result.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { OrbitCarousel } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive Orbit
@@ -31,6 +32,23 @@ function OrbitCard({ title, img }: (typeof CARDS)[number]) {
 }
 
 export function OrbitCarouselResult() {
+  const demo = (
+    <>
+      <OrbitCarousel defaultIndex={2} radius={230} angleStep={26}>
+        {CARDS.map((c) => (
+          <OrbitCard key={c.title} {...c} />
+        ))}
+      </OrbitCarousel>
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="relative flex min-h-[360px] items-center justify-center p-6 md:min-h-[420px] md:p-6 w-full">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -42,11 +60,7 @@ export function OrbitCarouselResult() {
         </span>
       </div>
       <div className="relative flex min-h-[360px] items-center justify-center p-6 md:min-h-[420px] md:p-10">
-        <OrbitCarousel defaultIndex={2} radius={230} angleStep={26}>
-          {CARDS.map((c) => (
-            <OrbitCard key={c.title} {...c} />
-          ))}
-        </OrbitCarousel>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/orbiting-circles-result.tsx
+++ b/apps/docs/src/components/learn/orbiting-circles-result.tsx
@@ -2,6 +2,7 @@
 
 import { OrbitingCircles } from "@godui/components";
 import { Box, Cloud, Cpu, Hexagon, Layers, Zap } from "lucide-react";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real `OrbitingCircles`,
@@ -16,6 +17,59 @@ function Chip({ children }: { children: React.ReactNode }) {
 }
 
 export function OrbitingCirclesResult() {
+  const demo = (
+    <>
+      <span className="pointer-events-none z-raised rounded-xl bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-md">
+        GodUI
+      </span>
+
+      <OrbitingCircles
+        className="absolute"
+        radius={70}
+        duration={18}
+        iconSize={36}
+      >
+        <Chip>
+          <Box className="size-4" />
+        </Chip>
+        <Chip>
+          <Cloud className="size-4" />
+        </Chip>
+        <Chip>
+          <Cpu className="size-4" />
+        </Chip>
+      </OrbitingCircles>
+
+      <OrbitingCircles
+        className="absolute"
+        radius={130}
+        duration={28}
+        iconSize={40}
+        reverse
+      >
+        <Chip>
+          <Hexagon className="size-5" />
+        </Chip>
+        <Chip>
+          <Layers className="size-5" />
+        </Chip>
+        <Chip>
+          <Zap className="size-5" />
+        </Chip>
+        <Chip>
+          <Box className="size-5" />
+        </Chip>
+      </OrbitingCircles>
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="relative flex h-[360px] w-full items-center justify-center">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -27,47 +81,7 @@ export function OrbitingCirclesResult() {
         </span>
       </div>
       <div className="relative flex h-[360px] w-full items-center justify-center">
-        <span className="pointer-events-none z-raised rounded-xl bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-md">
-          GodUI
-        </span>
-
-        <OrbitingCircles
-          className="absolute"
-          radius={70}
-          duration={18}
-          iconSize={36}
-        >
-          <Chip>
-            <Box className="size-4" />
-          </Chip>
-          <Chip>
-            <Cloud className="size-4" />
-          </Chip>
-          <Chip>
-            <Cpu className="size-4" />
-          </Chip>
-        </OrbitingCircles>
-
-        <OrbitingCircles
-          className="absolute"
-          radius={130}
-          duration={28}
-          iconSize={40}
-          reverse
-        >
-          <Chip>
-            <Hexagon className="size-5" />
-          </Chip>
-          <Chip>
-            <Layers className="size-5" />
-          </Chip>
-          <Chip>
-            <Zap className="size-5" />
-          </Chip>
-          <Chip>
-            <Box className="size-5" />
-          </Chip>
-        </OrbitingCircles>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/otp-result.tsx
+++ b/apps/docs/src/components/learn/otp-result.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { OTPInput } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive OTP Input.
@@ -8,6 +9,22 @@ import { OTPInput } from "@godui/components";
  * one shot, and see the masked variant render dots.
  */
 export function OtpResult() {
+  const demo = (
+    <>
+      <OTPInput length={6} />
+      <OTPInput length={6} mask />
+    </>
+  );
+
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full flex-col items-center justify-center gap-8 p-6">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -19,8 +36,7 @@ export function OtpResult() {
         </span>
       </div>
       <div className="flex min-h-[240px] flex-col items-center justify-center gap-8 p-10">
-        <OTPInput length={6} />
-        <OTPInput length={6} mask />
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/particle-dissolve-result.tsx
+++ b/apps/docs/src/components/learn/particle-dissolve-result.tsx
@@ -1,12 +1,38 @@
 "use client";
 
 import { ParticleDissolve } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
+
+/**
+ * The real, interactive `ParticleDissolve` in loop mode — no card chrome.
+ * Rendered on the shared `LearnPlayer` stage as the final chapter.
+ */
+export function ParticleDissolveResultBody() {
+  return (
+    <ParticleDissolve
+      text="GodUI"
+      mode="loop"
+      trigger="in-view"
+      width={520}
+      height={200}
+      className="max-w-full text-primary"
+    />
+  );
+}
 
 /**
  * Closing panel — real `ParticleDissolve` looping so the reader sees
  * scatter → form → disperse with per-particle delay and idle shimmer.
  */
 export function ParticleDissolveResult() {
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        <ParticleDissolveResultBody />
+      </div>
+    );
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -18,14 +44,7 @@ export function ParticleDissolveResult() {
         </span>
       </div>
       <div className="flex min-h-[280px] items-center justify-center p-6 md:p-10">
-        <ParticleDissolve
-          text="GodUI"
-          mode="loop"
-          trigger="in-view"
-          width={520}
-          height={200}
-          className="max-w-full text-primary"
-        />
+        <ParticleDissolveResultBody />
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/pixel-grid-result.tsx
+++ b/apps/docs/src/components/learn/pixel-grid-result.tsx
@@ -1,8 +1,40 @@
 "use client";
 
 import { PixelGrid } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
+
+/**
+ * The real, interactive Pixel Grid — no card chrome. Rendered on the shared
+ * `LearnPlayer` stage as the final chapter.
+ */
+export function PixelGridResultBody() {
+  return (
+    <div className="relative min-h-[300px] w-full overflow-hidden md:min-h-[360px]">
+      <PixelGrid
+        interactive
+        cursorReveal="hidden"
+        squareSize={4}
+        gridGap={6}
+        flickerChance={0.3}
+        maxOpacity={0.3}
+        interactionRadius={120}
+      />
+      <div className="pointer-events-none relative z-raised flex min-h-[300px] items-center justify-center md:min-h-[360px]">
+        <div className="h-2.5 w-32 rounded-full bg-[var(--foreground)]/30" />
+      </div>
+    </div>
+  );
+}
 
 export function PixelGridResult() {
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        <PixelGridResultBody />
+      </div>
+    );
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -13,20 +45,7 @@ export function PixelGridResult() {
           the real component — move to reveal
         </span>
       </div>
-      <div className="relative min-h-[300px] overflow-hidden md:min-h-[360px]">
-        <PixelGrid
-          interactive
-          cursorReveal="hidden"
-          squareSize={4}
-          gridGap={6}
-          flickerChance={0.3}
-          maxOpacity={0.3}
-          interactionRadius={120}
-        />
-        <div className="pointer-events-none relative z-raised flex min-h-[300px] items-center justify-center md:min-h-[360px]">
-          <div className="h-2.5 w-32 rounded-full bg-[var(--foreground)]/30" />
-        </div>
-      </div>
+      <PixelGridResultBody />
     </div>
   );
 }

--- a/apps/docs/src/components/learn/presence-facepile-result.tsx
+++ b/apps/docs/src/components/learn/presence-facepile-result.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { PresenceFacepile } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive
@@ -18,6 +19,14 @@ const USERS = [
 ];
 
 export function PresenceFacepileResult() {
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        <PresenceFacepile users={USERS} max={5} />
+      </div>
+    );
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">

--- a/apps/docs/src/components/learn/progress-fold-result.tsx
+++ b/apps/docs/src/components/learn/progress-fold-result.tsx
@@ -2,6 +2,7 @@
 
 import { ProgressFoldButton } from "@godui/components";
 import * as React from "react";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive
@@ -40,6 +41,31 @@ export function ProgressFoldResult() {
     setStatus("loading");
   };
 
+  const demo = (
+    <div className="flex min-h-[240px] flex-wrap items-center justify-center gap-6 p-10">
+      <ProgressFoldButton
+        variant="primary"
+        status={status}
+        progress={status === "loading" ? progress : undefined}
+        onClick={handleClick}
+      >
+        {status === "loading" ? "Submitting…" : "Submit"}
+      </ProgressFoldButton>
+      <ProgressFoldButton variant="secondary" status="loading">
+        Indeterminate
+      </ProgressFoldButton>
+    </div>
+  );
+
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -50,19 +76,7 @@ export function ProgressFoldResult() {
           the real component — click the left one
         </span>
       </div>
-      <div className="flex min-h-[240px] flex-wrap items-center justify-center gap-6 p-10">
-        <ProgressFoldButton
-          variant="primary"
-          status={status}
-          progress={status === "loading" ? progress : undefined}
-          onClick={handleClick}
-        >
-          {status === "loading" ? "Submitting…" : "Submit"}
-        </ProgressFoldButton>
-        <ProgressFoldButton variant="secondary" status="loading">
-          Indeterminate
-        </ProgressFoldButton>
-      </div>
+      {demo}
     </div>
   );
 }

--- a/apps/docs/src/components/learn/progressive-card-reveal-result.tsx
+++ b/apps/docs/src/components/learn/progressive-card-reveal-result.tsx
@@ -2,6 +2,7 @@
 
 import { ProgressiveCardReveal } from "@godui/components";
 import * as React from "react";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive
@@ -50,6 +51,61 @@ const LEGS: Leg[] = [
 export function ProgressiveCardRevealResult() {
   const [active, setActive] = React.useState(0);
 
+  const demo = (
+    <>
+      <ProgressiveCardReveal
+        activeIndex={active}
+        onActiveChange={setActive}
+        className="w-full max-w-[360px]"
+      >
+        {LEGS.map((leg) => (
+          <ProgressiveCardReveal.Card key={leg.label}>
+            <ProgressiveCardReveal.CardCollapsed>
+              <div className="flex items-center justify-between gap-4">
+                <span className="flex items-center gap-2 font-medium">
+                  <span aria-hidden>{leg.icon}</span>
+                  {leg.label}
+                </span>
+                <span className="text-muted-foreground text-sm">
+                  {leg.meta}
+                </span>
+              </div>
+            </ProgressiveCardReveal.CardCollapsed>
+            <ProgressiveCardReveal.CardExpanded>
+              <div className="flex flex-col gap-4">
+                <span className="flex items-center gap-2 font-medium">
+                  <span aria-hidden>{leg.icon}</span>
+                  {leg.label}
+                </span>
+                <div className="flex items-end justify-between gap-6">
+                  <div>
+                    <p className="text-muted-foreground text-xs uppercase tracking-wide">
+                      Distance
+                    </p>
+                    <p className="font-semibold text-2xl">{leg.distance}</p>
+                  </div>
+                  <div className="text-right">
+                    <p className="text-muted-foreground text-xs uppercase tracking-wide">
+                      Time
+                    </p>
+                    <p className="font-semibold text-2xl">{leg.time}</p>
+                  </div>
+                </div>
+              </div>
+            </ProgressiveCardReveal.CardExpanded>
+          </ProgressiveCardReveal.Card>
+        ))}
+      </ProgressiveCardReveal>
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="relative flex min-h-[280px] items-center justify-center p-6 sm:p-6 w-full">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -61,49 +117,7 @@ export function ProgressiveCardRevealResult() {
         </span>
       </div>
       <div className="relative flex min-h-[280px] items-center justify-center p-6 sm:p-10">
-        <ProgressiveCardReveal
-          activeIndex={active}
-          onActiveChange={setActive}
-          className="w-full max-w-[360px]"
-        >
-          {LEGS.map((leg) => (
-            <ProgressiveCardReveal.Card key={leg.label}>
-              <ProgressiveCardReveal.CardCollapsed>
-                <div className="flex items-center justify-between gap-4">
-                  <span className="flex items-center gap-2 font-medium">
-                    <span aria-hidden>{leg.icon}</span>
-                    {leg.label}
-                  </span>
-                  <span className="text-muted-foreground text-sm">
-                    {leg.meta}
-                  </span>
-                </div>
-              </ProgressiveCardReveal.CardCollapsed>
-              <ProgressiveCardReveal.CardExpanded>
-                <div className="flex flex-col gap-4">
-                  <span className="flex items-center gap-2 font-medium">
-                    <span aria-hidden>{leg.icon}</span>
-                    {leg.label}
-                  </span>
-                  <div className="flex items-end justify-between gap-6">
-                    <div>
-                      <p className="text-muted-foreground text-xs uppercase tracking-wide">
-                        Distance
-                      </p>
-                      <p className="font-semibold text-2xl">{leg.distance}</p>
-                    </div>
-                    <div className="text-right">
-                      <p className="text-muted-foreground text-xs uppercase tracking-wide">
-                        Time
-                      </p>
-                      <p className="font-semibold text-2xl">{leg.time}</p>
-                    </div>
-                  </div>
-                </div>
-              </ProgressiveCardReveal.CardExpanded>
-            </ProgressiveCardReveal.Card>
-          ))}
-        </ProgressiveCardReveal>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/prompt-composer-result.tsx
+++ b/apps/docs/src/components/learn/prompt-composer-result.tsx
@@ -2,6 +2,7 @@
 
 import { PromptComposer } from "@godui/components";
 import { useState } from "react";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive
@@ -12,6 +13,37 @@ import { useState } from "react";
 export function PromptComposerResult() {
   const [streaming, setStreaming] = useState(false);
   const [model, setModel] = useState("Opus 4.8");
+
+  const demo = (
+    <>
+      <div className="w-full max-w-xl">
+        <PromptComposer
+          placeholder="Ask anything, attach a file, or pick a model…"
+          models={["Opus 4.8", "Sonnet 4.6", "Haiku 4.5"]}
+          model={model}
+          onModelChange={setModel}
+          isStreaming={streaming}
+          onSend={() => {
+            setStreaming(true);
+            setTimeout(() => setStreaming(false), 2200);
+          }}
+          onStop={() => setStreaming(false)}
+        />
+      </div>
+      <p className="text-muted-foreground text-xs">
+        ⌘/Ctrl + Enter to send · drop or paste a file to attach it
+      </p>
+    </>
+  );
+
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full flex-col items-center justify-center gap-3 p-6">
+        {demo}
+      </div>
+    );
 
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
@@ -24,23 +56,7 @@ export function PromptComposerResult() {
         </span>
       </div>
       <div className="flex min-h-[280px] flex-col items-center justify-center gap-3 p-10">
-        <div className="w-full max-w-xl">
-          <PromptComposer
-            placeholder="Ask anything, attach a file, or pick a model…"
-            models={["Opus 4.8", "Sonnet 4.6", "Haiku 4.5"]}
-            model={model}
-            onModelChange={setModel}
-            isStreaming={streaming}
-            onSend={() => {
-              setStreaming(true);
-              setTimeout(() => setStreaming(false), 2200);
-            }}
-            onStop={() => setStreaming(false)}
-          />
-        </div>
-        <p className="text-muted-foreground text-xs">
-          ⌘/Ctrl + Enter to send · drop or paste a file to attach it
-        </p>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/prompt-suggestions-result.tsx
+++ b/apps/docs/src/components/learn/prompt-suggestions-result.tsx
@@ -2,6 +2,7 @@
 
 import { type PromptSuggestion, PromptSuggestions } from "@godui/components";
 import { useState } from "react";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive
@@ -23,6 +24,35 @@ const SUGGESTIONS: PromptSuggestion[] = [
 export function PromptSuggestionsResult() {
   const [last, setLast] = useState<string | null>(null);
 
+  const demo = (
+    <>
+      <div className="w-full max-w-lg">
+        <PromptSuggestions
+          suggestions={SUGGESTIONS}
+          onSelect={(suggestion) => setLast(suggestion.label)}
+        />
+      </div>
+      <p className="text-muted-foreground text-xs">
+        {last ? (
+          <>
+            Selected: <span className="text-foreground">{last}</span>
+          </>
+        ) : (
+          "Click or arrow-key to a suggestion and select it"
+        )}
+      </p>
+    </>
+  );
+
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full flex-col items-center justify-center gap-5 p-6">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -34,21 +64,7 @@ export function PromptSuggestionsResult() {
         </span>
       </div>
       <div className="flex min-h-[280px] flex-col items-center justify-center gap-5 p-10">
-        <div className="w-full max-w-lg">
-          <PromptSuggestions
-            suggestions={SUGGESTIONS}
-            onSelect={(suggestion) => setLast(suggestion.label)}
-          />
-        </div>
-        <p className="text-muted-foreground text-xs">
-          {last ? (
-            <>
-              Selected: <span className="text-foreground">{last}</span>
-            </>
-          ) : (
-            "Click or arrow-key to a suggestion and select it"
-          )}
-        </p>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/reorder-list-result.tsx
+++ b/apps/docs/src/components/learn/reorder-list-result.tsx
@@ -2,6 +2,7 @@
 
 import { ReorderItem, ReorderList } from "@godui/components";
 import * as React from "react";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive
@@ -17,6 +18,28 @@ const INITIAL = [
 export function ReorderListResult() {
   const [items, setItems] = React.useState(INITIAL);
 
+  const demo = (
+    <>
+      <ReorderList values={items} onReorder={setItems} className="w-72">
+        {items.map((item) => (
+          <ReorderItem key={item.id} value={item}>
+            <span aria-hidden className="text-muted-foreground">
+              ⠿
+            </span>
+            {item.label}
+          </ReorderItem>
+        ))}
+      </ReorderList>
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="relative flex min-h-[280px] items-center justify-center p-6 sm:p-6 w-full">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -28,16 +51,7 @@ export function ReorderListResult() {
         </span>
       </div>
       <div className="relative flex min-h-[280px] items-center justify-center p-6 sm:p-10">
-        <ReorderList values={items} onReorder={setItems} className="w-72">
-          {items.map((item) => (
-            <ReorderItem key={item.id} value={item}>
-              <span aria-hidden className="text-muted-foreground">
-                ⠿
-              </span>
-              {item.label}
-            </ReorderItem>
-          ))}
-        </ReorderList>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/resizable-header-result.tsx
+++ b/apps/docs/src/components/learn/resizable-header-result.tsx
@@ -2,6 +2,7 @@
 
 import { ResizableHeader } from "@godui/components";
 import { useRef, useState } from "react";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 const LINKS = [
   { label: "Product", href: "product" },
@@ -25,6 +26,80 @@ export function ResizableHeaderResult() {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [active, setActive] = useState("product");
 
+  const demo = (
+    <>
+      <div className="w-full max-w-3xl overflow-hidden rounded-xl border border-border shadow-sm">
+        <div className="flex items-center gap-1.5 border-border border-b bg-[var(--card)] px-4 py-2.5">
+          <span className="h-3 w-3 rounded-full bg-red-400/80" />
+          <span className="h-3 w-3 rounded-full bg-amber-400/80" />
+          <span className="h-3 w-3 rounded-full bg-emerald-400/80" />
+          <span className="ml-3 truncate text-muted-foreground text-xs">
+            northwind.com
+          </span>
+        </div>
+
+        <div
+          ref={scrollRef}
+          className="h-96 overflow-x-hidden overflow-y-auto bg-muted/20"
+        >
+          <ResizableHeader
+            scrollRef={scrollRef}
+            activeHref={active}
+            onNavigate={setActive}
+            logo={
+              <span className="flex items-center gap-2">
+                <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-primary font-bold text-[13px] text-primary-foreground">
+                  N
+                </span>
+                <span className="truncate">Northwind</span>
+              </span>
+            }
+            links={LINKS}
+            cta={
+              <button
+                type="button"
+                className="rounded-full bg-primary px-4 py-1.5 font-medium text-primary-foreground text-sm whitespace-nowrap"
+              >
+                Start free
+              </button>
+            }
+          />
+
+          <div className="space-y-6 px-6 pt-10 pb-16">
+            <div className="space-y-3">
+              <h3 className="font-semibold text-2xl text-foreground tracking-tight">
+                Ship faster with Northwind
+              </h3>
+              <p className="max-w-md text-muted-foreground text-sm leading-relaxed">
+                Scroll this panel — the nav springs into a compact, blurred pill
+                and the active-link indicator rides along.
+              </p>
+            </div>
+            {["Analytics", "Automations", "Integrations", "Security"].map(
+              (t) => (
+                <div
+                  key={t}
+                  className="rounded-xl border border-border bg-card p-5"
+                >
+                  <div className="font-medium text-foreground text-sm">{t}</div>
+                  <div className="mt-1.5 h-2 w-2/3 rounded-full bg-muted" />
+                  <div className="mt-2 h-2 w-1/2 rounded-full bg-muted" />
+                </div>
+              ),
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="min-h-[280px] flex items-center justify-center p-4 sm:p-6 md:p-8 w-full">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -36,70 +111,7 @@ export function ResizableHeaderResult() {
         </span>
       </div>
       <div className="flex items-center justify-center p-4 sm:p-6 md:p-8">
-        <div className="w-full max-w-3xl overflow-hidden rounded-xl border border-border shadow-sm">
-          <div className="flex items-center gap-1.5 border-border border-b bg-[var(--card)] px-4 py-2.5">
-            <span className="h-3 w-3 rounded-full bg-red-400/80" />
-            <span className="h-3 w-3 rounded-full bg-amber-400/80" />
-            <span className="h-3 w-3 rounded-full bg-emerald-400/80" />
-            <span className="ml-3 truncate text-muted-foreground text-xs">
-              northwind.com
-            </span>
-          </div>
-
-          <div
-            ref={scrollRef}
-            className="h-96 overflow-x-hidden overflow-y-auto bg-muted/20"
-          >
-            <ResizableHeader
-              scrollRef={scrollRef}
-              activeHref={active}
-              onNavigate={setActive}
-              logo={
-                <span className="flex items-center gap-2">
-                  <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-primary font-bold text-[13px] text-primary-foreground">
-                    N
-                  </span>
-                  <span className="truncate">Northwind</span>
-                </span>
-              }
-              links={LINKS}
-              cta={
-                <button
-                  type="button"
-                  className="rounded-full bg-primary px-4 py-1.5 font-medium text-primary-foreground text-sm whitespace-nowrap"
-                >
-                  Start free
-                </button>
-              }
-            />
-
-            <div className="space-y-6 px-6 pt-10 pb-16">
-              <div className="space-y-3">
-                <h3 className="font-semibold text-2xl text-foreground tracking-tight">
-                  Ship faster with Northwind
-                </h3>
-                <p className="max-w-md text-muted-foreground text-sm leading-relaxed">
-                  Scroll this panel — the nav springs into a compact, blurred
-                  pill and the active-link indicator rides along.
-                </p>
-              </div>
-              {["Analytics", "Automations", "Integrations", "Security"].map(
-                (t) => (
-                  <div
-                    key={t}
-                    className="rounded-xl border border-border bg-card p-5"
-                  >
-                    <div className="font-medium text-foreground text-sm">
-                      {t}
-                    </div>
-                    <div className="mt-1.5 h-2 w-2/3 rounded-full bg-muted" />
-                    <div className="mt-2 h-2 w-1/2 rounded-full bg-muted" />
-                  </div>
-                ),
-              )}
-            </div>
-          </div>
-        </div>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/result-preview.tsx
+++ b/apps/docs/src/components/learn/result-preview.tsx
@@ -1,12 +1,28 @@
 "use client";
 
 import { MagicButton } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
+
+const Demo = () => (
+  <>
+    <MagicButton>Push me</MagicButton>
+    <MagicButton variant="secondary">Push me</MagicButton>
+  </>
+);
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive component
  * so the reader can feel every mechanism the article just pulled apart.
  */
 export function ResultPreview() {
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full flex-wrap items-center justify-center gap-6 p-6">
+        <Demo />
+      </div>
+    );
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -18,8 +34,7 @@ export function ResultPreview() {
         </span>
       </div>
       <div className="flex min-h-[240px] flex-wrap items-center justify-center gap-6 p-10">
-        <MagicButton>Push me</MagicButton>
-        <MagicButton variant="secondary">Push me</MagicButton>
+        <Demo />
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/scroll-progress-result.tsx
+++ b/apps/docs/src/components/learn/scroll-progress-result.tsx
@@ -2,6 +2,7 @@
 
 import { ScrollProgress } from "@godui/components";
 import * as React from "react";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing panel — real ScrollProgress tracking a scrollable box (bar +
@@ -12,6 +13,44 @@ const FILLER = Array.from({ length: 12 });
 
 export function ScrollProgressResult() {
   const ref = React.useRef<HTMLDivElement>(null);
+
+  const demo = (
+    <div
+      ref={ref}
+      data-scroll-container
+      className="relative h-72 w-full max-w-md overflow-y-auto rounded-xl border border-border bg-card"
+    >
+      <ScrollProgress container={ref} />
+      <div className="space-y-4 p-6 pb-16">
+        <p className="font-medium text-foreground text-sm">Scroll this panel</p>
+        {FILLER.map((_, i) => (
+          <p
+            // biome-ignore lint/suspicious/noArrayIndexKey: static filler
+            key={i}
+            className="text-muted-foreground text-sm leading-relaxed"
+          >
+            Progress springs toward the scroll position — paragraph {i + 1} of{" "}
+            {FILLER.length}.
+          </p>
+        ))}
+      </div>
+      <ScrollProgress
+        variant="circle"
+        container={ref}
+        showAfter={0.05}
+        position="bottom-right"
+      />
+    </div>
+  );
+
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[320px] w-full items-center justify-center p-6">
+        {demo}
+      </div>
+    );
 
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
@@ -24,34 +63,7 @@ export function ScrollProgressResult() {
         </span>
       </div>
       <div className="flex min-h-[320px] items-center justify-center p-6 md:p-10">
-        <div
-          ref={ref}
-          data-scroll-container
-          className="relative h-72 w-full max-w-md overflow-y-auto rounded-xl border border-border bg-card"
-        >
-          <ScrollProgress container={ref} />
-          <div className="space-y-4 p-6 pb-16">
-            <p className="font-medium text-foreground text-sm">
-              Scroll this panel
-            </p>
-            {FILLER.map((_, i) => (
-              <p
-                // biome-ignore lint/suspicious/noArrayIndexKey: static filler
-                key={i}
-                className="text-muted-foreground text-sm leading-relaxed"
-              >
-                Progress springs toward the scroll position — paragraph {i + 1}{" "}
-                of {FILLER.length}.
-              </p>
-            ))}
-          </div>
-          <ScrollProgress
-            variant="circle"
-            container={ref}
-            showAfter={0.05}
-            position="bottom-right"
-          />
-        </div>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/scroll-reveal-result.tsx
+++ b/apps/docs/src/components/learn/scroll-reveal-result.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ScrollReveal } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing panel — real ScrollReveal cards with a short stagger so the
@@ -9,7 +10,27 @@ import { ScrollReveal } from "@godui/components";
 
 const CARDS = [0, 1, 2] as const;
 
+const Cards = () => (
+  <>
+    {CARDS.map((i) => (
+      <ScrollReveal key={i} delay={i * 0.1} className="w-full max-w-sm">
+        <div className="flex h-16 items-center justify-center rounded-xl border border-border bg-card shadow-sm">
+          <span className="h-2 w-24 rounded-full bg-foreground/25" />
+        </div>
+      </ScrollReveal>
+    ))}
+  </>
+);
+
 export function ScrollRevealResult() {
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full flex-col items-center justify-center gap-4 p-6">
+        <Cards />
+      </div>
+    );
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -21,13 +42,7 @@ export function ScrollRevealResult() {
         </span>
       </div>
       <div className="flex min-h-[280px] flex-col items-center justify-center gap-4 p-8 md:p-12">
-        {CARDS.map((i) => (
-          <ScrollReveal key={i} delay={i * 0.1} className="w-full max-w-sm">
-            <div className="flex h-16 items-center justify-center rounded-xl border border-border bg-card shadow-sm">
-              <span className="h-2 w-24 rounded-full bg-foreground/25" />
-            </div>
-          </ScrollReveal>
-        ))}
+        <Cards />
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/scroll-scene.tsx
+++ b/apps/docs/src/components/learn/scroll-scene.tsx
@@ -8,6 +8,7 @@ import {
   useSyncExternalStore,
 } from "react";
 import { BorderBeam } from "@/components/border-beam";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 import { ReplayButton } from "@/components/replay-button";
 import { cn } from "@/lib/cn";
 
@@ -17,7 +18,7 @@ import { cn } from "@/lib/cn";
  * the live match afterward — no hydration mismatch, and no derived setState in
  * an effect (which `react-hooks/set-state-in-effect` rightly flags).
  */
-function usePrefersReducedMotion() {
+export function usePrefersReducedMotion() {
   return useSyncExternalStore(
     (onChange) => {
       if (typeof matchMedia === "undefined") return () => {};
@@ -52,6 +53,36 @@ type ScrollSceneProps = {
 };
 
 export function ScrollScene({
+  label,
+  note,
+  children,
+  className,
+}: ScrollSceneProps) {
+  const bare = useBareScene();
+
+  // On the LearnPlayer stage the player owns the card + play lifecycle: render
+  // only the animated body, keyed by the player's cycle so it restarts cleanly.
+  // Center the body in the stage — scene roots often use `w-full max-w-*`, which
+  // would otherwise pin left inside a full-width wrapper.
+  if (bare) {
+    return (
+      <div
+        key={bare.cycle}
+        className={cn("flex w-full justify-center", className)}
+      >
+        {children(bare)}
+      </div>
+    );
+  }
+
+  return (
+    <ScrollSceneCard label={label} note={note} className={className}>
+      {children}
+    </ScrollSceneCard>
+  );
+}
+
+function ScrollSceneCard({
   label,
   note,
   children,

--- a/apps/docs/src/components/learn/scroll-stack-result.tsx
+++ b/apps/docs/src/components/learn/scroll-stack-result.tsx
@@ -3,6 +3,7 @@
 import { ScrollStack } from "@godui/components";
 import { BarChart3, GitBranch, Rocket } from "lucide-react";
 import type { ComponentType } from "react";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive
@@ -39,6 +40,45 @@ const CARDS: Card[] = [
 ];
 
 export function ScrollStackResult() {
+  const demo = (
+    <>
+      <ScrollStack
+        height="24rem"
+        pinTop="8%"
+        className="w-full max-w-md rounded-2xl border border-fd-border bg-[var(--muted)]/30"
+      >
+        {CARDS.map(({ Icon, eyebrow, title, body }) => (
+          <article
+            key={title}
+            className="flex w-full flex-col rounded-2xl border border-border bg-card p-7 shadow-[0_24px_60px_-24px_rgba(0,0,0,0.45)]"
+          >
+            <div className="flex items-center gap-3">
+              <span className="grid size-8 place-items-center rounded-lg bg-primary/10 text-primary ring-1 ring-primary/15 ring-inset">
+                <Icon className="size-4" strokeWidth={2} />
+              </span>
+              <span className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+                {eyebrow}
+              </span>
+            </div>
+            <h3 className="mt-5 text-xl font-semibold tracking-tight text-foreground">
+              {title}
+            </h3>
+            <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+              {body}
+            </p>
+          </article>
+        ))}
+      </ScrollStack>
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="relative flex min-h-[300px] items-center justify-center p-6 md:p-6 w-full">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -50,33 +90,7 @@ export function ScrollStackResult() {
         </span>
       </div>
       <div className="relative flex min-h-[300px] items-center justify-center p-6 md:p-10">
-        <ScrollStack
-          height="24rem"
-          pinTop="8%"
-          className="w-full max-w-md rounded-2xl border border-fd-border bg-[var(--muted)]/30"
-        >
-          {CARDS.map(({ Icon, eyebrow, title, body }) => (
-            <article
-              key={title}
-              className="flex w-full flex-col rounded-2xl border border-border bg-card p-7 shadow-[0_24px_60px_-24px_rgba(0,0,0,0.45)]"
-            >
-              <div className="flex items-center gap-3">
-                <span className="grid size-8 place-items-center rounded-lg bg-primary/10 text-primary ring-1 ring-primary/15 ring-inset">
-                  <Icon className="size-4" strokeWidth={2} />
-                </span>
-                <span className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-                  {eyebrow}
-                </span>
-              </div>
-              <h3 className="mt-5 text-xl font-semibold tracking-tight text-foreground">
-                {title}
-              </h3>
-              <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
-                {body}
-              </p>
-            </article>
-          ))}
-        </ScrollStack>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/scroll-text-reveal-result.tsx
+++ b/apps/docs/src/components/learn/scroll-text-reveal-result.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ScrollTextReveal } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing panel — the real ScrollTextReveal. useScroll targets the element
@@ -8,6 +9,34 @@ import { ScrollTextReveal } from "@godui/components";
  * vertical room and asks the reader to scroll the page through it.
  */
 export function ScrollTextRevealResult() {
+  const demo = (
+    <>
+      <ScrollTextReveal
+        as="p"
+        className="text-balance text-center text-2xl font-semibold leading-relaxed text-foreground sm:text-3xl"
+      >
+        Great interfaces read like a sentence — one idea resolving into the
+        next. As you scroll, each word settles into focus, pacing attention
+        exactly where it belongs.
+      </ScrollTextReveal>
+      <ScrollTextReveal
+        as="p"
+        keepRevealed
+        className="text-balance text-center text-xl font-semibold leading-relaxed text-foreground sm:text-2xl"
+      >
+        With keepRevealed, each word latches at full presence once it lands — so
+        the paragraph stays lit as you scroll back up instead of dimming again.
+      </ScrollTextReveal>
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="min-h-[280px] mx-auto flex max-w-lg flex-col gap-16 px-6 py-20 md:py-28 w-full">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -19,23 +48,7 @@ export function ScrollTextRevealResult() {
         </span>
       </div>
       <div className="mx-auto flex max-w-lg flex-col gap-16 px-6 py-20 md:py-28">
-        <ScrollTextReveal
-          as="p"
-          className="text-balance text-center text-2xl font-semibold leading-relaxed text-foreground sm:text-3xl"
-        >
-          Great interfaces read like a sentence — one idea resolving into the
-          next. As you scroll, each word settles into focus, pacing attention
-          exactly where it belongs.
-        </ScrollTextReveal>
-        <ScrollTextReveal
-          as="p"
-          keepRevealed
-          className="text-balance text-center text-xl font-semibold leading-relaxed text-foreground sm:text-2xl"
-        >
-          With keepRevealed, each word latches at full presence once it lands —
-          so the paragraph stays lit as you scroll back up instead of dimming
-          again.
-        </ScrollTextReveal>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/scroll-timeline-result.tsx
+++ b/apps/docs/src/components/learn/scroll-timeline-result.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ScrollTimeline } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive
@@ -10,6 +11,39 @@ import { ScrollTimeline } from "@godui/components";
  * compact.
  */
 export function ScrollTimelineResult() {
+  const demo = (
+    <>
+      <ScrollTimeline
+        data={[
+          {
+            date: "2021",
+            title: "The first commit",
+            content: (
+              <p className="text-sm text-muted-foreground md:text-base">
+                A single component and a big idea.
+              </p>
+            ),
+          },
+          {
+            date: "2025",
+            title: "One hundred components",
+            content: (
+              <p className="text-sm text-muted-foreground md:text-base">
+                Every surface, polished — you&apos;re looking at the rail right
+                now.
+              </p>
+            ),
+          },
+        ]}
+      />
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="min-h-[280px] px-4 py-10 md:px-8 w-full">{demo}</div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -20,31 +54,7 @@ export function ScrollTimelineResult() {
           the real component — scroll the page through it
         </span>
       </div>
-      <div className="px-4 py-10 md:px-8">
-        <ScrollTimeline
-          data={[
-            {
-              date: "2021",
-              title: "The first commit",
-              content: (
-                <p className="text-sm text-muted-foreground md:text-base">
-                  A single component and a big idea.
-                </p>
-              ),
-            },
-            {
-              date: "2025",
-              title: "One hundred components",
-              content: (
-                <p className="text-sm text-muted-foreground md:text-base">
-                  Every surface, polished — you&apos;re looking at the rail
-                  right now.
-                </p>
-              ),
-            },
-          ]}
-        />
-      </div>
+      <div className="px-4 py-10 md:px-8">{demo}</div>
     </div>
   );
 }

--- a/apps/docs/src/components/learn/segmented-control-result.tsx
+++ b/apps/docs/src/components/learn/segmented-control-result.tsx
@@ -3,6 +3,7 @@
 import { SegmentedControl, type SegmentedOption } from "@godui/components";
 import { CalendarDays, CalendarRange, Sun } from "lucide-react";
 import { useState } from "react";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive
@@ -22,6 +23,22 @@ const OPTIONS: SegmentedOption[] = [
 export function SegmentedControlResult() {
   const [view, setView] = useState("week");
 
+  const demo = (
+    <>
+      <SegmentedControl options={OPTIONS} value={view} onChange={setView} />
+      <p className="text-muted-foreground text-xs">
+        Viewing <span className="text-foreground">{view}</span> range
+      </p>
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[220px] flex-col items-center justify-center gap-4 p-6 w-full">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -33,10 +50,7 @@ export function SegmentedControlResult() {
         </span>
       </div>
       <div className="flex min-h-[220px] flex-col items-center justify-center gap-4 p-10">
-        <SegmentedControl options={OPTIONS} value={view} onChange={setView} />
-        <p className="text-muted-foreground text-xs">
-          Viewing <span className="text-foreground">{view}</span> range
-        </p>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/shimmer-result.tsx
+++ b/apps/docs/src/components/learn/shimmer-result.tsx
@@ -1,6 +1,15 @@
 "use client";
 
 import { ShimmerButton } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
+
+const ShimmerResultBody = () => (
+  <>
+    <ShimmerButton variant="primary">Primary</ShimmerButton>
+    <ShimmerButton variant="secondary">Secondary</ShimmerButton>
+    <ShimmerButton variant="outline">Outline</ShimmerButton>
+  </>
+);
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive Shimmer
@@ -8,6 +17,14 @@ import { ShimmerButton } from "@godui/components";
  * apart: hover/focus speed-up, the press dip, the border-only spark.
  */
 export function ShimmerResult() {
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full flex-wrap items-center justify-center gap-6 p-6">
+        <ShimmerResultBody />
+      </div>
+    );
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -19,9 +36,7 @@ export function ShimmerResult() {
         </span>
       </div>
       <div className="flex min-h-[240px] flex-wrap items-center justify-center gap-6 p-10">
-        <ShimmerButton variant="primary">Primary</ShimmerButton>
-        <ShimmerButton variant="secondary">Secondary</ShimmerButton>
-        <ShimmerButton variant="outline">Outline</ShimmerButton>
+        <ShimmerResultBody />
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/slide-confirm-result.tsx
+++ b/apps/docs/src/components/learn/slide-confirm-result.tsx
@@ -1,6 +1,21 @@
 "use client";
 
 import { SlideConfirmButton } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
+
+/**
+ * The real, interactive Slide Confirm buttons — no card chrome. Rendered on
+ * the shared `LearnPlayer` stage as the final chapter, and reused inside the
+ * classic card layout below.
+ */
+function SlideConfirmDemo() {
+  return (
+    <div className="flex flex-col items-center justify-center gap-6">
+      <SlideConfirmButton label="Slide to deploy" />
+      <SlideConfirmButton variant="destructive" label="Slide to delete" />
+    </div>
+  );
+}
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive
@@ -8,6 +23,14 @@ import { SlideConfirmButton } from "@godui/components";
  * apart: drag the thumb, watch the fill trail it, release past the line.
  */
 export function SlideConfirmResult() {
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        <SlideConfirmDemo />
+      </div>
+    );
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -18,9 +41,8 @@ export function SlideConfirmResult() {
           the real component — drag the thumb, or release early
         </span>
       </div>
-      <div className="flex min-h-[240px] flex-col items-center justify-center gap-6 p-10">
-        <SlideConfirmButton label="Slide to deploy" />
-        <SlideConfirmButton variant="destructive" label="Slide to delete" />
+      <div className="flex min-h-[240px] items-center justify-center p-10">
+        <SlideConfirmDemo />
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/source-citations-result.tsx
+++ b/apps/docs/src/components/learn/source-citations-result.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { SourceCitation, SourceList } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Same source set as the component's docs demo, extended to five entries so
@@ -39,6 +40,32 @@ const sources = [
 ];
 
 export function SourceCitationsResult() {
+  const demo = (
+    <div className="w-full max-w-lg">
+      <p className="text-sm leading-7 text-foreground">
+        Modern design systems standardize on OKLCH for perceptually uniform
+        theming
+        <SourceCitation index={1} source={sources[0]} />, and Tailwind v4 ships
+        a CSS-first config that makes tokens first-class
+        <SourceCitation index={2} source={sources[1]} />. Motion is now treated
+        as a core craft, not a finishing touch
+        <SourceCitation index={3} source={sources[2]} />.
+      </p>
+      <div className="mt-4 border-t border-border pt-4">
+        <SourceList sources={sources} />
+      </div>
+    </div>
+  );
+
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // components only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -50,20 +77,7 @@ export function SourceCitationsResult() {
         </span>
       </div>
       <div className="flex min-h-[320px] w-full items-center justify-center p-10">
-        <div className="w-full max-w-lg">
-          <p className="text-sm leading-7 text-foreground">
-            Modern design systems standardize on OKLCH for perceptually uniform
-            theming
-            <SourceCitation index={1} source={sources[0]} />, and Tailwind v4
-            ships a CSS-first config that makes tokens first-class
-            <SourceCitation index={2} source={sources[1]} />. Motion is now
-            treated as a core craft, not a finishing touch
-            <SourceCitation index={3} source={sources[2]} />.
-          </p>
-          <div className="mt-4 border-t border-border pt-4">
-            <SourceList sources={sources} />
-          </div>
-        </div>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/spin-viewer-result.tsx
+++ b/apps/docs/src/components/learn/spin-viewer-result.tsx
@@ -3,6 +3,7 @@
 import { SpinViewer } from "@godui/components";
 import { useMemo } from "react";
 import { makeCubeFrames } from "@/components/demos/spin-viewer-frames";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive
@@ -12,6 +13,19 @@ import { makeCubeFrames } from "@/components/demos/spin-viewer-frames";
  */
 export function SpinViewerResult() {
   const frames = useMemo(() => makeCubeFrames(48), []);
+
+  const demo = (
+    <>
+      <SpinViewer frames={frames} autoRotate className="size-56" />
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="relative flex min-h-[300px] items-center justify-center p-6 w-full">
+        {demo}
+      </div>
+    );
 
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
@@ -24,7 +38,7 @@ export function SpinViewerResult() {
         </span>
       </div>
       <div className="relative flex min-h-[300px] items-center justify-center p-10">
-        <SpinViewer frames={frames} autoRotate className="size-56" />
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/spotlight-card-result.tsx
+++ b/apps/docs/src/components/learn/spotlight-card-result.tsx
@@ -1,12 +1,49 @@
 "use client";
 
 import { SpotlightCard } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
+
+/**
+ * The real, interactive SpotlightCard pair — no card chrome. Rendered on the
+ * shared `LearnPlayer` stage as the final chapter.
+ */
+function SpotlightCardResultBody() {
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-8">
+      <SpotlightCard className="w-64 p-6">
+        <h3 className="text-lg font-semibold text-foreground">Default glow</h3>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Radial follows the pointer; border lights with it.
+        </p>
+      </SpotlightCard>
+      <SpotlightCard
+        border={false}
+        radius={220}
+        glowColor="color-mix(in oklch, var(--primary) 35%, transparent)"
+        className="w-64 p-6"
+      >
+        <h3 className="text-lg font-semibold text-foreground">Fill only</h3>
+        <p className="mt-2 text-sm text-muted-foreground">
+          border=false drops the ring layer entirely.
+        </p>
+      </SpotlightCard>
+    </div>
+  );
+}
 
 /**
  * Closing panel — the real SpotlightCard. Move across either card to feel
  * the CSS-var follow and the optional border ring.
  */
 export function SpotlightCardResult() {
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        <SpotlightCardResultBody />
+      </div>
+    );
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -17,26 +54,8 @@ export function SpotlightCardResult() {
           the real component — move your pointer across each card
         </span>
       </div>
-      <div className="flex min-h-[300px] flex-wrap items-center justify-center gap-8 p-10">
-        <SpotlightCard className="w-64 p-6">
-          <h3 className="text-lg font-semibold text-foreground">
-            Default glow
-          </h3>
-          <p className="mt-2 text-sm text-muted-foreground">
-            Radial follows the pointer; border lights with it.
-          </p>
-        </SpotlightCard>
-        <SpotlightCard
-          border={false}
-          radius={220}
-          glowColor="color-mix(in oklch, var(--primary) 35%, transparent)"
-          className="w-64 p-6"
-        >
-          <h3 className="text-lg font-semibold text-foreground">Fill only</h3>
-          <p className="mt-2 text-sm text-muted-foreground">
-            border=false drops the ring layer entirely.
-          </p>
-        </SpotlightCard>
+      <div className="flex min-h-[300px] items-center justify-center p-10">
+        <SpotlightCardResultBody />
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/spotlight-reveal-result.tsx
+++ b/apps/docs/src/components/learn/spotlight-reveal-result.tsx
@@ -1,11 +1,47 @@
 "use client";
 
 import { SpotlightReveal } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
+
+const Demo = (
+  <SpotlightReveal
+    radius={140}
+    className="aspect-[16/10] w-full max-w-md border border-border"
+    reveal={
+      <div className="grid size-full place-items-center bg-foreground">
+        <div className="text-center">
+          <p className="font-mono text-2xl font-semibold tracking-[0.18em] text-background">
+            GODUI
+          </p>
+        </div>
+      </div>
+    }
+  >
+    <div className="grid size-full place-items-center bg-card">
+      <div className="text-center">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+          Cover layer
+        </p>
+        <p className="mt-2 text-lg font-semibold text-foreground">
+          Move to reveal
+        </p>
+      </div>
+    </div>
+  </SpotlightReveal>
+);
 
 /**
  * Closing panel — the real SpotlightReveal. Hover to follow, click to pin.
  */
 export function SpotlightRevealResult() {
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        {Demo}
+      </div>
+    );
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -17,30 +53,7 @@ export function SpotlightRevealResult() {
         </span>
       </div>
       <div className="flex min-h-[320px] items-center justify-center p-6 md:p-10">
-        <SpotlightReveal
-          radius={140}
-          className="aspect-[16/10] w-full max-w-md border border-border"
-          reveal={
-            <div className="grid size-full place-items-center bg-foreground">
-              <div className="text-center">
-                <p className="font-mono text-2xl font-semibold tracking-[0.18em] text-background">
-                  GODUI
-                </p>
-              </div>
-            </div>
-          }
-        >
-          <div className="grid size-full place-items-center bg-card">
-            <div className="text-center">
-              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                Cover layer
-              </p>
-              <p className="mt-2 text-lg font-semibold text-foreground">
-                Move to reveal
-              </p>
-            </div>
-          </div>
-        </SpotlightReveal>
+        {Demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/stack-badge-result.tsx
+++ b/apps/docs/src/components/learn/stack-badge-result.tsx
@@ -1,12 +1,37 @@
 "use client";
 
 import { StackBadge } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive
  * StackBadge. Scroll it into view for the stagger, then hover a chip.
  */
 export function StackBadgeResult() {
+  const demo = (
+    <>
+      <StackBadge
+        items={[
+          "react",
+          "typescript",
+          "tailwind",
+          "nextjs",
+          "node",
+          "figma",
+          "rust",
+          "postgres",
+        ]}
+      />
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[220px] flex-wrap items-center justify-center gap-6 p-6 w-full">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -18,18 +43,7 @@ export function StackBadgeResult() {
         </span>
       </div>
       <div className="flex min-h-[220px] flex-wrap items-center justify-center gap-6 p-10">
-        <StackBadge
-          items={[
-            "react",
-            "typescript",
-            "tailwind",
-            "nextjs",
-            "node",
-            "figma",
-            "rust",
-            "postgres",
-          ]}
-        />
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/stepper-result.tsx
+++ b/apps/docs/src/components/learn/stepper-result.tsx
@@ -2,6 +2,7 @@
 
 import { Stepper } from "@godui/components";
 import * as React from "react";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive
@@ -21,6 +22,39 @@ const buttonClass =
 export function StepperResult() {
   const [active, setActive] = React.useState(1);
 
+  const demo = (
+    <>
+      <div className="w-full max-w-xl">
+        <Stepper steps={STEPS} active={active} />
+      </div>
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          className={buttonClass}
+          disabled={active === 0}
+          onClick={() => setActive((s) => Math.max(0, s - 1))}
+        >
+          Back
+        </button>
+        <button
+          type="button"
+          className={`${buttonClass} border-primary bg-primary text-primary-foreground hover:bg-primary/90`}
+          disabled={active === STEPS.length}
+          onClick={() => setActive((s) => Math.min(STEPS.length, s + 1))}
+        >
+          {active >= STEPS.length - 1 ? "Finish" : "Next"}
+        </button>
+      </div>
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="relative flex min-h-[280px] flex-col items-center justify-center gap-8 p-6 md:p-6 w-full">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -32,27 +66,7 @@ export function StepperResult() {
         </span>
       </div>
       <div className="relative flex min-h-[280px] flex-col items-center justify-center gap-8 p-6 md:p-10">
-        <div className="w-full max-w-xl">
-          <Stepper steps={STEPS} active={active} />
-        </div>
-        <div className="flex items-center gap-3">
-          <button
-            type="button"
-            className={buttonClass}
-            disabled={active === 0}
-            onClick={() => setActive((s) => Math.max(0, s - 1))}
-          >
-            Back
-          </button>
-          <button
-            type="button"
-            className={`${buttonClass} border-primary bg-primary text-primary-foreground hover:bg-primary/90`}
-            disabled={active === STEPS.length}
-            onClick={() => setActive((s) => Math.min(STEPS.length, s + 1))}
-          >
-            {active >= STEPS.length - 1 ? "Finish" : "Next"}
-          </button>
-        </div>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/sticky-scroll-result.tsx
+++ b/apps/docs/src/components/learn/sticky-scroll-result.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { StickyScroll, type StickyScrollItem } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive
@@ -40,6 +41,19 @@ const ITEMS: StickyScrollItem[] = [
 ];
 
 export function StickyScrollResult() {
+  const demo = (
+    <>
+      <StickyScroll items={ITEMS} />
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="min-h-[280px] flex justify-center p-6 md:p-6 w-full">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -50,9 +64,7 @@ export function StickyScrollResult() {
           the real component — scroll inside this panel
         </span>
       </div>
-      <div className="flex justify-center p-6 md:p-10">
-        <StickyScroll items={ITEMS} />
-      </div>
+      <div className="flex justify-center p-6 md:p-10">{demo}</div>
     </div>
   );
 }

--- a/apps/docs/src/components/learn/store-badge-result.tsx
+++ b/apps/docs/src/components/learn/store-badge-result.tsx
@@ -1,12 +1,37 @@
 "use client";
 
 import { StoreBadge, StoreBadgeGroup } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive
  * StoreBadgeGroup. Hover (or focus) a badge for the scan-to-download QR.
  */
 export function StoreBadgeResult() {
+  const demo = (
+    <>
+      <StoreBadgeGroup>
+        <StoreBadge
+          store="app-store"
+          href="https://apps.apple.com/app/id6761287549"
+          qr
+        />
+        <StoreBadge
+          store="google-play"
+          href="https://play.google.com/store/apps/details?id=lol.hivemind"
+          qr
+        />
+      </StoreBadgeGroup>
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[220px] flex-wrap items-center justify-center gap-4 p-6 w-full">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -18,18 +43,7 @@ export function StoreBadgeResult() {
         </span>
       </div>
       <div className="flex min-h-[220px] flex-wrap items-center justify-center gap-4 p-10">
-        <StoreBadgeGroup>
-          <StoreBadge
-            store="app-store"
-            href="https://apps.apple.com/app/id6761287549"
-            qr
-          />
-          <StoreBadge
-            store="google-play"
-            href="https://play.google.com/store/apps/details?id=lol.hivemind"
-            qr
-          />
-        </StoreBadgeGroup>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/swipe-deck-result.tsx
+++ b/apps/docs/src/components/learn/swipe-deck-result.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { SwipeDeck } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 const CARDS: { name: string; role: string; img: string }[] = [
   { name: "Aria Wells", role: "Product Designer", img: "1027" },
@@ -38,6 +39,23 @@ function ProfileCard({
  * SwipeDeck. Drag the front card, use the buttons, or the arrow keys.
  */
 export function SwipeDeckResult() {
+  const demo = (
+    <>
+      <SwipeDeck loop actions={{ left: "Pass", right: "Connect" }}>
+        {CARDS.map((c) => (
+          <ProfileCard key={c.name} {...c} />
+        ))}
+      </SwipeDeck>
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[420px] items-center justify-center p-6 w-full">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -49,11 +67,7 @@ export function SwipeDeckResult() {
         </span>
       </div>
       <div className="flex min-h-[420px] items-center justify-center p-10">
-        <SwipeDeck loop actions={{ left: "Pass", right: "Connect" }}>
-          {CARDS.map((c) => (
-            <ProfileCard key={c.name} {...c} />
-          ))}
-        </SwipeDeck>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/tab-bar-result.tsx
+++ b/apps/docs/src/components/learn/tab-bar-result.tsx
@@ -3,6 +3,7 @@
 import { TabBar, type TabBarTab } from "@godui/components";
 import { Bell, Home, Search, User } from "lucide-react";
 import { useState } from "react";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive Tab Bar.
@@ -24,6 +25,22 @@ const TABS: TabBarTab[] = [
 export function TabBarResult() {
   const [tab, setTab] = useState("home");
 
+  const demo = (
+    <>
+      <TabBar tabs={TABS} value={tab} onChange={setTab} />
+      <p className="text-muted-foreground text-xs">
+        Active tab: <span className="text-foreground">{tab}</span>
+      </p>
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[240px] flex-col items-center justify-center gap-4 p-6 w-full">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -35,10 +52,7 @@ export function TabBarResult() {
         </span>
       </div>
       <div className="flex min-h-[240px] flex-col items-center justify-center gap-4 p-10">
-        <TabBar tabs={TABS} value={tab} onChange={setTab} />
-        <p className="text-muted-foreground text-xs">
-          Active tab: <span className="text-foreground">{tab}</span>
-        </p>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/terminal-result.tsx
+++ b/apps/docs/src/components/learn/terminal-result.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Terminal, type TerminalLine } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 const LINES: TerminalLine[] = [
   { text: "npx shadcn@latest add @godui/terminal", type: "command" },
@@ -15,6 +16,19 @@ const LINES: TerminalLine[] = [
  * Closing panel — the real Terminal, looping with chrome.
  */
 export function TerminalResult() {
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        <Terminal
+          lines={LINES}
+          title="zsh — godui"
+          loop
+          className="w-full max-w-[26rem]"
+        />
+      </div>
+    );
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">

--- a/apps/docs/src/components/learn/text-animate-result.tsx
+++ b/apps/docs/src/components/learn/text-animate-result.tsx
@@ -1,12 +1,63 @@
 "use client";
 
 import { TextAnimate } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing panel — live TextAnimate instances so the reader feels split
  * granularity, preset motion, and the in-view stagger in one place.
  */
 export function TextAnimateResult() {
+  const demo = (
+    <>
+      <div className="flex flex-col items-center gap-2">
+        <TextAnimate
+          animation="blurInUp"
+          by="word"
+          className="text-center text-3xl font-semibold tracking-tight sm:text-4xl"
+        >
+          Animate your ideas into reality
+        </TextAnimate>
+        <span className="font-mono text-[11px] text-fd-muted-foreground">
+          blurInUp · by word
+        </span>
+      </div>
+      <div className="flex flex-col items-center gap-2">
+        <TextAnimate
+          animation="slideUp"
+          by="character"
+          stagger={0.03}
+          className="text-center text-2xl font-medium tracking-tight sm:text-3xl"
+        >
+          Character by character
+        </TextAnimate>
+        <span className="font-mono text-[11px] text-fd-muted-foreground">
+          slideUp · by character
+        </span>
+      </div>
+      <div className="flex flex-col items-center gap-2">
+        <TextAnimate
+          as="h2"
+          animation="scaleUp"
+          by="word"
+          className="text-center text-3xl font-bold tracking-tight sm:text-4xl"
+        >
+          Scale up with spring
+        </TextAnimate>
+        <span className="font-mono text-[11px] text-fd-muted-foreground">
+          scaleUp · as h2
+        </span>
+      </div>
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] flex-col items-center justify-center gap-10 p-6 w-full">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -18,44 +69,7 @@ export function TextAnimateResult() {
         </span>
       </div>
       <div className="flex min-h-[280px] flex-col items-center justify-center gap-10 p-10">
-        <div className="flex flex-col items-center gap-2">
-          <TextAnimate
-            animation="blurInUp"
-            by="word"
-            className="text-center text-3xl font-semibold tracking-tight sm:text-4xl"
-          >
-            Animate your ideas into reality
-          </TextAnimate>
-          <span className="font-mono text-[11px] text-fd-muted-foreground">
-            blurInUp · by word
-          </span>
-        </div>
-        <div className="flex flex-col items-center gap-2">
-          <TextAnimate
-            animation="slideUp"
-            by="character"
-            stagger={0.03}
-            className="text-center text-2xl font-medium tracking-tight sm:text-3xl"
-          >
-            Character by character
-          </TextAnimate>
-          <span className="font-mono text-[11px] text-fd-muted-foreground">
-            slideUp · by character
-          </span>
-        </div>
-        <div className="flex flex-col items-center gap-2">
-          <TextAnimate
-            as="h2"
-            animation="scaleUp"
-            by="word"
-            className="text-center text-3xl font-bold tracking-tight sm:text-4xl"
-          >
-            Scale up with spring
-          </TextAnimate>
-          <span className="font-mono text-[11px] text-fd-muted-foreground">
-            scaleUp · as h2
-          </span>
-        </div>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/text-scramble-result.tsx
+++ b/apps/docs/src/components/learn/text-scramble-result.tsx
@@ -1,12 +1,37 @@
 "use client";
 
 import { TextScramble } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing panel — the real TextScramble. Hover re-runs the scramble so the
  * reader can feel the cell queue, primary unresolved tint, and resolve lock.
  */
 export function TextScrambleResult() {
+  const demo = (
+    <>
+      <TextScramble
+        text="Decrypting…"
+        trigger="hover"
+        charset="symbols"
+        className="cursor-default font-mono text-4xl font-semibold tracking-tight sm:text-5xl"
+      />
+      <TextScramble
+        text="01001000"
+        trigger="hover"
+        charset="binary"
+        className="cursor-default font-mono text-2xl text-fd-muted-foreground tabular-nums sm:text-3xl"
+      />
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[240px] flex-col items-center justify-center gap-8 p-6 w-full">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -18,18 +43,7 @@ export function TextScrambleResult() {
         </span>
       </div>
       <div className="flex min-h-[240px] flex-col items-center justify-center gap-8 p-10">
-        <TextScramble
-          text="Decrypting…"
-          trigger="hover"
-          charset="symbols"
-          className="cursor-default font-mono text-4xl font-semibold tracking-tight sm:text-5xl"
-        />
-        <TextScramble
-          text="01001000"
-          trigger="hover"
-          charset="binary"
-          className="cursor-default font-mono text-2xl text-fd-muted-foreground tabular-nums sm:text-3xl"
-        />
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/three-d-marquee-result.tsx
+++ b/apps/docs/src/components/learn/three-d-marquee-result.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ThreeDMarquee } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 const IMAGES = [
   "1015",
@@ -26,6 +27,14 @@ const IMAGES = [
  * ThreeDMarquee, drifting on its tilted plane.
  */
 export function ThreeDMarqueeResult() {
+  const demo = (
+    <>
+      <ThreeDMarquee images={IMAGES} />
+    </>
+  );
+
+  if (useBareScene()) return <div className="h-[26rem] w-full p-6">{demo}</div>;
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -36,9 +45,7 @@ export function ThreeDMarqueeResult() {
           the real component — ambient, no interaction needed
         </span>
       </div>
-      <div className="h-[26rem] w-full p-6">
-        <ThreeDMarquee images={IMAGES} />
-      </div>
+      <div className="h-[26rem] w-full p-6">{demo}</div>
     </div>
   );
 }

--- a/apps/docs/src/components/learn/tilt-card-result.tsx
+++ b/apps/docs/src/components/learn/tilt-card-result.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { TiltCard } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive
@@ -9,6 +10,34 @@ import { TiltCard } from "@godui/components";
  * cranks `maxTilt`/`depth` for a more dramatic effect.
  */
 export function TiltCardResult() {
+  const demo = (
+    <>
+      <TiltCard className="w-64 p-6">
+        <h3 className="text-lg font-semibold text-foreground">
+          Designed in 3D
+        </h3>
+        <p className="mt-2 text-sm text-muted-foreground">
+          One spring drives rotation, depth, and glare together.
+        </p>
+      </TiltCard>
+      <TiltCard maxTilt={22} depth={70} className="w-64 p-6">
+        <h3 className="text-lg font-semibold text-foreground">
+          Deeper parallax
+        </h3>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Crank maxTilt and depth for a more dramatic effect.
+        </p>
+      </TiltCard>
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[300px] flex-wrap items-center justify-center gap-8 p-6 w-full">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -20,22 +49,7 @@ export function TiltCardResult() {
         </span>
       </div>
       <div className="flex min-h-[300px] flex-wrap items-center justify-center gap-8 p-10">
-        <TiltCard className="w-64 p-6">
-          <h3 className="text-lg font-semibold text-foreground">
-            Designed in 3D
-          </h3>
-          <p className="mt-2 text-sm text-muted-foreground">
-            One spring drives rotation, depth, and glare together.
-          </p>
-        </TiltCard>
-        <TiltCard maxTilt={22} depth={70} className="w-64 p-6">
-          <h3 className="text-lg font-semibold text-foreground">
-            Deeper parallax
-          </h3>
-          <p className="mt-2 text-sm text-muted-foreground">
-            Crank maxTilt and depth for a more dramatic effect.
-          </p>
-        </TiltCard>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/toast-result.tsx
+++ b/apps/docs/src/components/learn/toast-result.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ToastProvider, toast } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, imperative
@@ -8,6 +9,53 @@ import { ToastProvider, toast } from "@godui/components";
  * countdown, and drag one away to dismiss it.
  */
 export function ToastResult() {
+  const demo = (
+    <>
+      <button
+        type="button"
+        onClick={() =>
+          toast({ title: "Event created", description: "Friday at 5pm" })
+        }
+        className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground"
+      >
+        Show toast
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          toast.success({
+            title: "Saved",
+            description: "Your changes are live.",
+          })
+        }
+        className="rounded-lg bg-muted px-4 py-2 text-sm font-medium text-foreground"
+      >
+        Success
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          toast({
+            title: "Deleted file",
+            description: "report.pdf",
+            action: { label: "Undo", onClick: () => {} },
+          })
+        }
+        className="rounded-lg bg-muted px-4 py-2 text-sm font-medium text-foreground"
+      >
+        With action
+      </button>
+      <ToastProvider />
+    </>
+  );
+
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[240px] w-full flex-wrap items-center justify-center gap-3 p-6">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -19,41 +67,7 @@ export function ToastResult() {
         </span>
       </div>
       <div className="flex min-h-[240px] w-full flex-wrap items-center justify-center gap-3 p-10">
-        <button
-          type="button"
-          onClick={() =>
-            toast({ title: "Event created", description: "Friday at 5pm" })
-          }
-          className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground"
-        >
-          Show toast
-        </button>
-        <button
-          type="button"
-          onClick={() =>
-            toast.success({
-              title: "Saved",
-              description: "Your changes are live.",
-            })
-          }
-          className="rounded-lg bg-muted px-4 py-2 text-sm font-medium text-foreground"
-        >
-          Success
-        </button>
-        <button
-          type="button"
-          onClick={() =>
-            toast({
-              title: "Deleted file",
-              description: "report.pdf",
-              action: { label: "Undo", onClick: () => {} },
-            })
-          }
-          className="rounded-lg bg-muted px-4 py-2 text-sm font-medium text-foreground"
-        >
-          With action
-        </button>
-        <ToastProvider />
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/topographic-drift-result.tsx
+++ b/apps/docs/src/components/learn/topographic-drift-result.tsx
@@ -1,8 +1,23 @@
 "use client";
 
 import { TopographicDrift } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
+
+const demo = (
+  <div className="relative min-h-[320px] w-full overflow-hidden md:min-h-[380px]">
+    <TopographicDrift lineCount={9} noiseScale={0.004} speed={1} weight={1} />
+  </div>
+);
 
 export function TopographicDriftResult() {
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // background only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        {demo}
+      </div>
+    );
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -13,14 +28,7 @@ export function TopographicDriftResult() {
           the real component — drifting contours
         </span>
       </div>
-      <div className="relative min-h-[320px] overflow-hidden md:min-h-[380px]">
-        <TopographicDrift
-          lineCount={9}
-          noiseScale={0.004}
-          speed={1}
-          weight={1}
-        />
-      </div>
+      {demo}
     </div>
   );
 }

--- a/apps/docs/src/components/learn/voice-orb-result.tsx
+++ b/apps/docs/src/components/learn/voice-orb-result.tsx
@@ -2,6 +2,7 @@
 
 import { VoiceOrb, type VoiceOrbState } from "@godui/components";
 import * as React from "react";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Live VoiceOrb with synthetic amplitude — same idea as the docs demo,
@@ -30,6 +31,37 @@ export function VoiceOrbResult() {
     return () => cancelAnimationFrame(raf);
   }, [state]);
 
+  const demo = (
+    <div className="flex flex-col items-center justify-center gap-6">
+      <VoiceOrb state={state} amplitude={amp} />
+      <div className="flex flex-wrap justify-center gap-2">
+        {STATES.map((s) => (
+          <button
+            key={s}
+            type="button"
+            onClick={() => setState(s)}
+            className={`rounded-lg px-3 py-1.5 text-sm font-medium capitalize ${
+              state === s
+                ? "bg-primary text-primary-foreground"
+                : "bg-[var(--muted)] text-foreground hover:opacity-80"
+            }`}
+          >
+            {s}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // component only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -41,23 +73,7 @@ export function VoiceOrbResult() {
         </span>
       </div>
       <div className="flex min-h-[280px] flex-col items-center justify-center gap-6 p-10">
-        <VoiceOrb state={state} amplitude={amp} />
-        <div className="flex flex-wrap justify-center gap-2">
-          {STATES.map((s) => (
-            <button
-              key={s}
-              type="button"
-              onClick={() => setState(s)}
-              className={`rounded-lg px-3 py-1.5 text-sm font-medium capitalize ${
-                state === s
-                  ? "bg-primary text-primary-foreground"
-                  : "bg-[var(--muted)] text-foreground hover:opacity-80"
-              }`}
-            >
-              {s}
-            </button>
-          ))}
-        </div>
+        {demo}
       </div>
     </div>
   );

--- a/apps/docs/src/components/learn/warp-starfield-result.tsx
+++ b/apps/docs/src/components/learn/warp-starfield-result.tsx
@@ -1,12 +1,36 @@
 "use client";
 
 import { WarpStarfield } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Live WarpStarfield on the themed card surface — stars use --foreground,
  * so light and dark both stay readable without a forced night sky.
  */
 export function WarpStarfieldResult() {
+  // The interactive demo, reused by both the bare (LearnPlayer stage) and the
+  // classic carded return below.
+  const demo = (
+    <div className="relative min-h-[320px] w-full overflow-hidden rounded-2xl bg-[var(--card)] md:min-h-[380px]">
+      <WarpStarfield
+        starCount={400}
+        speed={1}
+        depth={1.5}
+        parallax={30}
+        warp={false}
+      />
+    </div>
+  );
+
+  // On the LearnPlayer stage, the player supplies the card — render the live
+  // field only. (Standalone / classic scroll layout keeps its own card.)
+  if (useBareScene())
+    return (
+      <div className="flex min-h-[280px] w-full items-center justify-center p-6">
+        {demo}
+      </div>
+    );
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">

--- a/apps/docs/src/components/learn/world-map-result.tsx
+++ b/apps/docs/src/components/learn/world-map-result.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { WorldMap } from "@godui/components";
+import { useBareScene } from "@/components/learn/bare-scene-context";
 
 /**
  * Closing "here's the finished thing" panel — the real, interactive
@@ -9,6 +10,30 @@ import { WorldMap } from "@godui/components";
  * panels.
  */
 export function WorldMapResult() {
+  const demo = (
+    <>
+      <WorldMap
+        connections={[
+          {
+            start: { lat: 37.7749, lng: -122.4194, label: "San Francisco" },
+            end: { lat: 51.5074, lng: -0.1278, label: "London" },
+          },
+          {
+            start: { lat: 51.5074, lng: -0.1278, label: "London" },
+            end: { lat: 35.6762, lng: 139.6503, label: "Tokyo" },
+          },
+          {
+            start: { lat: 40.7128, lng: -74.006, label: "New York" },
+            end: { lat: 1.3521, lng: 103.8198, label: "Singapore" },
+          },
+        ]}
+      />
+    </>
+  );
+
+  if (useBareScene())
+    return <div className="min-h-[280px] p-6 md:p-6 w-full">{demo}</div>;
+
   return (
     <div className="not-prose my-8 overflow-hidden rounded-2xl border border-fd-border bg-fd-card">
       <div className="flex items-center gap-2.5 border-b border-fd-border px-2.5 py-2">
@@ -19,24 +44,7 @@ export function WorldMapResult() {
           the real component — the arcs draw and loop
         </span>
       </div>
-      <div className="p-6 md:p-10">
-        <WorldMap
-          connections={[
-            {
-              start: { lat: 37.7749, lng: -122.4194, label: "San Francisco" },
-              end: { lat: 51.5074, lng: -0.1278, label: "London" },
-            },
-            {
-              start: { lat: 51.5074, lng: -0.1278, label: "London" },
-              end: { lat: 35.6762, lng: 139.6503, label: "Tokyo" },
-            },
-            {
-              start: { lat: 40.7128, lng: -74.006, label: "New York" },
-              end: { lat: 1.3521, lng: 103.8198, label: "Singapore" },
-            },
-          ]}
-        />
-      </div>
+      <div className="p-6 md:p-10">{demo}</div>
     </div>
   );
 }

--- a/apps/docs/src/components/mdx.tsx
+++ b/apps/docs/src/components/mdx.tsx
@@ -146,10 +146,13 @@ import { GlobeAnatomy } from "@/components/learn/globe-anatomy";
 import { GlobeLifecycle } from "@/components/learn/globe-lifecycle";
 import { GlobeResult } from "@/components/learn/globe-result";
 import { GlobeRotate } from "@/components/learn/globe-rotate";
-import { GooeyFabResult } from "@/components/learn/gooey-fab-result";
-import { GooeyFilter } from "@/components/learn/gooey-filter";
-import { GooeyLayers } from "@/components/learn/gooey-layers";
-import { GooeySpring } from "@/components/learn/gooey-spring";
+import {
+  GooeyFabResult,
+  GooeyFabResultBody,
+} from "@/components/learn/gooey-fab-result";
+import { GooeyFilter, GooeyFilterBody } from "@/components/learn/gooey-filter";
+import { GooeyLayers, GooeyLayersBody } from "@/components/learn/gooey-layers";
+import { GooeySpring, GooeySpringBody } from "@/components/learn/gooey-spring";
 import { GooeyStackAnatomy } from "@/components/learn/gooey-stack-anatomy";
 import { GooeyStackFilter } from "@/components/learn/gooey-stack-filter";
 import { GooeyStackNearness } from "@/components/learn/gooey-stack-nearness";
@@ -193,6 +196,8 @@ import { LampIgnite } from "@/components/learn/lamp-ignite";
 import { LampResult } from "@/components/learn/lamp-result";
 import { LampRise } from "@/components/learn/lamp-rise";
 import { LayerReveal } from "@/components/learn/layer-reveal";
+import { LearnChapter } from "@/components/learn/learn-chapter";
+import { LearnPlayer } from "@/components/learn/learn-player";
 import { LightRaysAnatomy } from "@/components/learn/light-rays-anatomy";
 import { LightRaysGrain } from "@/components/learn/light-rays-grain";
 import { LightRaysResult } from "@/components/learn/light-rays-result";
@@ -623,9 +628,13 @@ export function getMDXComponents(components?: MDXComponents) {
     GlobeResult,
     GlobeRotate,
     GooeyFabResult,
+    GooeyFabResultBody,
     GooeyFilter,
+    GooeyFilterBody,
     GooeyLayers,
+    GooeyLayersBody,
     GooeySpring,
+    GooeySpringBody,
     GooeyStackAnatomy,
     GooeyStackFilter,
     GooeyStackNearness,
@@ -669,6 +678,8 @@ export function getMDXComponents(components?: MDXComponents) {
     LampResult,
     LampRise,
     LayerReveal,
+    LearnChapter,
+    LearnPlayer,
     LightRaysAnatomy,
     LightRaysGrain,
     LightRaysResult,


### PR DESCRIPTION
## Summary
- Introduce a shared `LearnPlayer` carousel (sticky stage, chapter steps, collapsed code drawer) and migrate all 104 Learn articles to it via `learnPlayer: true` + `<LearnChapter>` chapters.
- Teach every Result preview `useBareScene` so stage chrome stays owned by the player; center scene bodies and size the last chapter so Result can pin until its title hits the card top.
- Wire docs page layout for `learnPlayer` (full width, no TOC) and register the new MDX components.

## Test plan
- [ ] Open any Learn tab (e.g. Gooey FAB, Magnetic Button, Animated Beam) — stage pins on desktop, chapters scroll on the left
- [ ] Confirm code panel starts collapsed; `</>` opens it
- [ ] Confirm scene content is centered in the stage
- [ ] On the Result step, scroll until the title reaches the card top — Motion Score should then come into view
- [ ] Spot-check overlays/navigation/text/visualizations Learn pages still render scenes + Result
- [ ] `pnpm check` and `pnpm test` pass

Made with [Cursor](https://cursor.com)