### PR TITLE
fix: reject inherited background preset keys

### DIFF
--- a/packages/components/src/lib/background-registry.test.ts
+++ b/packages/components/src/lib/background-registry.test.ts
@@ -33,6 +33,16 @@ describe("buildBackgroundFileContent", () => {
     );
   });
 
+  it.each([
+    "toString",
+    "constructor",
+    "__proto__",
+  ])("falls back to the default variant for inherited preset key %s", (variant) => {
+    expect(buildBackgroundFileContent("geometric-background", variant)).toBe(
+      buildBackgroundFileContent("geometric-background"),
+    );
+  });
+
   it("returns null for a non-background item", () => {
     expect(buildBackgroundFileContent("magic-button")).toBeNull();
   });

--- a/packages/components/src/lib/background-registry.ts
+++ b/packages/components/src/lib/background-registry.ts
@@ -68,7 +68,9 @@ export function buildBackgroundFileContent(
   const entry = REGISTRY[name];
   if (!entry) return null;
   const id =
-    variant && variant in entry.presets ? variant : entry.defaultVariant;
+    variant && Object.hasOwn(entry.presets, variant)
+      ? variant
+      : entry.defaultVariant;
   // The committed source already bakes the default variant.
   if (id === entry.defaultVariant) return entry.source;
   return entry.source.replace(


### PR DESCRIPTION
## Finding
- finding:9bc2fe5ba2c3505cfaa70e0972128c1c

## Summary
- Use an own-property check when resolving dynamic background preset variants.
- Add regression coverage for `toString`, `constructor`, and `__proto__`; valid presets remain customized.

## Validation
- focused Vitest — passed (9 tests)
- component lint — passed
- targeted Biome — passed
- pnpm test — passed (4 Turbo tasks; 87 component test files / 497 tests)
- pnpm build:registry — passed.
- Live docs route requests — reserved/unknown match default, blue valid customized.
- pnpm check — changed files pass, full check reports pre-existing `apps/docs/public/r/multi-button.json` formatter error plus existing image warnings.
This PR intentionally remains a draft.