### PR TITLE
ci: isolate pull-request checkout credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,16 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
Finding ID: finding:bfe5be4d4d1de56ef48e964ab0c84dba

## Summary
- Restrict workflow permissions to contents: read.
- Disable checkout credential persistence with persist-credentials: false.
- Keep the pull_request workflow free of explicit GitHub token or repository secret references.

## Validation
- pnpm check — passed (Biome checked 1298 files).
- pnpm test — passed (516 tests).
- pnpm lint — passed (19 existing next/no-img-element warnings).
- git diff --check — passed.
- GitHub Actions CI pull_request run for this PR — passed: https://github.com/LucasBassetti/godui/actions/runs/33252973483.
- Local git credential check — no checkout extraheader configured.
- Vercel preview checks were not run because the linked Vercel projects require authorization.