### PR TITLE
fix(mcp): harden registry requests

### DIFF
--- a/apps/docs/public/r/multi-button.json
+++ b/apps/docs/public/r/multi-button.json
@@ -3,12 +3,8 @@
   "name": "multi-button",
   "title": "Multi Button",
   "description": "A responsive action rail where Standard reserves width, Compact collapses, Original pairs ease-out redistribution with spring labels, and Gooey adds elastic metaballs.",
-  "dependencies": [
-    "framer-motion"
-  ],
-  "registryDependencies": [
-    "@godui/godui-theme"
-  ],
+  "dependencies": ["framer-motion"],
+  "registryDependencies": ["@godui/godui-theme"],
   "files": [
     {
       "path": "packages/components/src/multi-button/multi-button.tsx",

--- a/packages/mcp/src/registry-client.test.ts
+++ b/packages/mcp/src/registry-client.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it, vi } from "vitest";
 import { createRegistryClient } from "./registry-client.js";
 
 describe("registry client", () => {
+  const index = { name: "godui", homepage: "x", components: [] };
+  const response = (body: string) =>
+    new Response(body, { headers: { "content-type": "application/json" } });
+
   it("fetches the index from <base>/index.json and caches it", async () => {
-    const fetchJsonImpl = vi
-      .fn()
-      .mockResolvedValue({ name: "godui", homepage: "x", components: [] });
+    const fetchJsonImpl = vi.fn().mockResolvedValue(index);
     const client = createRegistryClient({
       baseUrl: "http://localhost:3000/r",
       fetchJsonImpl,
@@ -18,6 +20,75 @@ describe("registry client", () => {
     expect(fetchJsonImpl).toHaveBeenCalledWith(
       "http://localhost:3000/r/index.json",
     );
+  });
+
+  it("times out a stalled registry request and aborts it", async () => {
+    let signal: AbortSignal | undefined;
+    const fetchImpl = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      signal = init?.signal ?? undefined;
+      return new Promise<Response>(() => undefined);
+    });
+    const client = createRegistryClient({
+      baseUrl: "http://localhost:3000/r",
+      fetchImpl,
+      timeoutMs: 10,
+    });
+
+    await expect(client.getIndex()).rejects.toThrow(
+      "GodUI registry request timed out after 10ms",
+    );
+    expect(signal?.aborted).toBe(true);
+  });
+
+  it("retries the index after a rejected request", async () => {
+    const fetchJsonImpl = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("temporary outage"))
+      .mockResolvedValueOnce(index);
+    const client = createRegistryClient({ fetchJsonImpl });
+
+    await expect(client.getIndex()).rejects.toThrow("temporary outage");
+    await expect(client.getIndex()).resolves.toEqual(index);
+
+    expect(fetchJsonImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects oversized responses and retries after the failure", async () => {
+    const validBody = JSON.stringify(index);
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(response(`${validBody}x`))
+      .mockResolvedValueOnce(response(validBody));
+    const client = createRegistryClient({
+      baseUrl: "http://localhost:3000/r",
+      fetchImpl,
+      maxResponseBytes: new TextEncoder().encode(validBody).byteLength,
+    });
+
+    await expect(client.getIndex()).rejects.toThrow(
+      "GodUI registry response exceeded the",
+    );
+    await expect(client.getIndex()).resolves.toEqual(index);
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects malformed responses and retries after the failure", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(response("not json"))
+      .mockResolvedValueOnce(response(JSON.stringify(index)));
+    const client = createRegistryClient({
+      baseUrl: "http://localhost:3000/r",
+      fetchImpl,
+    });
+
+    await expect(client.getIndex()).rejects.toThrow(
+      "Failed to parse GodUI registry response",
+    );
+    await expect(client.getIndex()).resolves.toEqual(index);
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
 
   it("fetches a component, strips the @godui/ prefix, and caches per key", async () => {

--- a/packages/mcp/src/registry-client.ts
+++ b/packages/mcp/src/registry-client.ts
@@ -3,6 +3,8 @@
 // the newest components after each site deploy. Results are cached per process.
 
 const DEFAULT_BASE_URL = "https://godui.design/r";
+const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_MAX_RESPONSE_BYTES = 1_048_576;
 
 /** Base registry URL, overridable for local testing (e.g. http://localhost:3000/r). */
 export const registryBaseUrl = (
@@ -50,39 +52,156 @@ export type RegistryClient = {
   getComponent(name: string, variant?: string): Promise<RegistryItem>;
 };
 
-async function fetchJson<T>(url: string): Promise<T> {
-  let res: Response;
+type FetchJsonOptions = {
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+  maxResponseBytes?: number;
+};
+
+async function readResponseText(
+  res: Response,
+  maxResponseBytes: number,
+  url: string,
+): Promise<string> {
+  const contentLength = res.headers.get("content-length");
+  if (contentLength && Number(contentLength) > maxResponseBytes) {
+    throw new Error(
+      `GodUI registry response exceeded the ${maxResponseBytes}-byte limit: ${url}`,
+    );
+  }
+
+  if (!res.body) return "";
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let bytesRead = 0;
+  let text = "";
+
   try {
-    res = await fetch(url, { headers: { accept: "application/json" } });
-  } catch (cause) {
-    throw new Error(
-      `Failed to reach GodUI registry at ${url}: ${String(cause)}`,
-    );
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      bytesRead += value.byteLength;
+      if (bytesRead > maxResponseBytes) {
+        void reader.cancel().catch(() => undefined);
+        throw new Error(
+          `GodUI registry response exceeded the ${maxResponseBytes}-byte limit: ${url}`,
+        );
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+    return text + decoder.decode();
+  } finally {
+    reader.releaseLock();
   }
-  if (!res.ok) {
-    throw new Error(
-      `GodUI registry request failed (${res.status} ${res.statusText}): ${url}`,
-    );
-  }
-  return (await res.json()) as T;
 }
 
+async function fetchJson<T>(
+  url: string,
+  {
+    fetchImpl = fetch,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    maxResponseBytes = DEFAULT_MAX_RESPONSE_BYTES,
+  }: FetchJsonOptions = {},
+): Promise<T> {
+  if (!Number.isFinite(timeoutMs) || timeoutMs < 0) {
+    throw new RangeError(
+      "Registry request timeout must be a finite non-negative number",
+    );
+  }
+  if (!Number.isFinite(maxResponseBytes) || maxResponseBytes <= 0) {
+    throw new RangeError(
+      "Registry response size limit must be a finite positive number",
+    );
+  }
+
+  const controller = new AbortController();
+  const timeoutError = new Error(
+    `GodUI registry request timed out after ${timeoutMs}ms: ${url}`,
+  );
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      controller.abort(timeoutError);
+      reject(timeoutError);
+    }, timeoutMs);
+  });
+
+  const request = (async () => {
+    let res: Response;
+    try {
+      res = await fetchImpl(url, {
+        headers: { accept: "application/json" },
+        signal: controller.signal,
+      });
+    } catch (cause) {
+      if (controller.signal.aborted) throw timeoutError;
+      throw new Error(
+        `Failed to reach GodUI registry at ${url}: ${String(cause)}`,
+      );
+    }
+    if (!res.ok) {
+      throw new Error(
+        `GodUI registry request failed (${res.status} ${res.statusText}): ${url}`,
+      );
+    }
+
+    const text = await readResponseText(res, maxResponseBytes, url);
+    try {
+      return JSON.parse(text) as T;
+    } catch (cause) {
+      throw new Error(`Failed to parse GodUI registry response: ${url}`, {
+        cause,
+      });
+    }
+  })();
+
+  try {
+    return await Promise.race([request, timeout]);
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+  }
+}
+
+type FetchJson = <T>(url: string) => Promise<T>;
+
 /**
- * Create a registry client. `fetchImpl` is injectable for tests; production
- * uses the global `fetch`.
+ * Create a registry client. `fetchImpl` and `fetchJsonImpl` are injectable for
+ * tests; production uses the global `fetch`.
  */
 export function createRegistryClient(
-  options: { baseUrl?: string; fetchJsonImpl?: typeof fetchJson } = {},
+  options: {
+    baseUrl?: string;
+    fetchImpl?: typeof fetch;
+    fetchJsonImpl?: FetchJson;
+    timeoutMs?: number;
+    maxResponseBytes?: number;
+  } = {},
 ): RegistryClient {
   const baseUrl = (options.baseUrl ?? registryBaseUrl).replace(/\/$/, "");
-  const get = options.fetchJsonImpl ?? fetchJson;
+  const get: FetchJson =
+    options.fetchJsonImpl ??
+    (<T>(url: string) =>
+      fetchJson<T>(url, {
+        fetchImpl: options.fetchImpl,
+        timeoutMs: options.timeoutMs,
+        maxResponseBytes: options.maxResponseBytes,
+      }));
 
   let indexCache: Promise<CatalogIndex> | undefined;
   const componentCache = new Map<string, Promise<RegistryItem>>();
 
   return {
     getIndex() {
-      indexCache ??= get<CatalogIndex>(`${baseUrl}/index.json`);
+      if (!indexCache) {
+        const pending = get<CatalogIndex>(`${baseUrl}/index.json`);
+        const cached = pending.catch((cause) => {
+          if (indexCache === cached) indexCache = undefined;
+          throw cause;
+        });
+        indexCache = cached;
+      }
       return indexCache;
     },
     getComponent(name, variant) {


### PR DESCRIPTION
Finding: finding:3083296d470aa7491c15109a59f90dc2

## Summary
- Add a configurable 10-second timeout that aborts and races the full registry fetch/body read.
- Enforce a configurable 1 MiB response-size limit using Content-Length and streamed reads.
- Clear the cached index promise after rejection so transient registry failures can recover.
- Add regression tests for stalled, rejected, oversized, and malformed index responses.
- Normalize one pre-existing generated registry JSON formatting issue required by `pnpm check`.

## Validation
- `pnpm check` (passes; 16 existing non-failing `<img>` warnings)
- `pnpm test` (passes; 494 component tests and 18 MCP tests)
- `pnpm --filter @godui/mcp lint` (passes)
- `pnpm --filter @godui/mcp build` (passes)
- `pnpm exec biome check packages/mcp/src/registry-client.ts packages/mcp/src/registry-client.test.ts` (passes)