### PR TITLE
fix(mcp): evict rejected registry requests

### DIFF
--- a/packages/mcp/src/registry-client.test.ts
+++ b/packages/mcp/src/registry-client.test.ts
@@ -20,6 +20,26 @@ describe("registry client", () => {
     );
   });
 
+  it("evicts a rejected index request so a later call can retry", async () => {
+    const fetchJsonImpl = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("temporary failure"))
+      .mockResolvedValueOnce({ name: "godui", homepage: "x", components: [] });
+    const client = createRegistryClient({
+      baseUrl: "http://localhost:3000/r",
+      fetchJsonImpl,
+    });
+
+    await expect(client.getIndex()).rejects.toThrow("temporary failure");
+    await expect(client.getIndex()).resolves.toEqual({
+      name: "godui",
+      homepage: "x",
+      components: [],
+    });
+
+    expect(fetchJsonImpl).toHaveBeenCalledTimes(2);
+  });
+
   it("fetches a component, strips the @godui/ prefix, and caches per key", async () => {
     const fetchJsonImpl = vi.fn().mockResolvedValue({ name: "magic-button" });
     const client = createRegistryClient({
@@ -34,6 +54,29 @@ describe("registry client", () => {
     expect(fetchJsonImpl).toHaveBeenCalledWith(
       "http://localhost:3000/r/magic-button.json",
     );
+  });
+
+  it("shares a rejected component request and retries after it is evicted", async () => {
+    const fetchJsonImpl = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("temporary failure"))
+      .mockResolvedValueOnce({ name: "magic-button" });
+    const client = createRegistryClient({
+      baseUrl: "http://localhost:3000/r",
+      fetchJsonImpl,
+    });
+
+    const firstCall = client.getComponent("magic-button");
+    const concurrentCall = client.getComponent("magic-button");
+
+    expect(concurrentCall).toBe(firstCall);
+    await expect(firstCall).rejects.toThrow("temporary failure");
+    await expect(concurrentCall).rejects.toThrow("temporary failure");
+    await expect(client.getComponent("magic-button")).resolves.toEqual({
+      name: "magic-button",
+    });
+
+    expect(fetchJsonImpl).toHaveBeenCalledTimes(2);
   });
 
   it("appends a variant query for background components", async () => {

--- a/packages/mcp/src/registry-client.ts
+++ b/packages/mcp/src/registry-client.ts
@@ -82,7 +82,16 @@ export function createRegistryClient(
 
   return {
     getIndex() {
-      indexCache ??= get<CatalogIndex>(`${baseUrl}/index.json`);
+      if (!indexCache) {
+        const request = get<CatalogIndex>(`${baseUrl}/index.json`);
+        const pending = request.catch((error) => {
+          if (indexCache === pending) {
+            indexCache = undefined;
+          }
+          throw error;
+        });
+        indexCache = pending;
+      }
       return indexCache;
     },
     getComponent(name, variant) {
@@ -91,7 +100,13 @@ export function createRegistryClient(
       const key = `${slug}${query}`;
       let pending = componentCache.get(key);
       if (!pending) {
-        pending = get<RegistryItem>(`${baseUrl}/${slug}.json${query}`);
+        const request = get<RegistryItem>(`${baseUrl}/${slug}.json${query}`);
+        pending = request.catch((error) => {
+          if (componentCache.get(key) === pending) {
+            componentCache.delete(key);
+          }
+          throw error;
+        });
         componentCache.set(key, pending);
       }
       return pending;


### PR DESCRIPTION
## Finding
finding:a0b468db38814adf31bc9035584b6842

## Summary
- Evict rejected index and component registry requests from their caches.
- Preserve promise sharing for concurrent callers while allowing later retries after transient failures.
- Add regression tests for index retry and concurrent component failure recovery.

## Validation
- `pnpm --filter @godui/mcp test -- src/registry-client.test.ts` — passed (2 files, 16 tests).
- `pnpm --filter @godui/mcp lint` — passed.
- `pnpm exec biome check packages/mcp/src/registry-client.ts packages/mcp/src/registry-client.test.ts` — passed.
- `pnpm test` — passed (4 Turbo tasks; 16 MCP tests and 494 component tests).
- `pnpm check` — existing unrelated docs issues remain: one formatting error in `apps/docs/public/r/multi-button.json` and 16 existing `<img>` warnings; changed MCP files pass direct Biome validation.