### PR TITLE
fix(ci): pin npm release workflow actions

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -14,13 +14,13 @@ jobs:
       contents: read
       id-token: write # for npm provenance
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           cache: pnpm

--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -14,13 +14,13 @@ jobs:
       contents: read
       id-token: write # for npm provenance
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           cache: pnpm


### PR DESCRIPTION
## Finding

finding:2bab3654f5d0166ea6458a8d897f5dbd

## Implementation

- Replaced mutable `@v4` references for checkout, pnpm/action-setup, and setup-node in both npm release workflows with full commit SHAs.
- Retained `v4.4.0` comments to identify the pinned action releases for future dependency updates.

## Validation

- Full-SHA workflow assertion: passed for both release workflows (3/3 action references each).
- `git diff --check`: passed.
- `pnpm check`: passed (1,298 files).
- `pnpm test`: passed (87 test files, 494 tests).

This PR is intentionally left in draft.