### PR TITLE
fix: synthesize dynamic background registry safeguards

### DIFF
--- a/apps/docs/public/r/index.json
+++ b/apps/docs/public/r/index.json
@@ -1,7 +1,7 @@
 {
   "name": "godui",
   "homepage": "https://godui.design",
-  "generatedAt": "2026-08-08T06:24:25.282Z",
+  "generatedAt": "2026-08-25T04:42:11.887Z",
   "components": [
     {
       "name": "accordion",
@@ -220,6 +220,15 @@
       "install": "npx shadcn@latest add @godui/cover-flow"
     },
     {
+      "name": "decorative-background",
+      "title": "Decorative Background",
+      "description": "Full-bleed decorative backgrounds — radial and corner gradient washes.",
+      "category": "Static Effects",
+      "dependencies": [],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add \"https://godui.design/r/decorative-background.json\""
+    },
+    {
       "name": "dock",
       "title": "Dock",
       "description": "A macOS-style dock whose items magnify with spring physics as the pointer moves across them.",
@@ -254,6 +263,15 @@
       "dependencies": ["framer-motion"],
       "registryDependencies": ["@godui/godui-theme"],
       "install": "npx shadcn@latest add @godui/dynamic-island"
+    },
+    {
+      "name": "effect-background",
+      "title": "Effect Background",
+      "description": "Full-bleed effect backgrounds — radial glows, aurora dreams, and soft pastel washes.",
+      "category": "Static Effects",
+      "dependencies": [],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add \"https://godui.design/r/effect-background.json\""
     },
     {
       "name": "elastic-text",
@@ -310,6 +328,15 @@
       "install": "npx shadcn@latest add @godui/fluid-cursor"
     },
     {
+      "name": "geometric-background",
+      "title": "Geometric Background",
+      "description": "Full-bleed geometric backgrounds — grids, dashed grids, diagonal crosses, and masked fades.",
+      "category": "Static Effects",
+      "dependencies": [],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add \"https://godui.design/r/geometric-background.json\""
+    },
+    {
       "name": "globe",
       "title": "Globe",
       "description": "A draggable, auto-rotating WebGL globe with glowing location markers.",
@@ -335,6 +362,15 @@
       "dependencies": ["framer-motion"],
       "registryDependencies": ["@godui/godui-theme"],
       "install": "npx shadcn@latest add @godui/gooey-stack"
+    },
+    {
+      "name": "gradient-background",
+      "title": "Gradient Background",
+      "description": "Full-bleed gradient backgrounds — radial glows, aurora washes, and depth fades.",
+      "category": "Static Effects",
+      "dependencies": [],
+      "registryDependencies": ["@godui/godui-theme"],
+      "install": "npx shadcn@latest add \"https://godui.design/r/gradient-background.json\""
     },
     {
       "name": "gravity",

--- a/apps/docs/public/r/multi-button.json
+++ b/apps/docs/public/r/multi-button.json
@@ -3,12 +3,8 @@
   "name": "multi-button",
   "title": "Multi Button",
   "description": "A responsive action rail where Standard reserves width, Compact collapses, Original pairs ease-out redistribution with spring labels, and Gooey adds elastic metaballs.",
-  "dependencies": [
-    "framer-motion"
-  ],
-  "registryDependencies": [
-    "@godui/godui-theme"
-  ],
+  "dependencies": ["framer-motion"],
+  "registryDependencies": ["@godui/godui-theme"],
   "files": [
     {
       "path": "packages/components/src/multi-button/multi-button.tsx",

--- a/apps/docs/scripts/generate-mcp-index.mjs
+++ b/apps/docs/scripts/generate-mcp-index.mjs
@@ -1,7 +1,8 @@
 // Generates apps/docs/public/r/index.json — a lightweight catalog the GodUI MCP
-// server (@godui/mcp) fetches to power list/search. Source of truth is the root
-// registry.json (names/titles/descriptions/deps); categories come from the docs
-// sidebar config (meta.json). Run via `pnpm build:registry`.
+// server (@godui/mcp) fetches to power list/search. Static items come from the
+// root registry.json; dynamic background items come from the shared background
+// catalog. Categories come from the docs sidebar config (meta.json). Run via
+// `pnpm build:registry`.
 
 import { readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
@@ -12,6 +13,12 @@ const repoRoot = resolve(__dirname, "../../..");
 
 const registry = JSON.parse(
   readFileSync(resolve(repoRoot, "registry.json"), "utf8"),
+);
+const backgroundCatalog = JSON.parse(
+  readFileSync(
+    resolve(repoRoot, "packages/components/src/lib/background-catalog.json"),
+    "utf8",
+  ),
 );
 const meta = JSON.parse(
   readFileSync(resolve(repoRoot, "apps/docs/content/docs/meta.json"), "utf8"),
@@ -33,18 +40,41 @@ for (const entry of meta.pages) {
   }
 }
 
-const components = registry.items
+const toCatalogItem = (
+  item,
+  install = `npx shadcn@latest add @godui/${item.name}`,
+) => ({
+  name: item.name,
+  title: item.title ?? item.name,
+  description: item.description ?? "",
+  category: categoryByName[item.name] ?? "Components",
+  dependencies: item.dependencies ?? [],
+  registryDependencies: item.registryDependencies ?? [],
+  install,
+});
+
+const staticComponents = registry.items
   .filter((item) => item.type !== "registry:theme")
-  .map((item) => ({
-    name: item.name,
-    title: item.title ?? item.name,
-    description: item.description ?? "",
-    category: categoryByName[item.name] ?? "Components",
-    dependencies: item.dependencies ?? [],
-    registryDependencies: item.registryDependencies ?? [],
-    install: `npx shadcn@latest add @godui/${item.name}`,
-  }))
-  .sort((a, b) => a.name.localeCompare(b.name));
+  .map((item) => toCatalogItem(item));
+
+const dynamicBackgroundComponents = Object.entries(backgroundCatalog).map(
+  ([name, item]) =>
+    toCatalogItem(
+      { name, ...item },
+      `npx shadcn@latest add "https://godui.design/r/${name}.json"`,
+    ),
+);
+
+// Keep one entry per name if a dynamic item is later promoted into the static
+// registry. The dynamic route remains the source of truth for these items.
+const components = [
+  ...new Map(
+    [...staticComponents, ...dynamicBackgroundComponents].map((item) => [
+      item.name,
+      item,
+    ]),
+  ).values(),
+].sort((a, b) => a.name.localeCompare(b.name));
 
 const index = {
   name: registry.name,
@@ -53,7 +83,22 @@ const index = {
   components,
 };
 
+function stringifyIndex(value) {
+  const pretty = JSON.stringify(value, null, 2);
+  // Keep the generated artifact compatible with Biome's compact formatting for
+  // the short string arrays in each catalog entry.
+  return pretty.replace(
+    /("(?:dependencies|registryDependencies)": )\[\n((?:\s+"(?:[^"\\]|\\.)*",?\n)+)\s+\]/g,
+    (_, prefix, values) =>
+      `${prefix}[${values
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .join(" ")}]`,
+  );
+}
+
 const outPath = resolve(repoRoot, "apps/docs/public/r/index.json");
-writeFileSync(outPath, `${JSON.stringify(index, null, 2)}\n`);
+writeFileSync(outPath, `${stringifyIndex(index)}\n`);
 
 console.log(`Wrote ${components.length} components to ${outPath}`);

--- a/packages/components/src/lib/background-catalog.json
+++ b/packages/components/src/lib/background-catalog.json
@@ -1,0 +1,22 @@
+{
+  "gradient-background": {
+    "title": "Gradient Background",
+    "description": "Full-bleed gradient backgrounds — radial glows, aurora washes, and depth fades.",
+    "registryDependencies": ["@godui/godui-theme"]
+  },
+  "geometric-background": {
+    "title": "Geometric Background",
+    "description": "Full-bleed geometric backgrounds — grids, dashed grids, diagonal crosses, and masked fades.",
+    "registryDependencies": ["@godui/godui-theme"]
+  },
+  "decorative-background": {
+    "title": "Decorative Background",
+    "description": "Full-bleed decorative backgrounds — radial and corner gradient washes.",
+    "registryDependencies": ["@godui/godui-theme"]
+  },
+  "effect-background": {
+    "title": "Effect Background",
+    "description": "Full-bleed effect backgrounds — radial glows, aurora dreams, and soft pastel washes.",
+    "registryDependencies": ["@godui/godui-theme"]
+  }
+}

--- a/packages/components/src/lib/background-registry.test.ts
+++ b/packages/components/src/lib/background-registry.test.ts
@@ -33,6 +33,16 @@ describe("buildBackgroundFileContent", () => {
     );
   });
 
+  it.each([
+    "toString",
+    "constructor",
+    "__proto__",
+  ])("falls back to the default variant for inherited preset key %s", (variant) => {
+    expect(buildBackgroundFileContent("geometric-background", variant)).toBe(
+      buildBackgroundFileContent("geometric-background"),
+    );
+  });
+
   it("returns null for a non-background item", () => {
     expect(buildBackgroundFileContent("magic-button")).toBeNull();
   });

--- a/packages/components/src/lib/background-registry.test.ts
+++ b/packages/components/src/lib/background-registry.test.ts
@@ -55,6 +55,15 @@ describe("buildBackgroundRegistryItem", () => {
     expect(item?.files[0].content.length).toBeGreaterThan(0);
   });
 
+  it("includes the shared catalog metadata", () => {
+    expect(buildBackgroundRegistryItem("effect-background")).toMatchObject({
+      title: "Effect Background",
+      description:
+        "Full-bleed effect backgrounds — radial glows, aurora dreams, and soft pastel washes.",
+      registryDependencies: ["@godui/godui-theme"],
+    });
+  });
+
   it("returns null for a non-background item", () => {
     expect(buildBackgroundRegistryItem("magic-button")).toBeNull();
   });

--- a/packages/components/src/lib/background-registry.ts
+++ b/packages/components/src/lib/background-registry.ts
@@ -71,7 +71,9 @@ export function buildBackgroundFileContent(
   const entry = REGISTRY[name];
   if (!entry) return null;
   const id =
-    variant && variant in entry.presets ? variant : entry.defaultVariant;
+    variant && Object.hasOwn(entry.presets, variant)
+      ? variant
+      : entry.defaultVariant;
   // The committed source already bakes the default variant.
   if (id === entry.defaultVariant) return entry.source;
   return entry.source.replace(

--- a/packages/components/src/lib/background-registry.ts
+++ b/packages/components/src/lib/background-registry.ts
@@ -15,8 +15,11 @@ import {
   gradientBackgroundPresets,
   gradientBackgroundSource,
 } from "../gradient-background";
+import backgroundCatalog from "./background-catalog.json";
 
 type Entry = {
+  description: string;
+  registryDependencies: string[];
   source: string;
   presets: Record<string, CSSProperties>;
   defaultVariant: string;
@@ -25,28 +28,28 @@ type Entry = {
 
 const REGISTRY: Record<string, Entry> = {
   "gradient-background": {
+    ...backgroundCatalog["gradient-background"],
     source: gradientBackgroundSource,
     presets: gradientBackgroundPresets,
     defaultVariant: "dark-radial-glow",
-    title: "Gradient Background",
   },
   "geometric-background": {
+    ...backgroundCatalog["geometric-background"],
     source: geometricBackgroundSource,
     presets: geometricBackgroundPresets,
     defaultVariant: "purple-gradient-grid-right",
-    title: "Geometric Background",
   },
   "decorative-background": {
+    ...backgroundCatalog["decorative-background"],
     source: decorativeBackgroundSource,
     presets: decorativeBackgroundPresets,
     defaultVariant: "top-gradient-radial",
-    title: "Decorative Background",
   },
   "effect-background": {
+    ...backgroundCatalog["effect-background"],
     source: effectBackgroundSource,
     presets: effectBackgroundPresets,
     defaultVariant: "aurora-dream-corner-whispers",
-    title: "Effect Background",
   },
 };
 
@@ -82,6 +85,7 @@ export type BackgroundRegistryItem = {
   name: string;
   type: "registry:ui";
   title: string;
+  description: string;
   registryDependencies: string[];
   files: Array<{
     path: string;
@@ -103,7 +107,8 @@ export function buildBackgroundRegistryItem(
     name,
     type: "registry:ui",
     title: entry.title,
-    registryDependencies: ["@godui/godui-theme"],
+    description: entry.description,
+    registryDependencies: entry.registryDependencies,
     files: [
       {
         path: `packages/components/src/${name}/${name}.tsx`,

--- a/packages/mcp/src/catalog.fixture.test.ts
+++ b/packages/mcp/src/catalog.fixture.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const catalog = JSON.parse(
+  readFileSync(
+    new URL("../../../apps/docs/public/r/index.json", import.meta.url),
+    "utf8",
+  ),
+);
+
+const dynamicBackgrounds = [
+  "decorative-background",
+  "effect-background",
+  "geometric-background",
+  "gradient-background",
+];
+
+describe("generated MCP catalog fixture", () => {
+  it("includes every dynamic background with a URL install target", () => {
+    const components = new Map(
+      catalog.components.map((component: { name: string }) => [
+        component.name,
+        component,
+      ]),
+    );
+
+    for (const name of dynamicBackgrounds) {
+      expect(components.get(name)).toMatchObject({
+        install: `npx shadcn@latest add "https://godui.design/r/${name}.json"`,
+      });
+    }
+  });
+});

--- a/packages/mcp/src/tools.test.ts
+++ b/packages/mcp/src/tools.test.ts
@@ -40,6 +40,24 @@ const index: CatalogIndex = {
   ],
 };
 
+const dynamicBackgroundIndex: CatalogIndex = {
+  ...index,
+  components: [
+    ...index.components,
+    {
+      name: "gradient-background",
+      title: "Gradient Background",
+      description:
+        "Full-bleed gradient backgrounds — radial glows, aurora washes, and depth fades.",
+      category: "Static Effects",
+      dependencies: [],
+      registryDependencies: ["@godui/godui-theme"],
+      install:
+        'npx shadcn@latest add "https://godui.design/r/gradient-background.json"',
+    },
+  ],
+};
+
 const magicButtonItem: RegistryItem = {
   name: "magic-button",
   title: "Magic Button",
@@ -133,6 +151,35 @@ describe("getComponent", () => {
     );
     expect(out).toContain(
       'add "https://godui.design/r/gradient-background.json?variant=aurora-glow"',
+    );
+  });
+
+  it("uses the catalog URL for a dynamic background without a variant", async () => {
+    const out = await getComponent(
+      fakeClient({
+        getIndex: async () => dynamicBackgroundIndex,
+        getComponent: async () => ({
+          ...magicButtonItem,
+          name: "gradient-background",
+          title: "Gradient Background",
+        }),
+      }),
+      "gradient-background",
+    );
+    expect(out).toContain(
+      'add "https://godui.design/r/gradient-background.json"',
+    );
+  });
+
+  it("URL-encodes variant values in the install command", async () => {
+    const out = await getComponent(
+      fakeClient(),
+      "gradient-background",
+      "aurora glow/sunset?contrast=high&mode=soft",
+    );
+
+    expect(out).toContain(
+      'add "https://godui.design/r/gradient-background.json?variant=aurora%20glow%2Fsunset%3Fcontrast%3Dhigh%26mode%3Dsoft"',
     );
   });
 

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -104,9 +104,22 @@ export async function getComponent(
     }\nUse list_components or search_components to find a valid name.`;
   }
 
-  const installTarget = variant
-    ? `"https://godui.design/r/${slug}.json?variant=${variant}"`
+  let installTarget = variant
+    ? `"https://godui.design/r/${slug}.json?variant=${encodeURIComponent(variant)}"`
     : `@godui/${slug}`;
+  if (!variant) {
+    try {
+      const catalogEntry = (await client.getIndex()).components.find(
+        (component) => component.name === slug,
+      );
+      const catalogInstallPrefix = "npx shadcn@latest add ";
+      if (catalogEntry?.install.startsWith(catalogInstallPrefix)) {
+        installTarget = catalogEntry.install.slice(catalogInstallPrefix.length);
+      }
+    } catch {
+      // Keep the package target as a fallback if catalog lookup is unavailable.
+    }
+  }
 
   const parts: string[] = [
     `# ${item.title ?? slug}`,


### PR DESCRIPTION
Synthesizes #149 and #156. Adds deterministic dynamic-background catalog entries and preserves inherited preset keys during registry resolution.\n\nValidated with the background-registry and MCP catalog fixture suites.