### PR TITLE
fix(docs): clean up workbench resize on unmount

### DIFF
--- a/apps/docs/src/lib/use-resizable-pane.ts
+++ b/apps/docs/src/lib/use-resizable-pane.ts
@@ -81,6 +81,19 @@ export function useResizablePane({
   const pending = useRef(defaultPx);
   const start = useRef({ coord: 0, px: defaultPx });
 
+  // Navigation can unmount the workbench before pointerup. Cancel only the
+  // transient drag work here: there is no settled value to commit once this
+  // hook's owner is gone.
+  useEffect(() => {
+    return () => {
+      if (frame.current) {
+        cancelAnimationFrame(frame.current);
+        frame.current = 0;
+      }
+      delete document.documentElement.dataset.wbResizing;
+    };
+  }, []);
+
   const measure = useCallback(() => {
     const container = containerRef.current;
     const containerPx = container


### PR DESCRIPTION
Finding ID: finding:a7f2c720ff2a7eefbec7b0153304e7e3

## Summary
- Register an unmount-only cleanup for useResizablePane.
- Cancel any pending resize animation frame and remove data-wb-resizing.
- Leave the settled-size commit path unchanged so navigation cannot persist stale drag state.

## Validation
- pnpm exec biome check apps/docs/src/lib/use-resizable-pane.ts — passed.
- pnpm --filter docs lint — passed (existing image optimization warnings only).
- pnpm exec turbo test --force --output-logs=errors-only — passed (494 tests).
- pnpm --filter docs build — passed (TypeScript and 231 generated pages).
- pnpm check — existing unrelated failure: apps/docs/public/r/multi-button.json formatting; existing image warnings also reported.
- No existing apps/docs test suite covers this hook; a temporary lifecycle probe was attempted but the Node 26/jsdom runner was not reliable and was removed.