### PR TITLE
fix(mcp): timeout registry requests

### DIFF
--- a/packages/mcp/src/registry-client.test.ts
+++ b/packages/mcp/src/registry-client.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createRegistryClient } from "./registry-client.js";
 
 describe("registry client", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
   it("fetches the index from <base>/index.json and caches it", async () => {
     const fetchJsonImpl = vi
       .fn()
@@ -62,5 +67,86 @@ describe("registry client", () => {
     expect(fetchJsonImpl).toHaveBeenCalledWith(
       "http://localhost:3000/r/index.json",
     );
+  });
+
+  it("retries an index request after it rejects", async () => {
+    const error = new Error("temporary failure");
+    const fetchJsonImpl = vi
+      .fn()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce({ name: "godui", homepage: "x", components: [] });
+    const client = createRegistryClient({ fetchJsonImpl });
+
+    await expect(client.getIndex()).rejects.toBe(error);
+    await expect(client.getIndex()).resolves.toEqual({
+      name: "godui",
+      homepage: "x",
+      components: [],
+    });
+    expect(fetchJsonImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries a component request after it rejects", async () => {
+    const error = new Error("temporary failure");
+    const fetchJsonImpl = vi
+      .fn()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce({ name: "magic-button" });
+    const client = createRegistryClient({ fetchJsonImpl });
+
+    await expect(client.getComponent("magic-button")).rejects.toBe(error);
+    await expect(client.getComponent("magic-button")).resolves.toEqual({
+      name: "magic-button",
+    });
+    expect(fetchJsonImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("times out an injected request and retries it", async () => {
+    vi.useFakeTimers();
+    const fetchJsonImpl = vi
+      .fn()
+      .mockImplementationOnce(() => new Promise<never>(() => {}))
+      .mockResolvedValueOnce({ name: "godui", homepage: "x", components: [] });
+    const client = createRegistryClient({
+      fetchJsonImpl,
+      requestTimeoutMs: 25,
+    });
+
+    const request = client.getIndex();
+    const rejection = expect(request).rejects.toThrow(
+      "GodUI registry request timed out after 25ms",
+    );
+    await vi.advanceTimersByTimeAsync(25);
+    await rejection;
+
+    await expect(client.getIndex()).resolves.toEqual({
+      name: "godui",
+      homepage: "x",
+      components: [],
+    });
+    expect(fetchJsonImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("aborts and rejects a stalled network request", async () => {
+    vi.useFakeTimers();
+    const fetchImpl = vi.fn(
+      (..._args: Parameters<typeof fetch>) => new Promise<Response>(() => {}),
+    );
+    vi.stubGlobal("fetch", fetchImpl);
+    const client = createRegistryClient({
+      baseUrl: "http://localhost:3000/r",
+      requestTimeoutMs: 25,
+    });
+
+    const request = client.getIndex();
+    const rejection = expect(request).rejects.toThrow(
+      "GodUI registry request timed out after 25ms",
+    );
+    await vi.advanceTimersByTimeAsync(25);
+    await rejection;
+
+    const [, init] = fetchImpl.mock.calls[0] ?? [];
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+    expect(init?.signal?.aborted).toBe(true);
   });
 });

--- a/packages/mcp/src/registry-client.ts
+++ b/packages/mcp/src/registry-client.ts
@@ -3,6 +3,7 @@
 // the newest components after each site deploy. Results are cached per process.
 
 const DEFAULT_BASE_URL = "https://godui.design/r";
+const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
 
 /** Base registry URL, overridable for local testing (e.g. http://localhost:3000/r). */
 export const registryBaseUrl = (
@@ -50,39 +51,107 @@ export type RegistryClient = {
   getComponent(name: string, variant?: string): Promise<RegistryItem>;
 };
 
-async function fetchJson<T>(url: string): Promise<T> {
-  let res: Response;
+function requestTimeoutError(url: string, timeoutMs: number): Error {
+  return new Error(
+    `GodUI registry request timed out after ${timeoutMs}ms: ${url}`,
+  );
+}
+
+function withRequestTimeout<T>(
+  request: Promise<T>,
+  url: string,
+  timeoutMs: number,
+  onTimeout?: () => void,
+): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      onTimeout?.();
+      reject(requestTimeoutError(url, timeoutMs));
+    }, timeoutMs);
+  });
+
+  return Promise.race([request, timeout]).finally(() => {
+    clearTimeout(timeoutId);
+  });
+}
+
+async function fetchJson<T>(
+  url: string,
+  requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
+): Promise<T> {
+  const controller = new AbortController();
+  const request = (async () => {
+    let res: Response;
+    try {
+      res = await fetch(url, {
+        headers: { accept: "application/json" },
+        signal: controller.signal,
+      });
+    } catch (cause) {
+      throw new Error(
+        `Failed to reach GodUI registry at ${url}: ${String(cause)}`,
+      );
+    }
+    if (!res.ok) {
+      throw new Error(
+        `GodUI registry request failed (${res.status} ${res.statusText}): ${url}`,
+      );
+    }
+    return (await res.json()) as T;
+  })();
+
   try {
-    res = await fetch(url, { headers: { accept: "application/json" } });
+    return await withRequestTimeout(request, url, requestTimeoutMs, () =>
+      controller.abort(),
+    );
   } catch (cause) {
-    throw new Error(
-      `Failed to reach GodUI registry at ${url}: ${String(cause)}`,
-    );
+    if (controller.signal.aborted) {
+      throw requestTimeoutError(url, requestTimeoutMs);
+    }
+    throw cause;
   }
-  if (!res.ok) {
-    throw new Error(
-      `GodUI registry request failed (${res.status} ${res.statusText}): ${url}`,
-    );
-  }
-  return (await res.json()) as T;
 }
 
 /**
- * Create a registry client. `fetchImpl` is injectable for tests; production
- * uses the global `fetch`.
+ * Create a registry client. `fetchJsonImpl` is injectable for tests;
+ * production uses the global `fetch`.
  */
 export function createRegistryClient(
-  options: { baseUrl?: string; fetchJsonImpl?: typeof fetchJson } = {},
+  options: {
+    baseUrl?: string;
+    fetchJsonImpl?: typeof fetchJson;
+    requestTimeoutMs?: number;
+  } = {},
 ): RegistryClient {
   const baseUrl = (options.baseUrl ?? registryBaseUrl).replace(/\/$/, "");
-  const get = options.fetchJsonImpl ?? fetchJson;
+  const requestTimeoutMs =
+    options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+  if (!Number.isFinite(requestTimeoutMs) || requestTimeoutMs <= 0) {
+    throw new RangeError(
+      "requestTimeoutMs must be a finite number greater than 0",
+    );
+  }
+
+  const fetchJsonImpl = options.fetchJsonImpl;
+  const get: typeof fetchJson = fetchJsonImpl
+    ? <T>(url: string) =>
+        withRequestTimeout(fetchJsonImpl<T>(url), url, requestTimeoutMs)
+    : <T>(url: string) => fetchJson<T>(url, requestTimeoutMs);
 
   let indexCache: Promise<CatalogIndex> | undefined;
   const componentCache = new Map<string, Promise<RegistryItem>>();
 
   return {
     getIndex() {
-      indexCache ??= get<CatalogIndex>(`${baseUrl}/index.json`);
+      if (indexCache) return indexCache;
+
+      let pending: Promise<CatalogIndex>;
+      pending = get<CatalogIndex>(`${baseUrl}/index.json`).catch((cause) => {
+        if (indexCache === pending) indexCache = undefined;
+        throw cause;
+      });
+      indexCache = pending;
       return indexCache;
     },
     getComponent(name, variant) {
@@ -92,6 +161,10 @@ export function createRegistryClient(
       let pending = componentCache.get(key);
       if (!pending) {
         pending = get<RegistryItem>(`${baseUrl}/${slug}.json${query}`);
+        pending = pending.catch((cause) => {
+          if (componentCache.get(key) === pending) componentCache.delete(key);
+          throw cause;
+        });
         componentCache.set(key, pending);
       }
       return pending;


### PR DESCRIPTION
## Finding
- finding:7affd23876865c2fb5856ea6fa57745c

## Summary
- Add a bounded, configurable `requestTimeoutMs` for registry requests.
- Abort production fetches on timeout and cover injected loaders with the same deadline.
- Remove rejected index/component promises from their caches so retries issue fresh requests.

## Validation
- `pnpm --filter @godui/mcp test` — passed, 18/18 tests.
- `pnpm --filter @godui/mcp lint` — passed.
- `pnpm --filter @godui/mcp build` — passed.
- Targeted Biome check and `git diff --check` — passed.
- `pnpm test` — passed (4 Turbo tasks).
- `pnpm check` — existing unrelated failure in `apps/docs/public/r/multi-button.json` plus 16 existing `<img>` warnings; changed MCP files pass targeted Biome.