### PR TITLE
fix(mcp): bound registry fetch responses

### DIFF
--- a/packages/mcp/src/registry-client.test.ts
+++ b/packages/mcp/src/registry-client.test.ts
@@ -2,6 +2,15 @@ import { describe, expect, it, vi } from "vitest";
 import { createRegistryClient } from "./registry-client.js";
 
 describe("registry client", () => {
+  const index = {
+    name: "godui",
+    homepage: "https://godui.design",
+    components: [],
+  };
+
+  const jsonResponse = (body: string, contentType = "application/json") =>
+    new Response(body, { headers: { "content-type": contentType } });
+
   it("fetches the index from <base>/index.json and caches it", async () => {
     const fetchJsonImpl = vi
       .fn()
@@ -17,6 +26,120 @@ describe("registry client", () => {
     expect(fetchJsonImpl).toHaveBeenCalledTimes(1);
     expect(fetchJsonImpl).toHaveBeenCalledWith(
       "http://localhost:3000/r/index.json",
+    );
+  });
+
+  it("aborts a stalled registry request after the configured deadline", async () => {
+    let signal: AbortSignal | undefined;
+    const fetchImpl = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      signal = init?.signal ?? undefined;
+      return new Promise<Response>(() => undefined);
+    });
+    const client = createRegistryClient({
+      baseUrl: "http://localhost:3000/r",
+      fetchImpl,
+      timeoutMs: 10,
+    });
+
+    await expect(client.getIndex()).rejects.toThrow(
+      "GodUI registry request timed out after 10ms",
+    );
+    expect(signal?.aborted).toBe(true);
+  });
+
+  it("applies the deadline while reading a response body", async () => {
+    let signal: AbortSignal | undefined;
+    const fetchImpl = vi.fn(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        signal = init?.signal ?? undefined;
+        const body = new ReadableStream<Uint8Array>({
+          pull: () => new Promise<void>(() => undefined),
+        });
+        return new Response(body, {
+          headers: { "content-type": "application/json" },
+        });
+      },
+    );
+    const client = createRegistryClient({
+      baseUrl: "http://localhost:3000/r",
+      fetchImpl,
+      timeoutMs: 10,
+    });
+
+    await expect(client.getIndex()).rejects.toThrow(
+      "GodUI registry request timed out after 10ms",
+    );
+    expect(signal?.aborted).toBe(true);
+  });
+
+  it("rejects a response whose declared size exceeds the limit", async () => {
+    const body = JSON.stringify(index);
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(body, {
+        headers: {
+          "content-length": String(
+            new TextEncoder().encode(body).byteLength + 1,
+          ),
+          "content-type": "application/json",
+        },
+      }),
+    );
+    const client = createRegistryClient({
+      baseUrl: "http://localhost:3000/r",
+      fetchImpl,
+      maxResponseBytes: new TextEncoder().encode(body).byteLength,
+    });
+
+    await expect(client.getIndex()).rejects.toThrow(
+      "GodUI registry response exceeded the",
+    );
+  });
+
+  it("caps streamed response bytes before parsing JSON", async () => {
+    const body = new TextEncoder().encode(JSON.stringify(index));
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(body);
+            controller.close();
+          },
+        }),
+        { headers: { "content-type": "application/json" } },
+      ),
+    );
+    const client = createRegistryClient({
+      baseUrl: "http://localhost:3000/r",
+      fetchImpl,
+      maxResponseBytes: body.byteLength - 1,
+    });
+
+    await expect(client.getIndex()).rejects.toThrow(
+      "GodUI registry response exceeded the",
+    );
+  });
+
+  it("rejects non-JSON content types before parsing", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(JSON.stringify(index), "text/html"));
+    const client = createRegistryClient({
+      baseUrl: "http://localhost:3000/r",
+      fetchImpl,
+    });
+
+    await expect(client.getIndex()).rejects.toThrow("unexpected content type");
+  });
+
+  it("rejects malformed JSON without returning the response body", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse("not json"));
+    const client = createRegistryClient({
+      baseUrl: "http://localhost:3000/r",
+      fetchImpl,
+    });
+
+    await expect(client.getIndex()).rejects.toThrow(
+      "Failed to parse GodUI registry response",
     );
   });
 
