### PR TITLE
docs(learn): drop video from ASCII Dither result panel

### DIFF
--- a/apps/docs/src/components/learn/ascii-dither-result.tsx
+++ b/apps/docs/src/components/learn/ascii-dither-result.tsx
@@ -5,8 +5,6 @@ import { useBareScene } from "@/components/learn/bare-scene-context";
 
 const PORTRAIT =
   "https://images.unsplash.com/photo-1505740420928-5e560c06d30e?w=512&h=640&fit=crop&q=80";
-const VIDEO =
-  "https://videos.pexels.com/video-files/1409899/1409899-sd_640_360_25fps.mp4";
 
 function Demo() {
   return (
@@ -21,25 +19,13 @@ function Demo() {
           interactive
         />
       </div>
-      <div className="aspect-video w-full max-w-[30rem] overflow-hidden rounded-xl border border-fd-border bg-fd-card">
-        <AsciiDither
-          src={VIDEO}
-          alt="Ocean waves rendered as halftone dither"
-          type="video"
-          variant="dither"
-          dotShape="circle"
-          cellSize={5}
-          contrast={1.3}
-          color="theme"
-        />
-      </div>
     </div>
   );
 }
 
 /**
  * Closing "here's the finished thing" panel — the real component: a photo as
- * ASCII (hover to sweep the lens) and a live video as halftone dither.
+ * ASCII (hover to sweep the lens).
  */
 export function AsciiDitherResult() {
   if (useBareScene())


### PR DESCRIPTION
## Description

The ASCII Dither Learn page's "result" panel previously showed two demos — an ASCII image and a halftone-dither video. This trims it to just the ASCII image so the closing panel stays focused on the primary effect.

## Type of change

- [x] 📝 Docs

## Changes made

- Remove the halftone-dither video block from `AsciiDitherResult`
- Delete the now-unused `VIDEO` source constant
- Update the component doc comment to drop the video mention

## How to test

1. Run docs (`pnpm dev`)
2. Open the ASCII Dither component's Learn tab
3. Confirm the "The result" panel shows only the ASCII image (hover to sweep the lens), no video

## Checklist

- [x] Self-reviewed the diff; no stray logs, dead code, or commented-out blocks
- [x] Commits follow Conventional Commits
