### PR TITLE
fix: reject inherited background registry variants

### DIFF
--- a/packages/components/src/lib/background-registry.test.ts
+++ b/packages/components/src/lib/background-registry.test.ts
@@ -33,6 +33,16 @@ describe("buildBackgroundFileContent", () => {
     );
   });
 
+  it.each([
+    "constructor",
+    "toString",
+    "__proto__",
+  ])("falls back to the default variant for inherited preset name %s", (variant) => {
+    expect(buildBackgroundFileContent("geometric-background", variant)).toBe(
+      buildBackgroundFileContent("geometric-background"),
+    );
+  });
+
   it("returns null for a non-background item", () => {
     expect(buildBackgroundFileContent("magic-button")).toBeNull();
   });

--- a/packages/components/src/lib/background-registry.ts
+++ b/packages/components/src/lib/background-registry.ts
@@ -68,7 +68,9 @@ export function buildBackgroundFileContent(
   const entry = REGISTRY[name];
   if (!entry) return null;
   const id =
-    variant && variant in entry.presets ? variant : entry.defaultVariant;
+    variant && Object.hasOwn(entry.presets, variant)
+      ? variant
+      : entry.defaultVariant;
   // The committed source already bakes the default variant.
   if (id === entry.defaultVariant) return entry.source;
   return entry.source.replace(


### PR DESCRIPTION
## Summary

- Fix background preset membership to accept only own properties.
- Add regression coverage for `constructor`, `toString`, and `__proto__`.

Finding: `finding:ada9131c8fdd9392ee1ea62849df6c95`

## Validation

- `pnpm --filter @godui/components exec vitest run src/lib/background-registry.test.ts` — 9 tests passed.
- `pnpm test` — 87 test files / 497 tests passed.
- `pnpm --filter @godui/components lint` — passed.
- `pnpm --filter docs lint` — passed with existing image-element warnings.
- Live Next route smoke test — inherited variants matched the default source; `purple-gradient-grid-left` still baked its configured styles.
- `pnpm build:registry` — passed; generator-only formatting/timestamp drift was excluded from the focused commit.
- `pnpm check` still reports the pre-existing formatting error in `apps/docs/public/r/multi-button.json` (introduced by commit `01e171c`); the changed files pass targeted Biome checks.