@@ -177,6 +300,19 @@ describe("registry client", () => {
   it("rejects invalid component metadata", async () => {
     const client = createRegistryClient({
       fetchJsonImpl: vi.fn().mockResolvedValue({ title: "missing name" }),
+    });
+
+    await expect(client.getComponent("magic-button")).rejects.toThrow(
+      "invalid component metadata",
+    );
+  });
+
+  it("rejects malformed component file metadata", async () => {
+    const client = createRegistryClient({
+      fetchJsonImpl: vi.fn().mockResolvedValue({
+        name: "magic-button",
+        files: [{ path: "magic-button.tsx", content: 42 }],
+      }),
     });
 
     await expect(client.getComponent("magic-button")).rejects.toThrow(

--- a/packages/mcp/src/registry-client.ts
+++ b/packages/mcp/src/registry-client.ts
@@ -3,6 +3,9 @@
 // the newest components after each site deploy. Results are cached per process.
 
 const DEFAULT_BASE_URL = "https://godui.design/r";
+const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_MAX_RESPONSE_BYTES = 1_048_576;
+const MAX_ERROR_DETAIL_LENGTH = 200;
 
 /** Base registry URL, overridable for local testing (e.g. http://localhost:3000/r). */
 export const registryBaseUrl = (
@@ -68,6 +71,20 @@ function isStringArray(value: unknown): value is string[] {
   );
 }
 
+function isOptionalString(value: unknown): boolean {
+  return value === undefined || typeof value === "string";
+}
+
+function isRegistryFile(value: unknown): value is RegistryFile {
+  return (
+    isRecord(value) &&
+    isNonEmptyString(value.path) &&
+    isOptionalString(value.target) &&
+    isOptionalString(value.type) &&
+    isOptionalString(value.content)
+  );
+}
+
 function isCatalogComponent(value: unknown): value is CatalogComponent {
   return (
     isRecord(value) &&
@@ -118,7 +135,21 @@ function validateRegistryItem(
   url: string,
   expectedRevision?: string,
 ): RegistryItem {
-  if (!isRecord(value) || !isNonEmptyString(value.name)) {
+  if (
+    !isRecord(value) ||
+    !isNonEmptyString(value.name) ||
+    !isOptionalString(value.revision) ||
+    !isOptionalString(value.title) ||
+    !isOptionalString(value.description) ||
+    !isOptionalString(value.type) ||
+    (value.dependencies !== undefined && !isStringArray(value.dependencies)) ||
+    (value.registryDependencies !== undefined &&
+      !isStringArray(value.registryDependencies)) ||
+    (value.files !== undefined &&
+      (!Array.isArray(value.files) || !value.files.every(isRegistryFile))) ||
+    (value.cssVars !== undefined && !isRecord(value.cssVars)) ||
+    (value.css !== undefined && !isRecord(value.css))
+  ) {
     throw new Error(
       `GodUI registry returned invalid component metadata: ${url}`,
     );
@@ -143,21 +174,171 @@ function validateRegistryItem(
   return value as RegistryItem;
 }
 
-async function fetchJson<T>(url: string): Promise<T> {
-  let res: Response;
+type FetchJsonOptions = {
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+  maxResponseBytes?: number;
+};
+
+function boundedErrorDetail(cause: unknown): string {
+  const detail = cause instanceof Error ? cause.message : String(cause);
+  return detail.slice(0, MAX_ERROR_DETAIL_LENGTH);
+}
+
+function responseTooLarge(maxResponseBytes: number, url: string): Error {
+  return new Error(
+    `GodUI registry response exceeded the ${maxResponseBytes}-byte limit: ${url}`,
+  );
+}
+
+async function readResponseText(
+  res: Response,
+  maxResponseBytes: number,
+  signal: AbortSignal,
+  url: string,
+): Promise<string> {
+  const contentLengthHeader = res.headers.get("content-length");
+  if (contentLengthHeader !== null) {
+    const normalizedContentLength = contentLengthHeader.trim();
+    const contentLength = Number(normalizedContentLength);
+    if (
+      !/^\d+$/.test(normalizedContentLength) ||
+      !Number.isSafeInteger(contentLength)
+    ) {
+      throw new Error(
+        `GodUI registry returned an invalid Content-Length: ${url}`,
+      );
+    }
+    if (contentLength > maxResponseBytes) {
+      throw responseTooLarge(maxResponseBytes, url);
+    }
+  }
+
+  if (!res.body) return "";
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  let bytesRead = 0;
+  let text = "";
+
+  const cancel = () => {
+    void reader.cancel(signal.reason).catch(() => undefined);
+  };
+  signal.addEventListener("abort", cancel, { once: true });
+
   try {
-    res = await fetch(url, { headers: { accept: "application/json" } });
-  } catch (cause) {
-    throw new Error(
-      `Failed to reach GodUI registry at ${url}: ${String(cause)}`,
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      bytesRead += value.byteLength;
+      if (bytesRead > maxResponseBytes) {
+        cancel();
+        throw responseTooLarge(maxResponseBytes, url);
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+    return text + decoder.decode();
+  } finally {
+    signal.removeEventListener("abort", cancel);
+    reader.releaseLock();
+  }
+}
+
+async function fetchJson<T>(
+  url: string,
+  {
+    fetchImpl = fetch,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    maxResponseBytes = DEFAULT_MAX_RESPONSE_BYTES,
+  }: FetchJsonOptions = {},
+): Promise<T> {
+  if (!Number.isFinite(timeoutMs) || timeoutMs < 0) {
+    throw new RangeError(
+      "Registry request timeout must be a finite non-negative number",
     );
   }
-  if (!res.ok) {
-    throw new Error(
-      `GodUI registry request failed (${res.status} ${res.statusText}): ${url}`,
+  if (!Number.isSafeInteger(maxResponseBytes) || maxResponseBytes <= 0) {
+    throw new RangeError(
+      "Registry response size limit must be a positive safe integer",
     );
   }
-  return (await res.json()) as T;
+
+  const controller = new AbortController();
+  const timeoutError = new Error(
+    `GodUI registry request timed out after ${timeoutMs}ms: ${url}`,
+  );
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      controller.abort(timeoutError);
+      reject(timeoutError);
+    }, timeoutMs);
+  });
+
+  const request = (async () => {
+    let res: Response;
+    try {
+      res = await fetchImpl(url, {
+        headers: { accept: "application/json" },
+        signal: controller.signal,
+      });
+    } catch (cause) {
+      if (controller.signal.aborted) throw timeoutError;
+      throw new Error(
+        `Failed to reach GodUI registry at ${url}: ${boundedErrorDetail(cause)}`,
+      );
+    }
+    if (!res.ok) {
+      throw new Error(`GodUI registry request failed (${res.status}): ${url}`);
+    }
+
+    const contentType = res.headers
+      .get("content-type")
+      ?.split(";", 1)[0]
+      .trim()
+      .toLowerCase();
+    if (contentType !== "application/json") {
+      throw new Error(
+        `GodUI registry returned an unexpected content type (expected application/json): ${url}`,
+      );
+    }
+
+    let text: string;
+    try {
+      text = await readResponseText(
+        res,
+        maxResponseBytes,
+        controller.signal,
+        url,
+      );
+    } catch (cause) {
+      if (controller.signal.aborted) throw timeoutError;
+      if (
+        cause instanceof Error &&
+        cause.message.includes("response exceeded")
+      ) {
+        throw cause;
+      }
+      throw new Error(
+        `Failed to read GodUI registry response at ${url}: ${boundedErrorDetail(cause)}`,
+      );
+    }
+
+    try {
+      return JSON.parse(text) as T;
+    } catch (cause) {
+      throw new Error(`Failed to parse GodUI registry response: ${url}`, {
+        cause,
+      });
+    }
+  })();
+
+  try {
+    return await Promise.race([request, timeout]);
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+  }
 }
 
 /**
@@ -168,12 +349,22 @@ export function createRegistryClient(
   options: {
     baseUrl?: string;
     fetchJsonImpl?: typeof fetchJson;
+    fetchImpl?: typeof fetch;
+    timeoutMs?: number;
+    maxResponseBytes?: number;
     /** Require the catalog index to identify this exact deployment revision. */
     expectedRevision?: string;
   } = {},
 ): RegistryClient {
   const baseUrl = (options.baseUrl ?? registryBaseUrl).replace(/\/$/, "");
-  const get = options.fetchJsonImpl ?? fetchJson;
+  const get =
+    options.fetchJsonImpl ??
+    (<T>(url: string) =>
+      fetchJson<T>(url, {
+        fetchImpl: options.fetchImpl,
+        timeoutMs: options.timeoutMs,
+        maxResponseBytes: options.maxResponseBytes,
+      }));
   const expectedRevision =
     options.expectedRevision?.trim() ||
     process.env.GODUI_REGISTRY_REVISION?.trim();


### PR DESCRIPTION
Finding ID: finding:947068b11a325e041331d5eab802e67d

## Implementation summary

- Add a default 10-second application deadline and pass an AbortSignal to every live registry fetch.
- Stream response bodies and reject declared or observed payloads over the default 1 MiB limit before JSON parsing.
- Require application/json responses, reject malformed UTF-8/JSON, and validate component file metadata before tool consumption.
- Keep failures bounded and preserve existing cache eviction so rejected requests can retry.
- Add focused regressions for stalled fetches and bodies, Content-Length and streamed limits, content type, JSON parsing, and schema validation.

## Validation

- pnpm --filter @godui/mcp test — passed (17 tests, 30 assertions).
- pnpm --filter @godui/mcp lint — passed.
- pnpm --filter @godui/mcp build — passed.
- pnpm exec biome check packages/mcp/src/registry-client.ts packages/mcp/src/registry-client.test.ts — passed.
- pnpm test — passed (4 Turbo tasks; 92 component test files / 548 tests, 17 MCP tests / 30 assertions, and 9 CLI tests).
- pnpm check — passed (1,305 files).
- git diff --check — passed.

This pull request intentionally remains draft until explicitly marked ready for review.