### PR TITLE
fix(docs): secure predev port handling

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "predev": "node scripts/free-dev-port.mjs",
     "dev": "next dev --turbopack",
+    "test": "node --test scripts/free-dev-port.test.mjs",
     "build": "next build --turbopack && node scripts/aeo-postbuild.mjs",
     "start": "next start",
     "lint": "eslint",

--- a/apps/docs/scripts/free-dev-port.mjs
+++ b/apps/docs/scripts/free-dev-port.mjs
@@ -6,17 +6,44 @@
 //
 // It only kills a listener whose working directory is THIS app — so running
 // several Conductor workspaces (each its own checkout) never kills a sibling's
-// dev server. Anything unexpected is swallowed: this must never block `dev`.
+// dev server. lsof failures are swallowed: this cleanup must never block `dev`.
 
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const PORT = process.env.PORT || "3000";
-const APP_DIR = resolve(process.cwd());
+const DEFAULT_PORT = 3000;
+const MAX_PORT = 65535;
+const DECIMAL_INTEGER = /^\d+$/;
+const POSITIVE_INTEGER = /^[1-9]\d*$/;
 
-function sh(cmd) {
+export function parsePort(value) {
+  if (value === undefined || value === "") {
+    return DEFAULT_PORT;
+  }
+
+  if (typeof value !== "string" || !DECIMAL_INTEGER.test(value)) {
+    return null;
+  }
+
+  const port = Number(value);
+  return Number.isSafeInteger(port) && port >= 1 && port <= MAX_PORT
+    ? port
+    : null;
+}
+
+export function parsePids(output) {
+  return output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => POSITIVE_INTEGER.test(line))
+    .map(Number)
+    .filter(Number.isSafeInteger);
+}
+
+function runLsof(args) {
   try {
-    return execSync(cmd, {
+    return execFileSync("lsof", args, {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
     });
@@ -25,29 +52,54 @@ function sh(cmd) {
   }
 }
 
-function cwdOf(pid) {
-  // `lsof -d cwd -Fn` prints the process cwd on a line prefixed with `n`.
-  const out = sh(`lsof -a -p ${pid} -d cwd -Fn`);
-  const line = out.split("\n").find((l) => l.startsWith("n"));
-  return line ? resolve(line.slice(1)) : "";
+export function freeDevPort({
+  portValue = process.env.PORT,
+  appDir = resolve(process.cwd()),
+  runLsofCommand = runLsof,
+  kill = process.kill,
+  onInvalidPort = (message) => console.error(message),
+  onFreed = (message) => console.log(message),
+} = {}) {
+  const port = parsePort(portValue);
+  if (port === null) {
+    onInvalidPort(
+      "[predev] PORT must be a decimal integer between 1 and 65535",
+    );
+    return false;
+  }
+
+  const cwdOf = (pid) => {
+    // `lsof -d cwd -Fn` prints the process cwd on a line prefixed with `n`.
+    const out = runLsofCommand(["-a", "-p", String(pid), "-d", "cwd", "-Fn"]);
+    const line = out.split("\n").find((l) => l.startsWith("n"));
+    return line ? resolve(line.slice(1)) : "";
+  };
+
+  const pids = parsePids(
+    runLsofCommand(["-nP", `-iTCP:${port}`, "-sTCP:LISTEN", "-t"]),
+  );
+
+  for (const pid of pids) {
+    const cwd = cwdOf(pid);
+    // Only reclaim the port from a stale server started inside this workspace.
+    if (cwd === appDir) {
+      try {
+        kill(pid, "SIGKILL");
+        onFreed(`[predev] freed port ${port} — killed stale dev server ${pid}`);
+      } catch {
+        // already gone
+      }
+    }
+  }
+
+  return true;
 }
 
-const pids = sh(`lsof -nP -iTCP:${PORT} -sTCP:LISTEN -t`)
-  .split("\n")
-  .map((s) => s.trim())
-  .filter(Boolean);
-
-for (const pid of pids) {
-  const cwd = cwdOf(pid);
-  // Only reclaim the port from a stale server started inside this workspace.
-  if (cwd === APP_DIR) {
-    try {
-      process.kill(Number(pid), "SIGKILL");
-      console.log(
-        `[predev] freed port ${PORT} — killed stale dev server ${pid}`,
-      );
-    } catch {
-      // already gone
-    }
+if (
+  process.argv[1] &&
+  fileURLToPath(import.meta.url) === resolve(process.argv[1])
+) {
+  if (!freeDevPort()) {
+    process.exitCode = 1;
   }
 }

--- a/apps/docs/scripts/free-dev-port.test.mjs
+++ b/apps/docs/scripts/free-dev-port.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { freeDevPort, parsePids, parsePort } from "./free-dev-port.mjs";
+
+test("accepts valid decimal ports", () => {
+  assert.equal(parsePort("1"), 1);
+  assert.equal(parsePort("3000"), 3000);
+  assert.equal(parsePort("65535"), 65535);
+  assert.equal(parsePort(undefined), 3000);
+});
+
+test("rejects non-decimal and out-of-range ports", () => {
+  for (const value of ["0", "65536", "3000.0", "+3000", "0xBB8", " "]) {
+    assert.equal(parsePort(value), null, value);
+  }
+});
+
+test("does not pass shell metacharacters to lsof", () => {
+  const calls = [];
+  const errors = [];
+
+  assert.equal(
+    freeDevPort({
+      portValue: "3000; touch /tmp/port-was-injected",
+      runLsofCommand(args) {
+        calls.push(args);
+        return "";
+      },
+      onInvalidPort(message) {
+        errors.push(message);
+      },
+    }),
+    false,
+  );
+
+  assert.deepEqual(calls, []);
+  assert.equal(errors.length, 1);
+});
+
+test("passes a validated port as an lsof argument", () => {
+  const calls = [];
+
+  assert.equal(
+    freeDevPort({
+      portValue: "4242",
+      runLsofCommand(args) {
+        calls.push(args);
+        return "";
+      },
+    }),
+    true,
+  );
+
+  assert.deepEqual(calls, [["-nP", "-iTCP:4242", "-sTCP:LISTEN", "-t"]]);
+});
+
+test("only accepts positive safe integer PIDs from lsof", () => {
+  assert.deepEqual(
+    parsePids("123\n0\n-1\n123; touch /tmp/port-was-injected\n456\n"),
+    [123, 456],
+  );
+});


### PR DESCRIPTION
Finding ID: finding:9caff4e020235e66cdb28e3b2cf785b6

## Implementation summary

- Validate PORT as a decimal integer in the 1-65535 range before any port lookup.
- Replace shell-backed lsof commands with execFileSync argument arrays.
- Parse lsof output into positive safe integer PIDs before querying cwd or sending SIGKILL.
- Add docs-app Node test coverage for valid ports, invalid values, shell metacharacters, argument construction, and PID filtering.

## Validation

- pnpm --filter docs test — passed (5 tests).
- pnpm --filter docs lint — passed with 19 existing Next image warnings.
- pnpm check — passed (1,306 files).
- pnpm test — passed (5 workspace tasks; 92 component files / 548 tests).
- Direct malicious PORT invocation — rejected before lsof; no marker was created.
- git diff --check — passed.

This pull request intentionally remains draft until explicitly marked ready for review.