### PR TITLE
fix(cli): atomically replace MCP config

### DIFF
--- a/packages/cli/src/atomic-write.test.ts
+++ b/packages/cli/src/atomic-write.test.ts
@@ -1,0 +1,69 @@
+import {
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { writeFileAtomically } from "./atomic-write.js";
+
+const mockState = vi.hoisted(() => ({ failRename: false }));
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    renameSync(...args: Parameters<typeof actual.renameSync>) {
+      if (mockState.failRename) {
+        throw new Error("simulated replacement failure");
+      }
+      return actual.renameSync(...args);
+    },
+  };
+});
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  mockState.failRename = false;
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function makeTemporaryDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), "godui-cli-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+describe("writeFileAtomically", () => {
+  it("writes the complete config and removes the staging file", () => {
+    const directory = makeTemporaryDirectory();
+    const configPath = join(directory, "mcp.json");
+    const contents = '{"mcpServers":{}}\n';
+
+    writeFileAtomically(configPath, contents);
+
+    expect(readFileSync(configPath, "utf8")).toBe(contents);
+    expect(readdirSync(directory)).toEqual(["mcp.json"]);
+  });
+
+  it("keeps the existing config when replacement fails", () => {
+    const directory = makeTemporaryDirectory();
+    const configPath = join(directory, "mcp.json");
+    const original = '{"mcpServers":{"other":{"command":"x"}}}\n';
+    writeFileSync(configPath, original);
+
+    mockState.failRename = true;
+
+    expect(() => writeFileAtomically(configPath, '{"new":true}\n')).toThrow(
+      "simulated replacement failure",
+    );
+    expect(readFileSync(configPath, "utf8")).toBe(original);
+    expect(readdirSync(directory)).toEqual(["mcp.json"]);
+  });
+});

--- a/packages/cli/src/atomic-write.test.ts
+++ b/packages/cli/src/atomic-write.test.ts
@@ -10,7 +10,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { writeFileAtomically } from "./atomic-write.js";
 
-const mockState = vi.hoisted(() => ({ failRename: false }));
+const mockState = vi.hoisted(() => ({ failRename: false, failWrite: false }));
 
 vi.mock("node:fs", async () => {
   const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
@@ -22,6 +22,12 @@ vi.mock("node:fs", async () => {
       }
       return actual.renameSync(...args);
     },
+    writeFileSync(...args: Parameters<typeof actual.writeFileSync>) {
+      if (mockState.failWrite) {
+        throw new Error("simulated write failure");
+      }
+      return actual.writeFileSync(...args);
+    },
   };
 });
 
@@ -29,6 +35,7 @@ const temporaryDirectories: string[] = [];
 
 afterEach(() => {
   mockState.failRename = false;
+  mockState.failWrite = false;
   for (const directory of temporaryDirectories.splice(0)) {
     rmSync(directory, { recursive: true, force: true });
   }
@@ -62,6 +69,21 @@ describe("writeFileAtomically", () => {
 
     expect(() => writeFileAtomically(configPath, '{"new":true}\n')).toThrow(
       "simulated replacement failure",
+    );
+    expect(readFileSync(configPath, "utf8")).toBe(original);
+    expect(readdirSync(directory)).toEqual(["mcp.json"]);
+  });
+
+  it("keeps the existing config when staging the replacement fails", () => {
+    const directory = makeTemporaryDirectory();
+    const configPath = join(directory, "mcp.json");
+    const original = '{"mcpServers":{"other":{"command":"x"}}}\n';
+    writeFileSync(configPath, original);
+
+    mockState.failWrite = true;
+
+    expect(() => writeFileAtomically(configPath, '{"new":true}\n')).toThrow(
+      "simulated write failure",
     );
     expect(readFileSync(configPath, "utf8")).toBe(original);
     expect(readdirSync(directory)).toEqual(["mcp.json"]);

--- a/packages/cli/src/atomic-write.ts
+++ b/packages/cli/src/atomic-write.ts
@@ -1,0 +1,57 @@
+import { randomUUID } from "node:crypto";
+import {
+  closeSync,
+  fsyncSync,
+  openSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, join } from "node:path";
+
+/** Replace a file without exposing a partially written version to readers. */
+export function writeFileAtomically(filePath: string, contents: string): void {
+  const directory = dirname(filePath);
+  const temporaryPath = join(
+    directory,
+    `.${basename(filePath)}.${randomUUID()}.tmp`,
+  );
+  let fileDescriptor: number | undefined;
+  let temporaryFileCreated = false;
+
+  let mode = 0o666;
+  try {
+    mode = statSync(filePath).mode & 0o777;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  try {
+    fileDescriptor = openSync(temporaryPath, "wx", mode);
+    temporaryFileCreated = true;
+    writeFileSync(fileDescriptor, contents, "utf8");
+    fsyncSync(fileDescriptor);
+    closeSync(fileDescriptor);
+    fileDescriptor = undefined;
+    renameSync(temporaryPath, filePath);
+  } catch (error) {
+    if (fileDescriptor !== undefined) {
+      try {
+        closeSync(fileDescriptor);
+      } catch {
+        // Preserve the original write or replacement error.
+      }
+    }
+    if (temporaryFileCreated) {
+      try {
+        unlinkSync(temporaryPath);
+      } catch {
+        // Preserve the original write or replacement error.
+      }
+    }
+    throw error;
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,7 @@
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname } from "node:path";
+import { writeFileAtomically } from "./atomic-write.js";
 import {
   getConfigPath,
   mergeMcpConfig,
@@ -83,7 +84,7 @@ function run(argv: string[]) {
 
   try {
     mkdirSync(dirname(configPath), { recursive: true });
-    writeFileSync(configPath, `${JSON.stringify(merged, null, 2)}\n`);
+    writeFileAtomically(configPath, `${JSON.stringify(merged, null, 2)}\n`);
   } catch (error) {
     fail(`Couldn't write ${configPath}: ${String(error)}`);
   }


### PR DESCRIPTION
Finding IDs:
- finding:8a05c1ff8ef5dff52450273f99961cff
- finding:fa5fc4a466b58c8e652f71194f7445b7

## Implementation summary

- Verified the base CLI previously wrote merged MCP JSON directly to the destination, which could truncate the existing config before the replacement was durable.
- Keep the merge behavior, but stage serialized output in a uniquely named file in the same directory, opened exclusively with the existing config mode when available.
- Flush staged contents with fsyncSync, close the descriptor, and atomically replace the destination with renameSync.
- Clean up only staging files created by the current install when writing or replacement fails, preserving the existing config.
- Add focused regressions proving the original bytes remain intact after both staging-write and replacement failures.

## Validation

- pnpm --filter @godui/cli test — passed (12 tests).
- pnpm --filter @godui/cli lint — passed.
- pnpm --filter @godui/cli build — passed.
- pnpm check — passed (1,307 files).
- pnpm test — passed (4 Turbo tasks; 92 component files / 548 tests, 23 MCP tests, and 12 CLI tests).
- git diff --check — passed.

This pull request intentionally remains draft until explicitly marked ready for review.