### PR TITLE
fix(cli): pin MCP server package version

### DIFF
--- a/apps/docs/content/docs/mcp.mdx
+++ b/apps/docs/content/docs/mcp.mdx
@@ -45,8 +45,11 @@ The server exposes three tools:
 
 The server fetches the live registry at `https://godui.design/r`, so it always
 serves the latest components — no upgrade needed when GodUI ships something new.
-Point it at a local registry for development by setting `GODUI_REGISTRY_URL`:
+The installer and manual config pin the server to the approved `0.1.0` release.
+To update the server, review and publish the new release, then update the pinned
+version and rerun the installer. Point it at a local registry for development
+by setting `GODUI_REGISTRY_URL`:
 
 ```bash
-GODUI_REGISTRY_URL=http://localhost:3000/r npx @godui/mcp@latest
+GODUI_REGISTRY_URL=http://localhost:3000/r npx @godui/mcp@0.1.0
 ```

--- a/apps/docs/public/r/multi-button.json
+++ b/apps/docs/public/r/multi-button.json
@@ -3,12 +3,8 @@
   "name": "multi-button",
   "title": "Multi Button",
   "description": "A responsive action rail where Standard reserves width, Compact collapses, Original pairs ease-out redistribution with spring labels, and Gooey adds elastic metaballs.",
-  "dependencies": [
-    "framer-motion"
-  ],
-  "registryDependencies": [
-    "@godui/godui-theme"
-  ],
+  "dependencies": ["framer-motion"],
+  "registryDependencies": ["@godui/godui-theme"],
   "files": [
     {
       "path": "packages/components/src/multi-button/multi-button.tsx",

--- a/apps/docs/src/components/mcp-install.tsx
+++ b/apps/docs/src/components/mcp-install.tsx
@@ -22,7 +22,7 @@ const MANUAL_CONFIG = `{
   "mcpServers": {
     "godui": {
       "command": "npx",
-      "args": ["-y", "@godui/mcp@latest"]
+      "args": ["-y", "@godui/mcp@0.1.0"]
     }
   }
 }`;

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -26,6 +26,13 @@ npx @godui/cli@latest install <client>
 The command merges the GodUI server into the client's existing MCP config
 (creating it if needed) without touching your other servers.
 
+The installer deliberately pins the MCP server to the approved release
+`0.1.0`, so restarting your IDE does not silently select a new npm `latest`
+release. To update it, review and publish the new `@godui/mcp` version first,
+then update `GODUI_MCP_VERSION` in `src/install.ts`, the examples below, and
+the corresponding docs before releasing a new CLI version. Existing configs
+remain on their pinned version until the installer is run again.
+
 ## What it writes
 
 ```json
@@ -33,7 +40,7 @@ The command merges the GodUI server into the client's existing MCP config
   "mcpServers": {
     "godui": {
       "command": "npx",
-      "args": ["-y", "@godui/mcp@latest"]
+      "args": ["-y", "@godui/mcp@0.1.0"]
     }
   }
 }

--- a/packages/cli/src/install.test.ts
+++ b/packages/cli/src/install.test.ts
@@ -64,6 +64,15 @@ describe("getConfigPath", () => {
 });
 
 describe("mergeMcpConfig", () => {
+  it("writes the approved pinned MCP server version", () => {
+    const out = mergeMcpConfig(null);
+
+    expect(out.mcpServers?.[GODUI_SERVER_KEY]).toEqual({
+      command: "npx",
+      args: ["-y", "@godui/mcp@0.1.0"],
+    });
+  });
+
   it("adds the godui server to an empty config", () => {
     const out = mergeMcpConfig(null);
     expect(out.mcpServers?.[GODUI_SERVER_KEY]).toEqual(GODUI_SERVER);

--- a/packages/cli/src/install.ts
+++ b/packages/cli/src/install.ts
@@ -113,10 +113,14 @@ export type McpServerConfig = {
   args: string[];
 };
 
+// Deliberately pin the runtime version written into IDE configs. Update this
+// only after reviewing and publishing a new @godui/mcp release.
+const GODUI_MCP_VERSION = "0.1.0";
+
 /** The GodUI MCP server entry written into every client config. */
 export const GODUI_SERVER: McpServerConfig = {
   command: "npx",
-  args: ["-y", "@godui/mcp@latest"],
+  args: ["-y", `@godui/mcp@${GODUI_MCP_VERSION}`],
 };
 
 export const GODUI_SERVER_KEY = "godui";

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -15,7 +15,7 @@ Add this to your MCP config file:
   "mcpServers": {
     "godui": {
       "command": "npx",
-      "args": ["-y", "@godui/mcp@latest"]
+      "args": ["-y", "@godui/mcp@0.1.0"]
     }
   }
 }
@@ -50,7 +50,7 @@ always serves the latest components without an update. Override the base for
 local testing:
 
 ```bash
-GODUI_REGISTRY_URL=http://localhost:3000/r npx @godui/mcp@latest
+GODUI_REGISTRY_URL=http://localhost:3000/r npx @godui/mcp@0.1.0
 ```
 
 ## License


### PR DESCRIPTION
## Summary

- Finding: finding:86c07c465a64a7d461dc91d39e61301a
- Pin the CLI-generated and documented `@godui/mcp` command to the reviewed `0.1.0` release.
- Add a CLI regression test for the exact generated command and document the deliberate review-and-release upgrade path.
- Synchronize the docs examples and apply the required whitespace-only formatting fix to the existing generated Multi Button registry artifact.

## Validation

- `pnpm --filter @godui/cli test` — passed (9 tests).
- `pnpm --filter @godui/cli lint` — passed.
- `pnpm --filter @godui/cli build` — passed.
- `pnpm exec turbo test --force` — passed (4 tasks).
- `pnpm check` — passed with 16 existing image-element warnings.
- `pnpm --filter docs lint` — passed with 19 existing image-element warnings.
- Repository scan confirms no `@godui/mcp@latest` references remain.