### PR TITLE
ci(security): pin release workflow actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -14,13 +14,13 @@ jobs:
       contents: read
       id-token: write # for npm provenance
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           cache: pnpm

--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -14,13 +14,13 @@ jobs:
       contents: read
       id-token: write # for npm provenance
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           cache: pnpm


### PR DESCRIPTION
Finding IDs:
- finding:2517b7f6ce9eaa59df638b2bc81765ee
- finding:3bb2a08e6e2f76feb6c9a772b1cd2138

## Implementation summary

- Pin checkout, pnpm setup, and Node setup in both npm release workflows to full immutable v4.4.0 commit SHAs.
- Retain `v4.4.0` comments beside each SHA so Dependabot can identify the intended release.
- Add weekly Dependabot GitHub Actions updates so SHA rotations arrive as reviewed dependency-update pull requests.

## Validation

- Verified all three pinned SHAs against the upstream `v4.4.0` tags; the annotated pnpm tag was checked against its peeled commit.
- Release workflow SHA and Dependabot assertions passed for both workflows.
- `pnpm --filter @godui/cli test` — passed (8 tests).
- `pnpm --filter @godui/mcp test` — passed (14 tests).
- `pnpm check` — passed (1,298 files).
- `pnpm test` — passed (87 files / 494 tests).
- `git diff --check` — passed.

The pull request intentionally remains draft until explicitly marked ready for review.