### PR TITLE
ci: enforce formatting and registry consistency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,11 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+      - name: Check
+        run: pnpm check
+
+      - name: Check generated registry
+        run: pnpm check:registry
+
       - name: Test
         run: pnpm test

--- a/apps/docs/public/r/index.json
+++ b/apps/docs/public/r/index.json
@@ -1,7 +1,6 @@
 {
   "name": "godui",
   "homepage": "https://godui.design",
-  "generatedAt": "2026-08-08T06:24:25.282Z",
   "components": [
     {
       "name": "accordion",

--- a/apps/docs/public/r/multi-button.json
+++ b/apps/docs/public/r/multi-button.json
@@ -3,12 +3,8 @@
   "name": "multi-button",
   "title": "Multi Button",
   "description": "A responsive action rail where Standard reserves width, Compact collapses, Original pairs ease-out redistribution with spring labels, and Gooey adds elastic metaballs.",
-  "dependencies": [
-    "framer-motion"
-  ],
-  "registryDependencies": [
-    "@godui/godui-theme"
-  ],
+  "dependencies": ["framer-motion"],
+  "registryDependencies": ["@godui/godui-theme"],
   "files": [
     {
       "path": "packages/components/src/multi-button/multi-button.tsx",

--- a/apps/docs/scripts/generate-mcp-index.mjs
+++ b/apps/docs/scripts/generate-mcp-index.mjs
@@ -49,7 +49,6 @@ const components = registry.items
 const index = {
   name: registry.name,
   homepage: registry.homepage,
-  generatedAt: new Date().toISOString(),
   components,
 };
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "scripts": {
     "build": "turbo build",
-    "build:registry": "shadcn build --output apps/docs/public/r && node apps/docs/scripts/generate-mcp-index.mjs",
+    "build:registry": "rm -rf apps/docs/public/r && shadcn build --output apps/docs/public/r && node apps/docs/scripts/generate-mcp-index.mjs && biome format --write apps/docs/public/r",
+    "check:registry": "pnpm build:registry && git diff --exit-code -- apps/docs/public/r && test -z \"$(git status --short --untracked-files=all -- apps/docs/public/r)\"",
     "dev": "turbo dev",
     "dev:portless": "portless",
     "lint": "turbo lint",


### PR DESCRIPTION
## Finding

`finding:70a856139a508a1839e4e2173baf6622`

## Implementation

- Format and newline-normalize the checked-in Multi Button registry artifact.
- Remove the nondeterministic MCP catalog timestamp.
- Make registry generation clean, format its output, and add `pnpm check:registry` to detect tracked and untracked drift.
- Run `pnpm check` and `pnpm check:registry` in CI.

## Validation

- `pnpm check` passed with 16 existing non-failing `<img>` warnings.
- `pnpm lint` passed.
- `pnpm test` passed: 87 files, 494 tests.
- `pnpm build:registry` regenerated 110 artifacts successfully.
- `pnpm check:registry` passed on a clean worktree.
- A temporary committed formatting drift caused the registry gate to fail as expected.