### PR TITLE
ci: run Biome check in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,8 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+      - name: Check
+        run: pnpm check
+
       - name: Test
         run: pnpm test

--- a/apps/docs/public/r/multi-button.json
+++ b/apps/docs/public/r/multi-button.json
@@ -3,12 +3,8 @@
   "name": "multi-button",
   "title": "Multi Button",
   "description": "A responsive action rail where Standard reserves width, Compact collapses, Original pairs ease-out redistribution with spring labels, and Gooey adds elastic metaballs.",
-  "dependencies": [
-    "framer-motion"
-  ],
-  "registryDependencies": [
-    "@godui/godui-theme"
-  ],
+  "dependencies": ["framer-motion"],
+  "registryDependencies": ["@godui/godui-theme"],
   "files": [
     {
       "path": "packages/components/src/multi-button/multi-button.tsx",


### PR DESCRIPTION
## Summary

- Finding: finding:9a368055f90e2a79ccd12e8bd4660e8f
- Add an explicit `pnpm check` step to the GitHub Actions CI job so the repository Biome gate runs on pull requests and pushes to `main`.
- Format the existing `apps/docs/public/r/multi-button.json` registry artifact so the newly enforced gate is green.

## Validation

- `pnpm check` — passed with 16 existing `noImgElement` warnings.
- `pnpm lint` — passed with 19 existing warnings.
- `pnpm test` — passed: 87 test files, 494 tests.
- `git diff --check` — passed.