### PR TITLE
fix(multi-button): keep compact disabled trigger expandable

### DIFF
--- a/packages/components/src/multi-button/multi-button.test.tsx
+++ b/packages/components/src/multi-button/multi-button.test.tsx
@@ -687,6 +687,88 @@ describe("CompactMultiButton", () => {
     expect(screen.getAllByRole("button")).toHaveLength(1);
   });
 
+  it.each([
+    { gooey: false, mode: "classic" },
+    { gooey: true, mode: "gooey" },
+  ])("opens the $mode rail from a disabled selected action and activates its sibling", ({
+    gooey,
+  }) => {
+    const disabledOnClick = vi.fn();
+    const siblingOnClick = vi.fn();
+    const selectedItem = {
+      ...items[0],
+      disabled: true,
+      onClick: disabledOnClick,
+    };
+    const siblingItem = { ...items[1], onClick: siblingOnClick };
+    render(
+      <CompactMultiButton
+        items={[selectedItem, siblingItem]}
+        selectedId={selectedItem.id}
+        gooey={gooey}
+      />,
+    );
+
+    const group = screen.getByRole("group");
+    const selectedButton = screen.getByRole("button", { name: "View" });
+    expect(selectedButton).not.toBeDisabled();
+
+    touchTap(selectedButton);
+
+    expect(disabledOnClick).not.toHaveBeenCalled();
+    expect(group).toHaveAttribute("aria-expanded", "true");
+    expect(selectedButton).toBeDisabled();
+
+    finishWidthTransition(group);
+    const siblingButton = screen.getByRole("button", { name: "Edit" });
+    expect(siblingButton).not.toBeDisabled();
+
+    touchTap(siblingButton);
+
+    expect(siblingOnClick).toHaveBeenCalledOnce();
+    expect(disabledOnClick).not.toHaveBeenCalled();
+    expect(group).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it.each([
+    { gooey: false, mode: "classic" },
+    { gooey: true, mode: "gooey" },
+  ])("keeps the $mode disabled selected trigger focusable as a disclosure", async ({
+    gooey,
+  }) => {
+    const disabledOnClick = vi.fn();
+    const user = userEvent.setup();
+    const selectedItem = {
+      ...items[0],
+      disabled: true,
+      onClick: disabledOnClick,
+    };
+    render(
+      <CompactMultiButton
+        items={[selectedItem, items[1]]}
+        selectedId={selectedItem.id}
+        gooey={gooey}
+      />,
+    );
+
+    const group = screen.getByRole("group");
+    const selectedButton = screen.getByRole("button", { name: "View" });
+    expect(group).toHaveAttribute("aria-expanded", "false");
+    expect(selectedButton).not.toBeDisabled();
+
+    await user.tab();
+
+    expect(selectedButton).toHaveFocus();
+    expect(group).toHaveAttribute("aria-expanded", "true");
+    expect(selectedButton).toHaveAttribute("aria-expanded", "true");
+    expect(selectedButton).toBeDisabled();
+
+    await user.keyboard("{Enter}");
+
+    expect(disabledOnClick).not.toHaveBeenCalled();
+    expect(group).toHaveAttribute("aria-expanded", "true");
+  });
+
   it("closes after an outside touch in the component's owner document", () => {
     const iframe = document.createElement("iframe");
     document.body.appendChild(iframe);

--- a/packages/components/src/multi-button/multi-button.tsx
+++ b/packages/components/src/multi-button/multi-button.tsx
@@ -659,6 +659,7 @@ type MultiButtonItemButtonProps = {
   accessible?: boolean;
   ariaLabel?: string;
   disclosureExpanded?: boolean;
+  disabled: boolean;
   highlighted: boolean;
   gooey?: boolean;
   gooeyExpanded?: boolean;
@@ -753,6 +754,7 @@ function MultiButtonItemButton({
   accessible = true,
   ariaLabel,
   disclosureExpanded,
+  disabled,
   highlighted,
   gooey = false,
   gooeyExpanded = true,
@@ -781,8 +783,9 @@ function MultiButtonItemButton({
       aria-expanded={disclosureExpanded}
       aria-hidden={accessible ? undefined : true}
       tabIndex={accessible ? undefined : -1}
-      disabled={item.disabled}
+      disabled={disabled}
       onClick={(event) => {
+        if (item.disabled) return;
         item.onClick?.(event);
         onAction?.(event);
       }}
@@ -919,6 +922,7 @@ function MultiButtonItems({
   return items.map((item, index) => {
     const active = activeId === item.id;
     const selected = selectedId === item.id;
+    const collapsedSelectedTrigger = compact && selected && !expanded;
     const width =
       compact && !expanded
         ? selected
@@ -948,11 +952,12 @@ function MultiButtonItems({
           active={active}
           accessible={!compact || interactionReady || selected}
           ariaLabel={
-            compact && selected && !expanded
+            collapsedSelectedTrigger
               ? (restAriaLabel ?? (restIcon ? "Open actions" : undefined))
               : undefined
           }
           disclosureExpanded={compact && selected ? expanded : undefined}
+          disabled={Boolean(item.disabled && !collapsedSelectedTrigger)}
           highlighted={!gooey && Boolean(highlightColor) && active}
           gooey={gooey}
           gooeyExpanded={expanded}


### PR DESCRIPTION
## Summary

- Finding ID: finding:9919c32690ff0ccca1159b714f8747ed
- Keep a disabled selected CompactMultiButton item enabled only while collapsed so its disclosure pointer and keyboard focus paths can open the rail.
- Reapply native disabled state once expanded and guard disabled callbacks from direct click dispatches.
- Add classic and gooey touch and keyboard regression coverage.

## Validation

- `pnpm --filter @godui/components exec vitest run src/multi-button/multi-button.test.tsx` — 54 passed.
- `pnpm test` — 498 tests passed across 87 component files.
- `pnpm --filter @godui/components lint` — passed.
- Targeted Biome check and `git diff --check` — passed.
- `pnpm build:registry` — passed.
- `pnpm check` remains blocked by pre-existing repository findings: 16 existing `<img>` warnings and the existing unformatted `apps/docs/public/r/multi-button.json`; the HEAD version reproduces the same formatter error independently.