### PR TITLE
fix(mega-menu): prevent stale panels after rapid hover changes

### DIFF
--- a/packages/components/src/mega-menu/mega-menu.test.tsx
+++ b/packages/components/src/mega-menu/mega-menu.test.tsx
@@ -1,4 +1,10 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createRef } from "react";
 import { describe, expect, it, vi } from "vitest";
@@ -20,6 +26,20 @@ const items: MegaMenuItem[] = [
   { label: "Pricing", href: "/pricing" },
 ];
 
+const panelItems: MegaMenuItem[] = [
+  items[0],
+  {
+    label: "Solutions",
+    sections: [
+      {
+        heading: "Run",
+        links: [{ label: "Cloud", href: "/cloud" }],
+      },
+    ],
+  },
+  items[1],
+];
+
 describe("MegaMenu", () => {
   it("opens the panel on hover and shows links", async () => {
     render(<MegaMenu items={items} openDelay={0} />);
@@ -27,6 +47,38 @@ describe("MegaMenu", () => {
     await waitFor(() =>
       expect(screen.getByRole("link", { name: /Editor/ })).toBeInTheDocument(),
     );
+  });
+
+  it("only opens the most recently hovered panel", () => {
+    vi.useFakeTimers();
+    render(<MegaMenu items={panelItems} openDelay={100} />);
+
+    fireEvent.mouseEnter(screen.getByRole("button", { name: "Products" }));
+    act(() => vi.advanceTimersByTime(50));
+    fireEvent.mouseEnter(screen.getByRole("button", { name: "Solutions" }));
+
+    act(() => vi.advanceTimersByTime(50));
+    expect(
+      screen.queryByRole("link", { name: /Editor/ }),
+    ).not.toBeInTheDocument();
+
+    act(() => vi.advanceTimersByTime(50));
+    expect(screen.getByRole("link", { name: "Cloud" })).toBeInTheDocument();
+    vi.useRealTimers();
+  });
+
+  it("does not open a stale panel after hovering an item without sections", () => {
+    vi.useFakeTimers();
+    render(<MegaMenu items={items} openDelay={100} />);
+
+    fireEvent.mouseEnter(screen.getByRole("button", { name: "Products" }));
+    fireEvent.mouseEnter(screen.getByRole("link", { name: "Pricing" }));
+
+    act(() => vi.advanceTimersByTime(100));
+    expect(
+      screen.queryByRole("link", { name: /Editor/ }),
+    ).not.toBeInTheDocument();
+    vi.useRealTimers();
   });
 
   it("renders a plain link for items without sections", () => {

--- a/packages/components/src/mega-menu/mega-menu.tsx
+++ b/packages/components/src/mega-menu/mega-menu.tsx
@@ -78,6 +78,7 @@ const MegaMenu = React.forwardRef<HTMLElement, MegaMenuProps>(
       : ({ type: "spring", stiffness: 320, damping: 32, mass: 0.9 } as const);
 
     const scheduleOpen = (index: number) => {
+      clearTimeout(openTimer.current);
       clearTimeout(closeTimer.current);
       setHovered(index);
       if (!items[index]?.sections) {


### PR DESCRIPTION
Finding ID: finding:2ced63e6941c7f4f383c4fc2f2f09536

## Implementation
- Cancel the pending MegaMenu open timer whenever a new top-level item is entered.
- Add fake-timer regressions for rapid panel-to-panel and panel-to-plain-link hover changes.

## Validation
- Focused MegaMenu Vitest: 6 tests passed.
- `pnpm test`: all Turbo test tasks passed; @godui/components 496 tests, @godui/cli 8 tests, and @godui/mcp 14 tests (518 total).
- `pnpm --filter @godui/components lint`: passed.
- Targeted Biome check and `git diff --check`: passed.
- `pnpm build:registry`: passed.
- `pnpm check`: existing unrelated failures remain in docs image usage and `apps/docs/public/r/multi-button.json`; changed files pass targeted Biome.