### PR TITLE
fix(docs): handle clipboard copy failures

### DIFF
--- a/apps/docs/src/components/copy-button.tsx
+++ b/apps/docs/src/components/copy-button.tsx
@@ -8,19 +8,36 @@ type CopyButtonProps = {
   className?: string;
 };
 
+type CopyStatus = "idle" | "copied" | "error";
+
 export function CopyButton({ value, className }: CopyButtonProps) {
-  const [copied, setCopied] = useState(false);
+  const [status, setStatus] = useState<CopyStatus>("idle");
 
   const onCopy = useCallback(async () => {
-    await navigator.clipboard.writeText(value);
-    setCopied(true);
-    window.setTimeout(() => setCopied(false), 2000);
+    try {
+      const clipboard = navigator.clipboard;
+      if (typeof clipboard?.writeText !== "function") {
+        throw new Error("Clipboard API is unavailable");
+      }
+
+      await clipboard.writeText(value);
+      setStatus("copied");
+    } catch {
+      setStatus("error");
+    }
+
+    window.setTimeout(() => setStatus("idle"), 2000);
   }, [value]);
+
+  const copied = status === "copied";
+  const failed = status === "error";
 
   return (
     <button
       type="button"
-      aria-label={copied ? "Copied" : "Copy to clipboard"}
+      aria-label={
+        copied ? "Copied" : failed ? "Copy failed" : "Copy to clipboard"
+      }
       onClick={onCopy}
       className={cn(
         // Radius comes from the call site (cn has no tailwind-merge, so a base
@@ -64,6 +81,9 @@ export function CopyButton({ value, className }: CopyButtonProps) {
             <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
           </svg>
         )}
+      </span>
+      <span aria-live="polite" role="status" className="sr-only">
+        {copied ? "Copied" : failed ? "Copy failed" : ""}
       </span>
     </button>
   );


### PR DESCRIPTION
Finding ID: finding:93f9daff176df6affe0ba888d04c740b

## Summary
- Feature-detect the Clipboard API before writing.
- Catch rejected or unavailable clipboard writes and expose a transient `Copy failed` accessible status.
- Preserve the existing `Copied` state and two-second reset; failed controls remain retryable.

## Validation
- Focused Vitest/jsdom harness: 3 tests passed, covering rejected writes with no unhandled rejection, missing API/recovery, and success/reset.
- `pnpm --filter docs lint`: passed with 19 pre-existing image warnings.
- `pnpm exec tsc -p apps/docs/tsconfig.json --noEmit`: passed.
- `pnpm --filter docs build`: passed.
- `pnpm test`: passed (494 component tests plus CLI/MCP suites).
- `pnpm check`: pre-existing failure in unrelated demo `<img>` rules and formatting of `apps/docs/public/r/multi-button.json`; changed file passes Biome.